### PR TITLE
Fix # Update GraphDataPanel and SchemaDataPanel to include type check before displaying remove label/button options for edges.

### DIFF
--- a/app/graph/GraphDataPanel.tsx
+++ b/app/graph/GraphDataPanel.tsx
@@ -188,7 +188,7 @@ export default function GraphDataPanel({ object, setObject, onDeleteElement, set
                         >
                             <p>{l || "No Label"}</p>
                             {
-                                l && session?.user?.role !== "Read-Only" &&
+                                type && l && session?.user?.role !== "Read-Only" &&
                                 <RemoveLabel
                                     onRemoveLabel={handleRemoveLabel}
                                     selectedLabel={l}

--- a/app/schema/SchemaDataPanel.tsx
+++ b/app/schema/SchemaDataPanel.tsx
@@ -303,7 +303,7 @@ export default function SchemaDataPanel({ object, setObject, onDeleteElement, sc
                         <li key={l} className="flex gap-2 px-2 py-1 bg-background rounded-full items-center">
                             <p>{l}</p>
                             {
-                                session?.user?.role !== "Read-Only" &&
+                                type && session?.user?.role !== "Read-Only" &&
                                 <Button
                                     indicator={indicator}
                                     title="Remove"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add type check before showing remove label/button options

- Prevent label removal UI for edges without type

- Restrict label removal to non-read-only users only


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GraphDataPanel.tsx</strong><dd><code>Add type check for remove label button visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/graph/GraphDataPanel.tsx

<li>Added <code>type</code> check before displaying remove label button<br> <li> Ensures label removal UI only appears for valid types and <br>non-read-only users


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/falkordb-browser/pull/1023/files#diff-bc0b053aabb0a791b746b1a1343d9f70dd9961416e087c5a109450f9473aa582">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SchemaDataPanel.tsx</strong><dd><code>Add type check for label removal in schema panel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/schema/SchemaDataPanel.tsx

<li>Added <code>type</code> check before showing remove label button<br> <li> Prevents label removal UI for edges without a type and for read-only <br>users


</details>


  </td>
  <td><a href="https://github.com/FalkorDB/falkordb-browser/pull/1023/files#diff-1cf4712965b5f6f5061c1a010cdc38e78a1a71760ec89c764ba639453b95b8e2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>