### PR TITLE
Fix #1522 feat: add max items for search functionality in graph settings and UI

### DIFF
--- a/app/components/provider.ts
+++ b/app/components/provider.ts
@@ -54,6 +54,8 @@ type BrowserSettingsContextType = {
     graphInfo: {
       newRefreshInterval: number;
       setNewRefreshInterval: Dispatch<SetStateAction<number>>;
+      newMaxItemsForSearch: number;
+      setNewMaxItemsForSearch: Dispatch<SetStateAction<number>>;
     };
   };
   settings: {
@@ -109,6 +111,8 @@ type BrowserSettingsContextType = {
       showMemoryUsage: boolean;
       refreshInterval: number;
       setRefreshInterval: Dispatch<SetStateAction<number>>;
+      maxItemsForSearch: number;
+      setMaxItemsForSearch: Dispatch<SetStateAction<number>>;
     };
   };
   hasChanges: boolean;
@@ -257,6 +261,8 @@ export const BrowserSettingsContext = createContext<BrowserSettingsContextType>(
       graphInfo: {
         newRefreshInterval: 0,
         setNewRefreshInterval: () => { },
+        newMaxItemsForSearch: 0,
+        setNewMaxItemsForSearch: () => { },
       },
     },
     settings: {
@@ -306,6 +312,8 @@ export const BrowserSettingsContext = createContext<BrowserSettingsContextType>(
         showMemoryUsage: false,
         refreshInterval: 0,
         setRefreshInterval: () => { },
+        maxItemsForSearch: 0,
+        setMaxItemsForSearch: () => { },
       },
     },
     hasChanges: false,

--- a/app/graph/graphInfo.tsx
+++ b/app/graph/graphInfo.tsx
@@ -1,11 +1,12 @@
-import { Dispatch, SetStateAction, useContext } from "react";
-import { Loader2, X, Palette, Network } from "lucide-react";
+import { Dispatch, SetStateAction, useContext, useState } from "react";
+import { Loader2, X, Palette, Network, Search } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn, InfoLabel } from "@/lib/utils";
 import { getContrastTextColor } from "@falkordb/canvas";
 import Button from "../components/ui/Button";
 import { BrowserSettingsContext, GraphContext, QueryLoadingContext } from "../components/provider";
 import CustomizeStylePanel from "./CustomizeStylePanel";
