### PR TITLE
Fix #849 Refactor GraphView and SchemaView to use LabelsMap instead of Categor…

### DIFF
--- a/app/graph/GraphView.tsx
+++ b/app/graph/GraphView.tsx
@@ -187,12 +187,12 @@ function GraphView({ graph, selectedElement, setSelectedElement, runQuery, histo
                 }
             } else {
                 element.category.forEach((category) => {
-                    const cat = graph.CategoriesMap.get(category)
+                    const cat = graph.LabelsMap.get(category)
                     if (cat) {
                         cat.elements = cat.elements.filter((e) => e.id !== element.id)
                         if (cat.elements.length === 0) {
-                            graph.Categories.splice(graph.Categories.findIndex(c => c.name === cat.name), 1)
-                            graph.CategoriesMap.delete(cat.name)
+                            graph.Labels.splice(graph.Labels.findIndex(l => l.name === cat.name), 1)
+                            graph.LabelsMap.delete(cat.name)
                         }
                     }
                 })

--- a/app/schema/SchemaView.tsx
+++ b/app/schema/SchemaView.tsx
@@ -163,12 +163,12 @@ export default function SchemaView({ schema, fetchCount }: Props) {
                     }
                 })
             } else {
-                const cat = schema.CategoriesMap.get(element.label)
+                const cat = schema.LabelsMap.get(element.label)
                 if (cat) {
                     cat.elements = cat.elements.filter(n => n.id !== id)
                     if (cat.elements.length === 0) {
-                        schema.Categories.splice(schema.Categories.findIndex(c => c.name === cat.name), 1)
-                        schema.CategoriesMap.delete(cat.name)
+                        schema.Labels.splice(schema.Labels.findIndex(c => c.name === cat.name), 1)
+                        schema.LabelsMap.delete(cat.name)
                     }
                 }
             }


### PR DESCRIPTION
…iesMap

- Updated GraphView and SchemaView components to replace references to CategoriesMap with LabelsMap.
- Adjusted logic for filtering elements and removing categories to align with the new labels structure.