### PR TITLE
Fix #793 Remove delete node when role is read only

### DIFF
--- a/app/schema/SchemaDataPanel.tsx
+++ b/app/schema/SchemaDataPanel.tsx
@@ -581,13 +581,13 @@ export default function SchemaDataPanel({ obj, onExpand, onSetAttributes, onRemo
             </Table>
             <div className="p-8 flex justify-end">
                 {
-                    session?.user.role &&
+                    session?.user.role !== "Read-Only" &&
                     <DeleteElement
                         description={`Are you sure you want to delete this ${type ? "Node" : "Relation"}?`}
                         open={deleteOpen}
                         setOpen={setDeleteOpen}
                         onDeleteElement={onDeleteElement}
-                        trigger={<Button label="Delete" variant="Secondary" title="Remove the selected element" />}
+                        trigger={<Button label={`Delete ${type ? "Node" : "Relation"}`} variant="Secondary" title="Remove the selected element" />}
                     />
                 }
             </div>


### PR DESCRIPTION
### **User description**
…and enhance delete button label for clarity.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Restrict delete access for users with "Read-Only" role.

- Enhance delete button label for better clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SchemaDataPanel.tsx</strong><dd><code>Restrict delete access and improve button label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/schema/SchemaDataPanel.tsx

<li>Added condition to restrict delete access for "Read-Only" role.<br> <li> Updated delete button label to include specific element type.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/falkordb-browser/pull/799/files#diff-1cf4712965b5f6f5061c1a010cdc38e78a1a71760ec89c764ba639453b95b8e2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>