### PR TITLE
Fix tests

### DIFF
--- a/e2e/logic/POM/settingsUsersPage.ts
+++ b/e2e/logic/POM/settingsUsersPage.ts
@@ -21,7 +21,7 @@ export default class SettingsUsersPage extends BasePage {
     }
 
     private get userSelectRoleEditBtn(): (selectedUser: string) => Locator {
-        return (selectedUser: string) => this.page.locator(`//tbody/tr[@data-id='${selectedUser}']/td[3]/div/div/button`)
+        return (selectedUser: string) => this.page.locator(`//tbody/tr[@data-id='${selectedUser}']/td[3]//button`)
     }
 
     private get userRow(): (selectedUser: string) => Locator {
@@ -102,6 +102,7 @@ export default class SettingsUsersPage extends BasePage {
     async modifyUserRole(selectedUser: string, role: string): Promise<void> {
         await this.page.waitForLoadState('networkidle');
         await this.userRow(selectedUser).hover();
+        await this.userSelectRoleEditBtn(selectedUser).waitFor({ state: "visible" });
         await this.userSelectRoleEditBtn(selectedUser).click();
         await this.userSelectRoleBtn(selectedUser).click();
         await this.selectUserRole(role).click();

--- a/e2e/tests/settingsConfig.spec.ts
+++ b/e2e/tests/settingsConfig.spec.ts
@@ -222,7 +222,6 @@ test.describe('Settings Tests', () => {
         const settingsConfigPage = await browser.createNewPage(SettingsConfigPage, urls.settingsUrl)
         await settingsConfigPage.modifyRoleValue(roles.maxInfoQueries, Data.roleModificationData[8].input)
         await settingsConfigPage.refreshPage();
-        await settingsConfigPage.scrollToBottomInTable();
         await settingsConfigPage.getRoleContentValue(roles.maxInfoQueries);
         const apiCall = new ApiCalls()
         let value = String((await apiCall.getSettingsRoleValue(roles.maxInfoQueries)).config[1]);


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed incorrect locator in `userSelectRoleEditBtn` method.

- Added visibility wait before clicking role edit button.

- Removed unnecessary scroll action in settings tests.

- Improved test reliability for modifying user roles.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settingsUsersPage.ts</strong><dd><code>Fix locator and improve role modification logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/logic/POM/settingsUsersPage.ts

<li>Fixed locator in <code>userSelectRoleEditBtn</code> method.<br> <li> Added visibility wait for role edit button.<br> <li> Enhanced user role modification functionality.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/falkordb-browser/pull/663/files#diff-98cae9d276b703173e0285297b3fbc61b5afe54887ce054a560cd9f8de565ab8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settingsConfig.spec.ts</strong><dd><code>Remove redundant scroll and enhance test reliability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/tests/settingsConfig.spec.ts

<li>Removed unnecessary scroll action in test.<br> <li> Improved test reliability for role value modification.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/falkordb-browser/pull/663/files#diff-111e51977f8f79003882c10e2d61e4e4fbdebf87bb0f8c2a9e166d20a82905ee">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>