### PR TITLE
Remove serverExternalPackages from next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,8 +7,6 @@ const nextConfig = {
   images: {
     unoptimized: true
   },
-  // Keep falkordb server-only to avoid bundling BigInt in client/runtime
-  serverExternalPackages: ['falkordb'],
   async headers() {
     return [
       {


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR removes the `serverExternalPackages` configuration for `falkordb` from `next.config.js`. This change likely addresses an issue where `falkordb` was being incorrectly externalized or the original reason for its externalization (avoiding BigInt bundling) is no longer relevant.

#### Key Changes
- Removed the `serverExternalPackages` array from `next.config.js`, specifically ceasing to externalize `falkordb` from server-side bundles.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Churn    | 2 (100.0%)    |
| Total Changes | 2         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->