### PR TITLE
feat(settings): bump users management view L&F

### DIFF
--- a/app/components/FormComponent.tsx
+++ b/app/components/FormComponent.tsx
@@ -161,6 +161,7 @@ export default function FormComponent({ handleSubmit, fields, error = undefined,
                                             setSelectedValue={field.onChange}
                                         />
                                         : <Input
+                                            className={cn("w-full", field.type === "password" && "pr-10")}
                                             id={field.label}
                                             type={field.type === "password" ? passwordType : field.type}
                                             placeholder={field.placeholder}

--- a/app/settings/users/AddUser.tsx
+++ b/app/settings/users/AddUser.tsx
@@ -151,18 +151,20 @@ export default function AddUser({ onAddUser }: {
                     <PlusCircle size={20} />
                 </Button>
             </DrawerTrigger>
-            <DrawerContent side="right" className="w-[28rem] max-w-[90vw] gap-2 after:hidden overflow-y-auto">
-                <DrawerHeader className="px-4 pt-4 pb-0">
-                    <DrawerTitle>Add User</DrawerTitle>
-                    <DrawerDescription>
-                        Create a new user with role-based access permissions.
-                    </DrawerDescription>
-                </DrawerHeader>
-                <FormComponent
-                    className="p-4"
-                    handleSubmit={handleAddUser}
-                    fields={fields}
-                />
+            <DrawerContent side="right" className="w-[30rem] max-w-[90vw] gap-2 after:hidden">
+                <div className="flex-1 flex flex-col overflow-y-auto">
+                    <DrawerHeader className="px-6 pt-6 pb-2 text-left border-b border-border">
+                        <DrawerTitle className="text-xl">Add User</DrawerTitle>
+                        <DrawerDescription>
+                            Create a new user with role-based access permissions.
+                        </DrawerDescription>
+                    </DrawerHeader>
+                    <FormComponent
+                        className="px-6 py-4"
+                        handleSubmit={handleAddUser}
+                        fields={fields}
+                    />
+                </div>
             </DrawerContent>
         </Drawer>
     );

--- a/app/settings/users/AddUser.tsx
+++ b/app/settings/users/AddUser.tsx
@@ -7,8 +7,7 @@ import { PlusCircle } from "lucide-react";
 import { CreateUser } from "@/app/api/user/model";
 import Button from "@/app/components/ui/Button";
 import FormComponent, { Field } from "@/app/components/FormComponent";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import { Drawer, DrawerDescription, DrawerContent, DrawerTitle, DrawerTrigger } from "@/components/ui/drawer";
+import { Drawer, DrawerDescription, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from "@/components/ui/drawer";
 
 export default function AddUser({ onAddUser }: {
     onAddUser: (user: CreateUser, keys: string) => Promise<void>
@@ -152,11 +151,13 @@ export default function AddUser({ onAddUser }: {
                     <PlusCircle size={20} />
                 </Button>
             </DrawerTrigger>
-            <DrawerContent side="right" className="gap-2 after:hidden">
-                <VisuallyHidden>
-                    <DrawerTitle />
-                    <DrawerDescription />
-                </VisuallyHidden>
+            <DrawerContent side="right" className="w-[28rem] max-w-[90vw] gap-2 after:hidden overflow-y-auto">
+                <DrawerHeader className="px-4 pt-4 pb-0">
+                    <DrawerTitle>Add User</DrawerTitle>
+                    <DrawerDescription>
+                        Create a new user with role-based access permissions.
+                    </DrawerDescription>
+                </DrawerHeader>
                 <FormComponent
                     className="p-4"
                     handleSubmit={handleAddUser}

--- a/app/settings/users/EditUser.tsx
+++ b/app/settings/users/EditUser.tsx
@@ -4,8 +4,7 @@ import { FormEvent, useEffect, useState } from "react";
 import { Pencil } from "lucide-react";
 import Button from "@/app/components/ui/Button";
 import FormComponent, { Field } from "@/app/components/FormComponent";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import { Drawer, DrawerDescription, DrawerContent, DrawerTitle, DrawerTrigger } from "@/components/ui/drawer";
+import { Drawer, DrawerDescription, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from "@/components/ui/drawer";
 
 interface EditUserProps {
     username: string
@@ -139,11 +138,13 @@ export default function EditUser({ username, role: initialRole, keys: initialKey
                     <Pencil size={20} />
                 </Button>
             </DrawerTrigger>
-            <DrawerContent side="right" className="gap-2 after:hidden">
-                <VisuallyHidden>
-                    <DrawerTitle />
-                    <DrawerDescription />
-                </VisuallyHidden>
+            <DrawerContent side="right" className="w-[28rem] max-w-[90vw] gap-2 after:hidden overflow-y-auto">
+                <DrawerHeader className="px-4 pt-4 pb-0">
+                    <DrawerTitle>Edit User</DrawerTitle>
+                    <DrawerDescription>
+                        Update role, key/graph permissions, or password for this user.
+                    </DrawerDescription>
+                </DrawerHeader>
                 <FormComponent
                     className="p-4"
                     handleSubmit={handleEditUser}

--- a/app/settings/users/EditUser.tsx
+++ b/app/settings/users/EditUser.tsx
@@ -138,19 +138,21 @@ export default function EditUser({ username, role: initialRole, keys: initialKey
                     <Pencil size={20} />
                 </Button>
             </DrawerTrigger>
-            <DrawerContent side="right" className="w-[28rem] max-w-[90vw] gap-2 after:hidden overflow-y-auto">
-                <DrawerHeader className="px-4 pt-4 pb-0">
-                    <DrawerTitle>Edit User</DrawerTitle>
-                    <DrawerDescription>
-                        Update role, key/graph permissions, or password for this user.
-                    </DrawerDescription>
-                </DrawerHeader>
-                <FormComponent
-                    className="p-4"
-                    handleSubmit={handleEditUser}
-                    fields={fields}
-                    submitButtonLabel="Save"
-                />
+            <DrawerContent side="right" className="w-[30rem] max-w-[90vw] gap-2 after:hidden">
+                <div className="flex-1 flex flex-col overflow-y-auto">
+                    <DrawerHeader className="px-6 pt-6 pb-2 text-left border-b border-border">
+                        <DrawerTitle className="text-xl">Edit User</DrawerTitle>
+                        <DrawerDescription>
+                            Update role, key/graph permissions, or password for this user.
+                        </DrawerDescription>
+                    </DrawerHeader>
+                    <FormComponent
+                        className="px-6 py-4"
+                        handleSubmit={handleEditUser}
+                        fields={fields}
+                        submitButtonLabel="Save"
+                    />
+                </div>
             </DrawerContent>
         </Drawer>
     );

--- a/app/settings/users/Users.tsx
+++ b/app/settings/users/Users.tsx
@@ -129,35 +129,49 @@ export default function Users() {
     } : null;
 
     return (
-        <div className="w-full h-full flex flex-col space-y-4">
-            <TableComponent
-                label="Users"
-                entityName="User"
-                headers={["Name", "Role", "Key / Graph Permissions"]}
-                rows={rows}
-                setRows={setRows}
-                itemHeight={40}
-            >
-                <div className="flex flex-row-reverse gap-4">
-                    <AddUser onAddUser={handleAddUser} />
-                    <EditUser
-                        username={selectedUserData?.username || ""}
-                        role={selectedUserData?.role || ""}
-                        keys={selectedUserData?.keys || "*"}
-                        onEditUser={handleEditUser}
-                        disabled={!selectedUserData || selectedUserData.username === "default"}
-                    />
-                    <DeleteUser users={rows.filter(row => row.checked && row.cells[0].value !== "default").map(row => users.find(user => user.username === row.cells[0].value)!)} setUsers={setUsers} setRows={setRows} />
-                    <ActionButton
-                        variant="Primary"
-                        label="Save Users"
-                        title="Save users to disk"
-                        onClick={handleSaveUsers}
-                    >
-                        <Save />
-                    </ActionButton>
+        <div className="w-full h-full flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-3">
+                    <h2 className="text-xl font-semibold text-foreground">Users</h2>
+                    <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                        {users.length} {users.length === 1 ? "user" : "users"}
+                    </span>
                 </div>
-            </TableComponent>
+                <p className="text-sm text-muted-foreground">
+                    Manage users, roles, and key/graph permissions for this database.
+                </p>
+            </div>
+            <div className="flex-1 min-h-0 rounded-lg border border-border bg-background p-4">
+                <TableComponent
+                    label="Users"
+                    entityName="User"
+                    headers={["Name", "Role", "Key / Graph Permissions"]}
+                    rows={rows}
+                    setRows={setRows}
+                    itemHeight={40}
+                >
+                    <div className="flex flex-row-reverse gap-2">
+                        <AddUser onAddUser={handleAddUser} />
+                        <EditUser
+                            username={selectedUserData?.username || ""}
+                            role={selectedUserData?.role || ""}
+                            keys={selectedUserData?.keys || "*"}
+                            onEditUser={handleEditUser}
+                            disabled={!selectedUserData || selectedUserData.username === "default"}
+                        />
+                        <DeleteUser users={rows.filter(row => row.checked && row.cells[0].value !== "default").map(row => users.find(user => user.username === row.cells[0].value)!)} setUsers={setUsers} setRows={setRows} />
+                        <ActionButton
+                            variant="Secondary"
+                            label="Save Users"
+                            title="Save users to disk"
+                            className="px-4 py-[10px]"
+                            onClick={handleSaveUsers}
+                        >
+                            <Save size={20} />
+                        </ActionButton>
+                    </div>
+                </TableComponent>
+            </div>
         </div >
     );
 }


### PR DESCRIPTION
## Summary
Polish the users management drawer (Add/Edit User) so it looks more professional and stops resizing with input length, addressing #1657.

## Changes
- Fixed-width drawer (`w-[28rem]`, capped at `90vw`) for Add/Edit user panels — the panel no longer grows with the length of the password when toggling the show/hide eye.
- Surfaced a proper `DrawerHeader` with `Add User` / `Edit User` title and a short description (replacing the `VisuallyHidden` placeholders) for a cleaner, more professional look.
- Form inputs now span the full form width and reserve right padding when the password show/hide toggle is present, so long values don't slide under the icon.

## Testing
- `npx tsc --noEmit` (only a pre-existing unrelated error in `app/api/user/model.test.ts`)
- Existing Playwright POM selectors (`#add-user`, `#edit-user`, `#Username`, `#Password`, `#Confirm Password`, `#New Password`, `#Key / Graph Permissions`, `Submit`, `Save`) are preserved.

## Memory / Performance Impact
N/A — UI-only change.

## Related Issues
Closes #1657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced form input styling with improved width handling and responsive padding to properly accommodate password field visibility controls.
  * Improved user management drawer layouts with visible headers containing clear titles and descriptions, responsive sizing constraints, and vertical scrolling support for better overall usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->