### PR TITLE
Fix #953 Enhance Header component to toggle settings page navigation based on current path. 

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -74,7 +74,7 @@ export default function Header({ onSetGraphName, graphNames }: Props) {
                         <Button
                             indicator={indicator}
                             title="Adjust application settings"
-                            onClick={() => router.push("/settings")}
+                            onClick={() => pathname.includes("/settings") ? router.back() : router.push("/settings")}
                         >
                             <Settings size={35} />
                         </Button>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -16,6 +16,22 @@ export default function Settings() {
     const { data: session } = useSession()
 
     useEffect(() => {
+        window.addEventListener("keydown", (e) => {
+            if (e.key === "Escape") {
+                router.back()
+            }
+        })
+
+        return () => {
+            window.removeEventListener("keydown", (e) => {
+                if (e.key === "Escape") {
+                    router.back()
+                }
+            })
+        }
+    }, [router])
+
+    useEffect(() => {
         if (session && session.user.role !== "Admin") router.back()
     }, [router, session])
 


### PR DESCRIPTION
Add Escape key listener in Settings component to navigate back when pressed.