### PR TITLE
Fix node caption and size not applied from saved label styles

### DIFF
--- a/app/api/graph/model.ts
+++ b/app/api/graph/model.ts
@@ -834,8 +834,10 @@ export class Graph {
             (l) => this.labelsMap.get(l) || this.createLabel([l])[0]
           )
         );
-        // Use custom color if available, otherwise use default label color
+        // Use custom style if available, otherwise use default label style
         node.color = label.style.color;
+        node.caption = label.style.caption;
+        node.size = label.style.size;
       });
 
     // remove empty category if there are no more empty nodes category

--- a/app/components/ForceGraph.tsx
+++ b/app/components/ForceGraph.tsx
@@ -150,7 +150,7 @@ export default function ForceGraph({
                 // Get only new elements from graph
                 const dataElements: Data = {
                     nodes: graph.Elements.nodes
-                        .map(({ id, labels, color, visible, data: nodeData }) => ({ id, labels, color, visible, data: nodeData })),
+                        .map(({ id, labels, color, visible, caption, size, data: nodeData }) => ({ id, labels, color, visible, caption, size, data: nodeData })),
                     links: graph.Elements.links
                         .map(({ id, relationship, color, visible, source, target, data: linkData }) => ({
                             id, relationship, color, visible, source, target, data: linkData


### PR DESCRIPTION
## Bug Fix

Node **caption** and **size** styles configured via the Style Settings panel reset to defaults on every new query, while **color** persists correctly. This is especially visible with multi-label nodes (e.g. Graphiti/GraphRAG nodes with labels like `["Entity", "DesignApprovalHolder"]`).

## Root Cause

Two independent bugs:

1. **`Graph.extend()` post-processing only applies color** — After nodes are created, a loop re-resolves each node's label using `getLabelWithFewestElements()` and applies the saved style, but only sets `node.color`, ignoring `caption` and `size`.

2. **Neighbor expansion drops caption and size** — In `ForceGraph.tsx`, the object destructuring when mapping expanded neighbor nodes omits `caption` and `size`, causing them to revert to defaults.

## Changes

- **`app/api/graph/model.ts`**: Apply `caption` and `size` alongside `color` in the post-processing loop
- **`app/components/ForceGraph.tsx`**: Include `caption` and `size` in neighbor expansion destructuring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nodes now display caption and size styling derived from label styles, providing enhanced visual presentation in graph visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->