### PR TITLE
Change FalkorDB Browser installation to OCI format

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,8 @@ docker run -p 6379:6379 -it --rm falkordb/falkordb:latest
 Deploy the FalkorDB Browser to your Kubernetes cluster using Helm:
 
 ```bash
-# Add the FalkorDB Helm repository
-helm repo add falkordb https://falkordb.github.io/helm-charts
-helm repo update
-
 # Install the chart
-helm install falkordb-browser falkordb/falkordb-browser
+helm install falkordb-browser oci://ghcr.io/falkordb/helm-charts/falkordb-browser
 
 # Access via port-forward
 kubectl port-forward svc/falkordb-browser 3000:3000


### PR DESCRIPTION
Updated Helm installation command for FalkorDB Browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Helm installation process by replacing multiple repository commands with a single OCI-based install command for faster setup
  * Updated Helm chart installation to use an OCI registry path, replacing the previous local chart reference method
  * Installation workflow now streamlined with fewer steps required

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->