+import Input from "../components/ui/Input";
 
 /**
  * Render a side panel showing graph metadata and interactive controls to run representative queries.
@@ -16,10 +17,14 @@ import CustomizeStylePanel from "./CustomizeStylePanel";
 export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizingLabel }: { onClose: () => void, customizingLabel: InfoLabel | null, setCustomizingLabel: Dispatch<SetStateAction<InfoLabel | null>> }) {
     const { graphInfo: { Labels, Relationships, PropertyKeys, MemoryUsage }, nodesCount, edgesCount, runQuery, graphName } = useContext(GraphContext);
     const { isQueryLoading } = useContext(QueryLoadingContext);
-    const { settings: { graphInfo: { showMemoryUsage } } } = useContext(BrowserSettingsContext);
+    const { settings: { graphInfo: { showMemoryUsage, maxItemsForSearch } } } = useContext(BrowserSettingsContext);
+
+    const [nodesSearch, setNodesSearch] = useState("");
+    const [edgesSearch, setEdgesSearch] = useState("");
+    const [propertyKeysSearch, setPropertyKeysSearch] = useState("");
 
     return (
-        <div aria-disabled={nodesCount === undefined || edgesCount === undefined} data-testid="graphInfoPanel" className={cn(`relative h-full w-full p-2 grid grid-rows-[max-content_max-content_minmax(0,max-content)_minmax(0,max-content)_minmax(0,max-content)] gap-2`)}>
+        <div aria-disabled={nodesCount === undefined || edgesCount === undefined} data-testid="graphInfoPanel" className={cn(`relative h-full w-full p-2 grid grid-rows-[max-content_max-content_max-content_1fr_1fr_1fr] gap-2`)}>
             {
                 !customizingLabel ? (
                     <>
@@ -85,6 +90,13 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
                                         </Tooltip>
                                         : <Loader2 data-testid="nodesCountLoader" className="animate-spin" />
                                 }
+                                {
+                                    Labels.size > maxItemsForSearch &&
+                                    <div className="basis-0 grow flex gap-1 items-center">
+                                        <Search size={16} />
+                                        <Input value={nodesSearch} onChange={(e) => setNodesSearch(e.target.value)} className="w-1 grow" />
+                                    </div>
+                                }
                             </div>
                             <ul className="flex flex-wrap gap-2 p-2 overflow-auto">
                                 <li className="max-w-full">
@@ -97,7 +109,7 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
                                         disabled={isQueryLoading}
                                     />
                                 </li>
-                                {Array.from(Labels.values()).sort((a, b) => b.count - a.count).map((label) => {
+                                {Array.from(Labels.values()).filter(label => label.name.toLowerCase().includes(nodesSearch.toLowerCase())).sort((a, b) => b.count - a.count).map((label) => {
                                     const name = label.name || "Empty";
                                     const labelColor = label.style.color;
 
@@ -157,6 +169,13 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
                                         :
                                         <Loader2 data-testid="edgesCountLoader" className="animate-spin" />
                                 }
+                                {
+                                    Relationships.size > maxItemsForSearch &&
+                                    <div className="basis-0 grow flex gap-1 items-center">
+                                        <Search size={16} />
+                                        <Input value={edgesSearch} onChange={(e) => setEdgesSearch(e.target.value)} className="w-1 grow" />
+                                    </div>
+                                }
                             </div>
                             <ul className="flex flex-wrap gap-2 p-2 overflow-auto">
                                 <li className="max-w-full">
@@ -169,7 +188,7 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
                                         disabled={isQueryLoading}
                                     />
                                 </li>
-                                {Array.from(Relationships.values()).sort((a, b) => b.count - a.count).map((relationship) => {
+                                {Array.from(Relationships.values()).filter(relationship => relationship.name.toLowerCase().includes(edgesSearch.toLowerCase())).sort((a, b) => b.count - a.count).map((relationship) => {
                                     const relationshipColor = relationship.style.color;
                                     const textColor = getContrastTextColor(relationshipColor);
 
@@ -215,10 +234,17 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
                                         :
                                         <Loader2 className="animate-spin" />
                                 }
+                                {
+                                    PropertyKeys && PropertyKeys.length > maxItemsForSearch &&
+                                    <div className="basis-0 grow flex gap-1 items-center">
+                                        <Search size={16} />
+                                        <Input value={propertyKeysSearch} onChange={(e) => setPropertyKeysSearch(e.target.value)} className="w-1 grow" />
+                                    </div>
+                                }
                             </div>
                             <ul className="flex flex-wrap gap-2 p-2 overflow-auto">
                                 {
-                                    PropertyKeys && PropertyKeys.map((key) => (
+                                    PropertyKeys && PropertyKeys.filter(key => key.toLowerCase().includes(propertyKeysSearch.toLowerCase())).map((key) => (
                                         <li key={key} className="max-w-full">
                                             <Button
                                                 title={`MATCH (e) WHERE e.${key} IS NOT NULL RETURN e\nUNION\nMATCH ()-[e]-() WHERE e.${key} IS NOT NULL RETURN e`}
@@ -230,7 +256,8 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
                                                 disabled={isQueryLoading}
                                             />
                                         </li>
-                                    ))}
+                                    ))
+                                }
                             </ul>
                         </div>
                     </>

--- a/app/graph/graphInfo.tsx
+++ b/app/graph/graphInfo.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext, useState } from "react";
+import { Dispatch, SetStateAction, useContext, useEffect, useState } from "react";
 import { Loader2, X, Palette, Network, Search } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn, InfoLabel } from "@/lib/utils";
@@ -22,6 +22,10 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
     const [nodesSearch, setNodesSearch] = useState("");
     const [edgesSearch, setEdgesSearch] = useState("");
     const [propertyKeysSearch, setPropertyKeysSearch] = useState("");
+
+    useEffect(() => { setNodesSearch(""); }, [Labels]);
+    useEffect(() => { setEdgesSearch(""); }, [Relationships]);
+    useEffect(() => { setPropertyKeysSearch(""); }, [PropertyKeys]);
 
     return (
         <div aria-disabled={nodesCount === undefined || edgesCount === undefined} data-testid="graphInfoPanel" className={cn(`relative h-full w-full p-2 grid grid-rows-[max-content_max-content_max-content_1fr_1fr_1fr] gap-2`)}>
@@ -94,7 +98,7 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
                                     Labels.size > maxItemsForSearch &&
                                     <div className="basis-0 grow flex gap-1 items-center">
                                         <Search size={16} />
-                                        <Input value={nodesSearch} onChange={(e) => setNodesSearch(e.target.value)} className="w-1 grow" />
+                                        <Input aria-label="Search node labels" value={nodesSearch} onChange={(e) => setNodesSearch(e.target.value)} className="w-1 grow" />
                                     </div>
                                 }
                             </div>
@@ -173,7 +177,7 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
                                     Relationships.size > maxItemsForSearch &&
                                     <div className="basis-0 grow flex gap-1 items-center">
                                         <Search size={16} />
-                                        <Input value={edgesSearch} onChange={(e) => setEdgesSearch(e.target.value)} className="w-1 grow" />
+                                        <Input aria-label="Search relationship types" value={edgesSearch} onChange={(e) => setEdgesSearch(e.target.value)} className="w-1 grow" />
                                     </div>
                                 }
                             </div>
@@ -238,7 +242,7 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
                                     PropertyKeys && PropertyKeys.length > maxItemsForSearch &&
                                     <div className="basis-0 grow flex gap-1 items-center">
                                         <Search size={16} />
-                                        <Input value={propertyKeysSearch} onChange={(e) => setPropertyKeysSearch(e.target.value)} className="w-1 grow" />
+                                        <Input aria-label="Search property keys" value={propertyKeysSearch} onChange={(e) => setPropertyKeysSearch(e.target.value)} className="w-1 grow" />
                                     </div>
                                 }
                             </div>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -186,6 +186,7 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
       localStorage.setItem("columnWidth", newColumnWidth.toString());
       localStorage.setItem("rowHeight", newRowHeight.toString());
       localStorage.setItem("rowHeightExpandMultiple", newRowHeightExpandMultiple.toString());
+      localStorage.setItem("maxItemsForSearch", newMaxItemsForSearch.toString());
 
       // Only encrypt and save secret key if it has changed
       if (newSecretKey !== secretKey) {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -119,13 +119,15 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
   const [cypherOnly, setCypherOnly] = useState<boolean>(false);
   const [udfList, setUdfList] = useState<UDFEntry[]>([]);
   const [selectedUdf, setSelectedUdf] = useState<UDFEntryWithCode>();
-  const [columnWidth, setColumnWidth] = useState<number>(25);
-  const [rowHeight, setRowHeight] = useState<number>(40);
-  const [newColumnWidth, setNewColumnWidth] = useState<number>(25);
-  const [newRowHeight, setNewRowHeight] = useState<number>(40);
-  const [newRowHeightExpandMultiple, setNewRowHeightExpandMultiple] = useState<number>(3);
-  const [rowHeightExpandMultiple, setRowHeightExpandMultiple] = useState<number>(3);
+  const [columnWidth, setColumnWidth] = useState<number>(0);
+  const [rowHeight, setRowHeight] = useState<number>(0);
+  const [newColumnWidth, setNewColumnWidth] = useState<number>(0);
+  const [newRowHeight, setNewRowHeight] = useState<number>(0);
+  const [newRowHeightExpandMultiple, setNewRowHeightExpandMultiple] = useState<number>(0);
+  const [rowHeightExpandMultiple, setRowHeightExpandMultiple] = useState<number>(0);
   const [showUDF, setShowUDF] = useState<boolean>(true);
+  const [maxItemsForSearch, setMaxItemsForSearch] = useState<number>(0);
+  const [newMaxItemsForSearch, setNewMaxItemsForSearch] = useState<number>(0);
 
   const replayTutorial = useCallback(() => {
     router.push("/graph");
@@ -149,7 +151,7 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
       captionsKeysSettings: { newCaptionsKeys, setNewCaptionsKeys },
       showPropertyKeyPrefixSettings: { newShowPropertyKeyPrefix, setNewShowPropertyKeyPrefix },
       chatSettings: { newSecretKey, setNewSecretKey, newModel, setNewModel, newMaxSavedMessages, setNewMaxSavedMessages, newCypherOnly, setNewCypherOnly },
-      graphInfo: { newRefreshInterval, setNewRefreshInterval },
+      graphInfo: { newRefreshInterval, setNewRefreshInterval, newMaxItemsForSearch, setNewMaxItemsForSearch },
       tableViewSettings: { newColumnWidth, setNewColumnWidth, newRowHeight, setNewRowHeight, newRowHeightExpandMultiple, setNewRowHeightExpandMultiple }
     },
     settings: {
@@ -161,7 +163,7 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
       captionsKeysSettings: { captionsKeys, setCaptionsKeys },
       showPropertyKeyPrefixSettings: { showPropertyKeyPrefix, setShowPropertyKeyPrefix },
       chatSettings: { secretKey, setSecretKey, model, setModel, maxSavedMessages, setMaxSavedMessages, cypherOnly, setCypherOnly },
-      graphInfo: { showMemoryUsage, refreshInterval, setRefreshInterval },
+      graphInfo: { showMemoryUsage, refreshInterval, setRefreshInterval, maxItemsForSearch, setMaxItemsForSearch },
       tableViewSettings: { columnWidth, setColumnWidth, rowHeight, setRowHeight, rowHeightExpandMultiple, setRowHeightExpandMultiple }
     },
     hasChanges,
@@ -241,6 +243,7 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
       setColumnWidth(newColumnWidth);
       setRowHeight(newRowHeight);
       setRowHeightExpandMultiple(newRowHeightExpandMultiple);
+      setMaxItemsForSearch(newMaxItemsForSearch);
       // Reset has changes
       setHasChanges(false);
 
@@ -266,10 +269,11 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
       setNewColumnWidth(columnWidth);
       setNewRowHeight(rowHeight);
       setNewRowHeightExpandMultiple(rowHeightExpandMultiple);
+      setNewMaxItemsForSearch(maxItemsForSearch);
       setHasChanges(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }), [contentPersistence, defaultQuery, hasChanges, lastLimit, limit, model, newContentPersistence, newDefaultQuery, newLimit, newModel, newRefreshInterval, newRunDefaultQuery, newSecretKey, newTimeout, refreshInterval, runDefaultQuery, secretKey, timeout, replayTutorial, tutorialOpen, showMemoryUsage, newMaxSavedMessages, maxSavedMessages, newCaptionsKeys, captionsKeys, newShowPropertyKeyPrefix, showPropertyKeyPrefix, newCypherOnly, cypherOnly, newColumnWidth, columnWidth, newRowHeight, rowHeight, newRowHeightExpandMultiple, rowHeightExpandMultiple, toast]);
+  }), [contentPersistence, defaultQuery, hasChanges, lastLimit, limit, model, newContentPersistence, newDefaultQuery, newLimit, newModel, newRefreshInterval, newRunDefaultQuery, newSecretKey, newTimeout, refreshInterval, runDefaultQuery, secretKey, timeout, replayTutorial, tutorialOpen, showMemoryUsage, newMaxSavedMessages, maxSavedMessages, newCaptionsKeys, captionsKeys, newShowPropertyKeyPrefix, showPropertyKeyPrefix, newCypherOnly, cypherOnly, newColumnWidth, columnWidth, newRowHeight, rowHeight, newRowHeightExpandMultiple, rowHeightExpandMultiple, newMaxItemsForSearch, maxItemsForSearch, toast]);
 
   const historyQueryContext = useMemo(() => ({
     historyQuery,
@@ -629,7 +633,7 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
       setColumnWidth(parseInt(localStorage.getItem("columnWidth") || "25", 10));
       setRowHeight(parseInt(localStorage.getItem("rowHeight") || "40", 10));
       setRowHeightExpandMultiple(parseInt(localStorage.getItem("rowHeightExpandMultiple") || "3", 10));
-
+      setMaxItemsForSearch(parseInt(localStorage.getItem("maxItemsForSearch") || "20", 10));
       // Decrypt secret key if encrypted, or migrate plain text keys to encrypted format
       const storedSecretKey = localStorage.getItem("secretKey") || "";
       if (storedSecretKey) {

--- a/app/settings/browserSettings.tsx
+++ b/app/settings/browserSettings.tsx
@@ -27,7 +27,7 @@ export default function BrowserSettings() {
             captionsKeysSettings: { newCaptionsKeys, setNewCaptionsKeys },
             showPropertyKeyPrefixSettings: { newShowPropertyKeyPrefix, setNewShowPropertyKeyPrefix },
             chatSettings: { newSecretKey, setNewSecretKey, newModel, setNewModel, newMaxSavedMessages, setNewMaxSavedMessages, newCypherOnly, setNewCypherOnly },
-            graphInfo: { newRefreshInterval, setNewRefreshInterval },
+            graphInfo: { newRefreshInterval, setNewRefreshInterval, newMaxItemsForSearch, setNewMaxItemsForSearch },
             tableViewSettings: { newColumnWidth, setNewColumnWidth, newRowHeight, setNewRowHeight, newRowHeightExpandMultiple, setNewRowHeightExpandMultiple }
         },
         settings: {
@@ -39,7 +39,7 @@ export default function BrowserSettings() {
             captionsKeysSettings: { captionsKeys },
             showPropertyKeyPrefixSettings: { showPropertyKeyPrefix },
             chatSettings: { secretKey, model, setModel, maxSavedMessages, cypherOnly },
-            graphInfo: { refreshInterval },
+            graphInfo: { refreshInterval, maxItemsForSearch },
             tableViewSettings: { columnWidth, rowHeight, rowHeightExpandMultiple }
         },
         hasChanges,
@@ -131,7 +131,8 @@ export default function BrowserSettings() {
         setNewColumnWidth(columnWidth);
         setNewRowHeight(rowHeight);
         setNewRowHeightExpandMultiple(rowHeightExpandMultiple);
-    }, [contentPersistence, runDefaultQuery, defaultQuery, timeoutValue, limit, secretKey, setNewContentPersistence, setNewRunDefaultQuery, setNewDefaultQuery, setNewTimeout, setNewLimit, setNewSecretKey, model, setNewModel, setNewRefreshInterval, refreshInterval, setNewMaxSavedMessages, maxSavedMessages, setNewCaptionsKeys, captionsKeys, setNewShowPropertyKeyPrefix, showPropertyKeyPrefix, setNewCypherOnly, cypherOnly, setNewColumnWidth, columnWidth, setNewRowHeight, rowHeight, setNewRowHeightExpandMultiple, rowHeightExpandMultiple]);
+        setNewMaxItemsForSearch(maxItemsForSearch);
+    }, [contentPersistence, runDefaultQuery, defaultQuery, timeoutValue, limit, secretKey, setNewContentPersistence, setNewRunDefaultQuery, setNewDefaultQuery, setNewTimeout, setNewLimit, setNewSecretKey, model, setNewModel, setNewRefreshInterval, refreshInterval, setNewMaxSavedMessages, maxSavedMessages, setNewCaptionsKeys, captionsKeys, setNewShowPropertyKeyPrefix, showPropertyKeyPrefix, setNewCypherOnly, cypherOnly, setNewColumnWidth, columnWidth, setNewRowHeight, rowHeight, setNewRowHeightExpandMultiple, rowHeightExpandMultiple, setNewMaxItemsForSearch, maxItemsForSearch]);
 
     useEffect(() => {
         setHasChanges(
@@ -149,9 +150,10 @@ export default function BrowserSettings() {
             newCypherOnly !== cypherOnly ||
             newColumnWidth !== columnWidth ||
             newRowHeight !== rowHeight ||
-            newRowHeightExpandMultiple !== rowHeightExpandMultiple
+            newRowHeightExpandMultiple !== rowHeightExpandMultiple ||
+            newMaxItemsForSearch !== maxItemsForSearch
         );
-    }, [defaultQuery, limit, newDefaultQuery, newLimit, newRunDefaultQuery, newContentPersistence, newTimeout, runDefaultQuery, contentPersistence, setHasChanges, timeoutValue, newSecretKey, secretKey, newModel, model, refreshInterval, newRefreshInterval, newMaxSavedMessages, maxSavedMessages, newCaptionsKeys, captionsKeys, newShowPropertyKeyPrefix, showPropertyKeyPrefix, newCypherOnly, cypherOnly, newColumnWidth, columnWidth, newRowHeight, rowHeight, newRowHeightExpandMultiple, rowHeightExpandMultiple]);
+    }, [defaultQuery, limit, newDefaultQuery, newLimit, newRunDefaultQuery, newContentPersistence, newTimeout, runDefaultQuery, contentPersistence, setHasChanges, timeoutValue, newSecretKey, secretKey, newModel, model, refreshInterval, newRefreshInterval, newMaxSavedMessages, maxSavedMessages, newCaptionsKeys, captionsKeys, newShowPropertyKeyPrefix, showPropertyKeyPrefix, newCypherOnly, cypherOnly, newColumnWidth, columnWidth, newRowHeight, rowHeight, newRowHeightExpandMultiple, rowHeightExpandMultiple, newMaxItemsForSearch, maxItemsForSearch]);
 
     const handleSubmit = useCallback((e?: React.FormEvent<HTMLFormElement>) => {
         e?.preventDefault();
@@ -368,31 +370,56 @@ export default function BrowserSettings() {
                     </CardHeader>
                     {expandedSections.graphInfo && (
                         <CardContent>
-                            {/* Refresh Interval */}
-                            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2 p-2 bg-muted/10 rounded-lg">
-                                <div className="flex flex-col gap-2 flex-1">
-                                    {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-                                    <label htmlFor="refreshInterval" className="text-lg font-semibold">Refresh Interval</label>
-                                    <p className="text-sm text-muted-foreground">
-                                        Reload graph info data every {newRefreshInterval} seconds
-                                    </p>
+                            <div className="flex gap-2">
+                                {/* Refresh Interval */}
+                                <div className="basis-0 grow flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2 p-2 bg-muted/10 rounded-lg">
+                                    <div className="flex flex-col gap-2 flex-1">
+                                        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                                        <label htmlFor="refreshInterval" className="text-lg font-semibold">Refresh Interval</label>
+                                        <p className="text-sm text-muted-foreground">
+                                            Reload graph info data every {newRefreshInterval} seconds
+                                        </p>
+                                    </div>
+                                    <div className="w-full sm:w-64">
+                                        <Slider
+                                            id="refreshInterval"
+                                            className="w-full"
+                                            min={5}
+                                            max={60}
+                                            value={[newRefreshInterval]}
+                                            onValueChange={(value) => createChangeHandler(setNewRefreshInterval)(value[value.length - 1], "refreshInterval")}
+                                        />
+                                        <div className="flex justify-between text-xs text-muted-foreground mt-2">
+                                            <span>5s</span>
+                                            <span>60s</span>
+                                        </div>
+                                    </div>
                                 </div>
-                                <div className="w-full sm:w-64">
-                                    <Slider
-                                        id="refreshInterval"
-                                        className="w-full"
-                                        min={5}
-                                        max={60}
-                                        value={[newRefreshInterval]}
-                                        onValueChange={(value) => createChangeHandler(setNewRefreshInterval)(value[value.length - 1], "refreshInterval")}
-                                    />
-                                    <div className="flex justify-between text-xs text-muted-foreground mt-2">
-                                        <span>5s</span>
-                                        <span>60s</span>
+                                {/* Max Items For Search */}
+                                <div className="basis-0 grow flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2 p-2 bg-muted/10 rounded-lg">
+                                    <div className="flex flex-col gap-2 flex-1">
+                                        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                                        <label htmlFor="maxItemsForSearch" className="text-lg font-semibold">Max Items For Search</label>
+                                        <p className="text-sm text-muted-foreground">
+                                            Set the maximum number of items before search display.
+                                        </p>
+                                    </div>
+                                    <div className="w-full sm:w-64">
+                                        <Slider
+                                            id="maxItemsForSearch"
+                                            className="w-full"
+                                            min={10}
+                                            max={50}
+                                            value={[newMaxItemsForSearch]}
+                                            onValueChange={(value) => createChangeHandler(setNewMaxItemsForSearch)(value[value.length - 1], "maxItemsForSearch")}
+                                        />
+                                        <div className="flex justify-between text-xs text-muted-foreground mt-2">
+                                            <span>10 Items</span>
+                                            <span>50 Items</span>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-
                         </CardContent>
                     )}
                 </Card>

--- a/app/settings/browserSettings.tsx
+++ b/app/settings/browserSettings.tsx
@@ -370,7 +370,7 @@ export default function BrowserSettings() {
                     </CardHeader>
                     {expandedSections.graphInfo && (
                         <CardContent>
-                            <div className="flex gap-2">
+                            <div className="flex flex-col sm:flex-row gap-2">
                                 {/* Refresh Interval */}
                                 <div className="basis-0 grow flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2 p-2 bg-muted/10 rounded-lg">
                                     <div className="flex flex-col gap-2 flex-1">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search and filtering for Graph Info items (Nodes, Edges, Property Keys) with case-insensitive substring matching.
  * Introduced a new "Max Items for Search" setting (adjustable 10-50, default 20) to control when search functionality displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->