### PR TITLE
fix(e2e): increase chat wait timeouts to reduce flakiness

### DIFF
--- a/e2e/logic/POM/chatComponent.ts
+++ b/e2e/logic/POM/chatComponent.ts
@@ -84,15 +84,25 @@ export default class ChatComponent extends GraphPage {
   }
 
   async waitForChatUserMessage(): Promise<boolean> {
-    return waitForElementToBeVisible(this.chatUserMessages.first());
+    try {
+      await this.chatUserMessages.first().waitFor({ state: 'visible', timeout: 15000 });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async waitForChatAssistantMessage(type: string): Promise<boolean> {
-    return waitForElementToBeVisible(this.chatAssistantMessage(type));
+    try {
+      await this.chatAssistantMessage(type).first().waitFor({ state: 'visible', timeout: 30000 });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async waitForUserMessageCount(expectedCount: number): Promise<void> {
-    await expect(this.chatUserMessages).toHaveCount(expectedCount, { timeout: 10000 });
+    await expect(this.chatUserMessages).toHaveCount(expectedCount, { timeout: 30000 });
   }
 
   async waitForChatSendButtonEnabled(): Promise<void> {


### PR DESCRIPTION
## Summary
Fixes flaky Playwright tests in `chat.spec.ts` (lines 84 and 453) that were failing in shard 3/6 CI runs.

## Root Cause
- `waitForChatUserMessage` used `waitForElementToBeVisible` with only 5s total polling — too short for the UI to render after sending a message.
- `waitForChatAssistantMessage` had the same 5s limit, causing assistant response checks to pass before the element appeared, leading to count assertions failing.
- `waitForUserMessageCount` had a 10s timeout which was insufficient under CI load.

## Changes
- `waitForChatUserMessage`: switched to Playwright native `waitFor({ state: 'visible', timeout: 15000 })`
- `waitForChatAssistantMessage`: switched to Playwright native `waitFor({ state: 'visible', timeout: 30000 })` to accommodate slower AI responses
- `waitForUserMessageCount`: increased timeout from 10s → 30s

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved chat component test reliability with enhanced timeout handling and error recovery for message validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->