### PR TITLE
fix relative URL to prevent SSRF vulnerability

### DIFF
--- a/app/api/graph/[graph]/count/route.ts
+++ b/app/api/graph/[graph]/count/route.ts
@@ -14,7 +14,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     try {
         const query = "MATCH (n) OPTIONAL MATCH (n)-[e]->() WITH count(n) as nodes, count(e) as edges RETURN nodes, edges"
 
-        const result = await fetch(`${request.nextUrl.origin}/api/graph/${graph}/?query=${encodeURIComponent(query)}`, {
+        // Use relative URL to prevent SSRF vulnerability
+        const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000'
+        const result = await fetch(`${baseUrl}/api/graph/${graph}/?query=${encodeURIComponent(query)}`, {
             method: "GET",
             headers: {
                 cookie: request.headers.get('cookie') || '',

--- a/app/api/schema/[schema]/count/route.ts
+++ b/app/api/schema/[schema]/count/route.ts
@@ -15,7 +15,9 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     try {
         const query = "MATCH (n) OPTIONAL MATCH (n)-[e]->() WITH count(n) as nodes, count(e) as edges RETURN nodes, edges"
 
-        const result = await fetch(`${request.nextUrl.origin}/api/graph/${schemaName}/?query=${encodeURIComponent(query)}`, {
+        // Use relative URL to prevent SSRF vulnerability
+        const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000'
+        const result = await fetch(`${baseUrl}/api/graph/${schemaName}/?query=${encodeURIComponent(query)}`, {
             method: "GET",
             headers: {
                 cookie: request.headers.get('cookie') || '',


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes potential SSRF vulnerability by avoiding use of user-controlled URLs.

- Replaces dynamic origin with trusted base URL from environment variable.

- Adds fallback to localhost for base URL if environment variable is unset.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Use trusted base URL to prevent SSRF in graph count route</code></dd></summary>
<hr>

app/api/graph/[graph]/count/route.ts

<li>Replaces use of <code>request.nextUrl.origin</code> with a trusted base URL.<br> <li> Adds comment explaining SSRF prevention.<br> <li> Uses <code>process.env.NEXTAUTH_URL</code> or localhost as base URL.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/falkordb-browser/pull/1010/files#diff-3ebb8e171d5035b25202772e5c66eaa979f8aee602e7f3aa9a6262ac6d4930ed">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Use trusted base URL to prevent SSRF in schema count route</code></dd></summary>
<hr>

app/api/schema/[schema]/count/route.ts

<li>Replaces use of <code>request.nextUrl.origin</code> with a trusted base URL.<br> <li> Adds comment explaining SSRF prevention.<br> <li> Uses <code>process.env.NEXTAUTH_URL</code> or localhost as base URL.


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/falkordb-browser/pull/1010/files#diff-07ca7a0f10e7ac81e9971099436b3be941132424570ad23b1d7afdc46c801bb6">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>