### PR TITLE
Fix #827 Add onExpand call in ForceGraph component to reset selection state

### DIFF
--- a/app/components/ForceGraph.tsx
+++ b/app/components/ForceGraph.tsx
@@ -202,6 +202,7 @@ export default function ForceGraph({
         if (evt?.ctrlKey || (!selectedElement && selectedElements.length === 0)) return
         setSelectedElement(undefined)
         setSelectedElements([])
+        onExpand(false)
     }
 
     return (


### PR DESCRIPTION
### **User description**
on blur


___

### **PR Type**
Bug fix


___

### **Description**
- Added `onExpand(false)` call in `handleUnselected` to reset selection state.

- Ensures proper state reset when no elements are selected.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ForceGraph.tsx</strong><dd><code>Add `onExpand(false)` to reset selection state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/components/ForceGraph.tsx

<li>Added <code>onExpand(false)</code> in <code>handleUnselected</code> function.<br> <li> Ensures selection state is reset properly on blur.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/falkordb-browser/pull/829/files#diff-4ad21cfa06a8daf0bf6fd1307fcd9f8c753243dbb1d6da07fd0b83f60082bd50">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>