### PR TITLE
Refactor next.config.js: Remove turbopack configuration and ensure se…

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,8 @@ const nextConfig = {
   images: {
     unoptimized: true
   },
+  // Keep falkordb server-only to avoid bundling BigInt in client/runtime
+  serverExternalPackages: ['falkordb'],
   async headers() {
     return [
       {
@@ -40,17 +42,6 @@ const nextConfig = {
       }
     ];
   },
-  // Turbopack configuration for Next.js 16
-  turbopack: {
-    rules: {
-      // Handle SVG imports as React components (equivalent to @svgr/webpack)
-      '*.svg': {
-        loaders: ['@svgr/webpack'],
-        as: '*.js',
-      },
-    },
-  },
-  // Webpack fallback for development/build with --webpack flag
   webpack(config) {
     // Grab the existing rule that handles SVG imports
     const fileLoaderRule = config.module.rules.find((rule) =>


### PR DESCRIPTION
…rverExternalPackages is defined only once
 
 **PR Summary by Typo**
------------

#### Overview
This PR refactors the `next.config.js` file by removing outdated Turbopack-specific configurations and explicitly marking `falkordb` as a server-only external package. This ensures proper bundling and prevents client-side issues related to `BigInt` usage.

#### Key Changes
- Removed the entire `turbopack` configuration block, including rules for SVG imports.
- Added `falkordb` to `serverExternalPackages` to prevent it from being bundled on the client side.
- Removed a comment related to Webpack fallback configuration.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 2 (15.4%)     |
| Churn       | 11 (84.6%)    |
| Total Changes | 13          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration by removing Turbopack settings and related SVG handling
  * Modified server package management configuration for external package handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->