### PR TITLE
Security: Unrestricted file upload to publicly served directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ next-env.d.ts
 /e2e/playwright/.auth
 /playwright
 /tls
+/uploads/
 .history

--- a/app/api/upload/[filename]/route.ts
+++ b/app/api/upload/[filename]/route.ts
@@ -1,0 +1,71 @@
+import { getClient } from "@/app/api/auth/[...nextauth]/options";
+import fs from "fs";
+import { NextRequest, NextResponse } from "next/server";
+import { getCorsHeaders } from "../../utils";
+import { getStoredUpload, MAX_FILE_SIZE } from "../file-validation";
+
+function hasErrorCode(error: unknown, code: string) {
+  return error instanceof Error && "code" in error && error.code === code;
+}
+
+export async function OPTIONS(request: Request) {
+  return new NextResponse(null, { status: 204, headers: getCorsHeaders(request) });
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ filename: string }> }
+) {
+  try {
+    const corsHeaders = getCorsHeaders(request);
+    const session = await getClient(request);
+
+    if (session instanceof NextResponse) {
+      return session;
+    }
+
+    const { filename } = await params;
+    const upload = getStoredUpload(filename);
+
+    if (!upload?.filePath) {
+      return NextResponse.json({ message: "File not found." }, { status: 404, headers: corsHeaders });
+    }
+
+    try {
+      const stats = await fs.promises.stat(upload.filePath);
+
+      if (!stats.isFile()) {
+        return NextResponse.json({ message: "File not found." }, { status: 404, headers: corsHeaders });
+      }
+
+      if (stats.size > MAX_FILE_SIZE) {
+        return NextResponse.json({ message: "File is too large." }, { status: 413, headers: corsHeaders });
+      }
+
+      const fileBuffer = await fs.promises.readFile(upload.filePath);
+
+      return new NextResponse(new Blob([new Uint8Array(fileBuffer)], { type: upload.fileType.contentType }), {
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": upload.fileType.contentType,
+          "Content-Disposition": `attachment; filename="${filename}"`,
+          "X-Content-Type-Options": "nosniff",
+          "Cache-Control": "private, no-store",
+        },
+      });
+    } catch (error) {
+      if (hasErrorCode(error, "ENOENT")) {
+        return NextResponse.json({ message: "File not found." }, { status: 404, headers: corsHeaders });
+      }
+
+      throw error;
+    }
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { message: (err as Error).message },
+      { status: 500, headers: getCorsHeaders(request) }
+    );
+  }
+}

--- a/app/api/upload/[filename]/route.ts
+++ b/app/api/upload/[filename]/route.ts
@@ -25,7 +25,7 @@ export async function GET(
     }
 
     const { filename } = await params;
-    const upload = getStoredUpload(filename);
+    const upload = getStoredUpload(filename, session.user.id);
 
     if (!upload?.filePath) {
       return NextResponse.json({ message: "File not found." }, { status: 404, headers: corsHeaders });
@@ -64,7 +64,7 @@ export async function GET(
   } catch (err) {
     console.error(err);
     return NextResponse.json(
-      { message: (err as Error).message },
+      { message: "Failed to download uploaded file." },
       { status: 500, headers: getCorsHeaders(request) }
     );
   }

--- a/app/api/upload/file-validation.ts
+++ b/app/api/upload/file-validation.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import crypto from "crypto";
 
 export const MAX_FILE_SIZE = 5 * 1024 * 1024;
 export const MAX_MULTIPART_SIZE = MAX_FILE_SIZE + 1024 * 1024;
@@ -13,6 +14,11 @@ const UUID_FILE_NAME_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9
 
 function getUploadsDir() {
   return path.join(process.cwd(), "uploads");
+}
+
+function getUserUploadsDir(userId: string) {
+  const userDirectory = crypto.createHash("sha256").update(userId).digest("hex");
+  return path.join(getUploadsDir(), userDirectory);
 }
 
 async function readFilePrefix(file: File, length: number) {
@@ -123,8 +129,8 @@ export function getAllowedFileType(extension: string) {
   return ALLOWED_FILE_TYPES[extension];
 }
 
-export function getUploadFilePath(filename: string) {
-  const uploadsDir = getUploadsDir();
+export function getUploadFilePath(filename: string, userId: string) {
+  const uploadsDir = getUserUploadsDir(userId);
   const filePath = path.join(uploadsDir, filename);
   const relativePath = path.relative(uploadsDir, filePath);
 
@@ -135,7 +141,7 @@ export function getUploadFilePath(filename: string) {
   return filePath;
 }
 
-export function getStoredUpload(filename: string) {
+export function getStoredUpload(filename: string, userId: string) {
   if (!UUID_FILE_NAME_PATTERN.test(filename)) {
     return null;
   }
@@ -149,11 +155,11 @@ export function getStoredUpload(filename: string) {
 
   return {
     extension,
-    filePath: getUploadFilePath(filename),
+    filePath: getUploadFilePath(filename, userId),
     fileType,
   };
 }
 
-export function getUploadsDirectory() {
-  return getUploadsDir();
+export function getUploadsDirectory(userId: string) {
+  return getUserUploadsDir(userId);
 }

--- a/app/api/upload/file-validation.ts
+++ b/app/api/upload/file-validation.ts
@@ -1,0 +1,159 @@
+import path from "path";
+
+export const MAX_FILE_SIZE = 5 * 1024 * 1024;
+export const MAX_MULTIPART_SIZE = MAX_FILE_SIZE + 1024 * 1024;
+
+type AllowedFileType = {
+  mimeTypes: readonly string[];
+  contentType: string;
+  validateContent: (file: File) => Promise<boolean>;
+};
+
+const UUID_FILE_NAME_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.[a-z0-9]+$/;
+
+function getUploadsDir() {
+  return path.join(process.cwd(), "uploads");
+}
+
+async function readFilePrefix(file: File, length: number) {
+  const buffer = await file.slice(0, length).arrayBuffer();
+  return new Uint8Array(buffer);
+}
+
+function matchesBytes(bytes: Uint8Array, signature: readonly number[], offset = 0) {
+  if (bytes.length < offset + signature.length) {
+    return false;
+  }
+
+  return signature.every((byte, index) => bytes[offset + index] === byte);
+}
+
+function matchesAscii(bytes: Uint8Array, value: string, offset = 0) {
+  return matchesBytes(
+    bytes,
+    Array.from(value, (character) => character.charCodeAt(0)),
+    offset
+  );
+}
+
+async function hasPngSignature(file: File) {
+  return matchesBytes(await readFilePrefix(file, 8), [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+}
+
+async function hasJpegSignature(file: File) {
+  return matchesBytes(await readFilePrefix(file, 3), [0xff, 0xd8, 0xff]);
+}
+
+async function hasGifSignature(file: File) {
+  const bytes = await readFilePrefix(file, 6);
+
+  return matchesAscii(bytes, "GIF87a") || matchesAscii(bytes, "GIF89a");
+}
+
+async function hasWebpSignature(file: File) {
+  const bytes = await readFilePrefix(file, 12);
+
+  return matchesAscii(bytes, "RIFF") && matchesAscii(bytes, "WEBP", 8);
+}
+
+async function hasPdfSignature(file: File) {
+  return matchesAscii(await readFilePrefix(file, 5), "%PDF-");
+}
+
+async function isUtf8TextFile(file: File) {
+  const bytes = new Uint8Array(await file.arrayBuffer());
+
+  if (bytes.includes(0)) {
+    return false;
+  }
+
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return false;
+  }
+
+  return bytes.every((byte) => byte === 9 || byte === 10 || byte === 12 || byte === 13 || byte >= 32);
+}
+
+export const ALLOWED_FILE_TYPES: Record<string, AllowedFileType> = {
+  ".png": {
+    mimeTypes: ["image/png"],
+    contentType: "image/png",
+    validateContent: hasPngSignature,
+  },
+  ".jpg": {
+    mimeTypes: ["image/jpeg"],
+    contentType: "image/jpeg",
+    validateContent: hasJpegSignature,
+  },
+  ".jpeg": {
+    mimeTypes: ["image/jpeg"],
+    contentType: "image/jpeg",
+    validateContent: hasJpegSignature,
+  },
+  ".gif": {
+    mimeTypes: ["image/gif"],
+    contentType: "image/gif",
+    validateContent: hasGifSignature,
+  },
+  ".webp": {
+    mimeTypes: ["image/webp"],
+    contentType: "image/webp",
+    validateContent: hasWebpSignature,
+  },
+  ".pdf": {
+    mimeTypes: ["application/pdf"],
+    contentType: "application/pdf",
+    validateContent: hasPdfSignature,
+  },
+  ".txt": {
+    mimeTypes: ["text/plain"],
+    contentType: "text/plain",
+    validateContent: isUtf8TextFile,
+  },
+  ".csv": {
+    mimeTypes: ["text/csv", "application/csv", "text/plain"],
+    contentType: "text/csv",
+    validateContent: isUtf8TextFile,
+  },
+};
+
+export function getAllowedFileType(extension: string) {
+  return ALLOWED_FILE_TYPES[extension];
+}
+
+export function getUploadFilePath(filename: string) {
+  const uploadsDir = getUploadsDir();
+  const filePath = path.join(uploadsDir, filename);
+  const relativePath = path.relative(uploadsDir, filePath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return filePath;
+}
+
+export function getStoredUpload(filename: string) {
+  if (!UUID_FILE_NAME_PATTERN.test(filename)) {
+    return null;
+  }
+
+  const extension = path.extname(filename).toLowerCase();
+  const fileType = getAllowedFileType(extension);
+
+  if (!fileType) {
+    return null;
+  }
+
+  return {
+    extension,
+    filePath: getUploadFilePath(filename),
+    fileType,
+  };
+}
+
+export function getUploadsDirectory() {
+  return getUploadsDir();
+}

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,72 +1,146 @@
 import { NextRequest, NextResponse } from "next/server";
 import path from "path";
-import { promisify } from "util";
-import { pipeline } from "stream";
+import { Readable } from "stream";
+import type { ReadableStream as NodeReadableStream } from "stream/web";
+import { pipeline } from "stream/promises";
 import fs from "fs";
 import { randomUUID } from "crypto";
 import { getCorsHeaders } from "../utils";
 import { getClient } from "../auth/[...nextauth]/options";
+import {
+  getAllowedFileType,
+  getUploadFilePath,
+  getUploadsDirectory,
+  MAX_FILE_SIZE,
+  MAX_MULTIPART_SIZE,
+} from "./file-validation";
 
-const pump = promisify(pipeline);
-const MAX_FILE_SIZE = 5 * 1024 * 1024;
-const ALLOWED_FILE_TYPES: Record<string, string[]> = {
-  ".png": ["image/png"],
-  ".jpg": ["image/jpeg"],
-  ".jpeg": ["image/jpeg"],
-  ".gif": ["image/gif"],
-  ".webp": ["image/webp"],
-  ".pdf": ["application/pdf"],
-  ".txt": ["text/plain"],
-  ".csv": ["text/csv", "application/csv", "text/plain"],
-};
+class PayloadTooLargeError extends Error {
+  constructor() {
+    super("Payload too large.");
+    this.name = "PayloadTooLargeError";
+  }
+}
 
-// eslint-disable-next-line import/prefer-default-export
+export async function OPTIONS(request: Request) {
+  return new NextResponse(null, { status: 204, headers: getCorsHeaders(request) });
+}
+
+function createSizeLimitedStream(body: ReadableStream<Uint8Array>, maxBytes: number) {
+  const reader = body.getReader();
+  let bytesRead = 0;
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        controller.close();
+        return;
+      }
+
+      bytesRead += value.byteLength;
+
+      if (bytesRead > maxBytes) {
+        const error = new PayloadTooLargeError();
+        await reader.cancel(error);
+        throw error;
+      }
+
+      controller.enqueue(value);
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
+async function getSizeLimitedFormData(request: NextRequest) {
+  if (!request.body) {
+    return request.formData();
+  }
+
+  const headers = new Headers(request.headers);
+  headers.delete("content-length");
+
+  const requestInit: RequestInit & { duplex: "half" } = {
+    body: createSizeLimitedStream(request.body, MAX_MULTIPART_SIZE),
+    duplex: "half",
+    headers,
+    method: request.method,
+  };
+
+  return new Request(request.url, requestInit).formData();
+}
+
 export async function POST(request: NextRequest) {
   try {
+    const corsHeaders = getCorsHeaders(request);
     const session = await getClient(request);
 
     if (session instanceof NextResponse) {
       return session;
     }
 
-    const formData = await request.formData();
+    const contentLength = Number(request.headers.get("content-length") ?? 0);
+
+    if (contentLength > MAX_MULTIPART_SIZE) {
+      return NextResponse.json({ error: "Payload too large." }, { status: 413, headers: corsHeaders });
+    }
+
+    let formData;
+
+    try {
+      formData = await getSizeLimitedFormData(request);
+    } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        return NextResponse.json({ error: "Payload too large." }, { status: 413, headers: corsHeaders });
+      }
+
+      throw error;
+    }
 
     const file = formData.get("file");
 
     if (!(file instanceof File)) {
-      return NextResponse.json({ error: "No files received." }, { status: 400, headers: getCorsHeaders(request) });
+      return NextResponse.json({ error: "No files received." }, { status: 400, headers: corsHeaders });
     }
 
     if (file.size > MAX_FILE_SIZE) {
-      return NextResponse.json({ error: "File is too large." }, { status: 400, headers: getCorsHeaders(request) });
+      return NextResponse.json({ error: "File is too large." }, { status: 413, headers: corsHeaders });
     }
 
     const extension = path.extname(file.name).toLowerCase();
-    const allowedMimeTypes = ALLOWED_FILE_TYPES[extension];
+    const allowedFileType = getAllowedFileType(extension);
 
-    if (!allowedMimeTypes || !allowedMimeTypes.includes(file.type)) {
-      return NextResponse.json({ error: "Invalid file type." }, { status: 400, headers: getCorsHeaders(request) });
+    if (!allowedFileType || !allowedFileType.mimeTypes.includes(file.type)) {
+      return NextResponse.json({ error: "Invalid file type." }, { status: 400, headers: corsHeaders });
+    }
+
+    if (!(await allowedFileType.validateContent(file))) {
+      return NextResponse.json({ error: "Invalid file contents." }, { status: 400, headers: corsHeaders });
     }
 
     const filename = `${randomUUID()}${extension}`;
-    const assetsDir = path.join(process.cwd(), "public", "assets");
-    const filePath = path.join(assetsDir, filename);
+    const uploadsDir = getUploadsDirectory();
+    const filePath = getUploadFilePath(filename);
 
-    if (!filePath.startsWith(assetsDir)) {
-      return NextResponse.json({ error: "Invalid file name." }, { status: 400, headers: getCorsHeaders(request) });
+    if (!filePath) {
+      return NextResponse.json({ error: "Invalid file name." }, { status: 400, headers: corsHeaders });
     }
 
     try {
-      await fs.promises.mkdir(assetsDir, { recursive: true });
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      await pump(file.stream(), fs.createWriteStream(filePath));
-      return NextResponse.json({ path: `/assets/${filename}`, status: 200 }, { headers: getCorsHeaders(request) });
+      await fs.promises.mkdir(uploadsDir, { recursive: true });
+      await pipeline(
+        Readable.fromWeb(file.stream() as NodeReadableStream<Uint8Array>),
+        fs.createWriteStream(filePath)
+      );
+      return NextResponse.json({ id: filename, path: `/api/upload/${filename}`, status: 200 }, { headers: corsHeaders });
     } catch (error) {
       console.error(error);
       return NextResponse.json(
         { message: (error as Error).message },
-        { status: 400, headers: getCorsHeaders(request) }
+        { status: 400, headers: corsHeaders }
       );
     }
   } catch (err) {

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -122,25 +122,31 @@ export async function POST(request: NextRequest) {
     }
 
     const filename = `${randomUUID()}${extension}`;
-    const uploadsDir = getUploadsDirectory();
-    const filePath = getUploadFilePath(filename);
+    const uploadsDir = getUploadsDirectory(session.user.id);
+    const filePath = getUploadFilePath(filename, session.user.id);
 
     if (!filePath) {
       return NextResponse.json({ error: "Invalid file name." }, { status: 400, headers: corsHeaders });
     }
 
     try {
+      const tempFilePath = `${filePath}.tmp`;
+
       await fs.promises.mkdir(uploadsDir, { recursive: true });
       await pipeline(
         Readable.fromWeb(file.stream() as NodeReadableStream<Uint8Array>),
-        fs.createWriteStream(filePath)
+        fs.createWriteStream(tempFilePath)
       );
+      await fs.promises.rename(tempFilePath, filePath);
       return NextResponse.json({ id: filename, path: `/api/upload/${filename}`, status: 200 }, { headers: corsHeaders });
     } catch (error) {
       console.error(error);
+      await fs.promises.unlink(`${filePath}.tmp`).catch((cleanupError) => {
+        console.warn("Failed to clean up partial upload:", cleanupError);
+      });
       return NextResponse.json(
-        { message: (error as Error).message },
-        { status: 400, headers: corsHeaders }
+        { message: "Failed to store uploaded file." },
+        { status: 500, headers: corsHeaders }
       );
     }
   } catch (err) {

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -3,10 +3,22 @@ import path from "path";
 import { promisify } from "util";
 import { pipeline } from "stream";
 import fs from "fs";
+import { randomUUID } from "crypto";
 import { getCorsHeaders } from "../utils";
 import { getClient } from "../auth/[...nextauth]/options";
 
 const pump = promisify(pipeline);
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+const ALLOWED_FILE_TYPES: Record<string, string[]> = {
+  ".png": ["image/png"],
+  ".jpg": ["image/jpeg"],
+  ".jpeg": ["image/jpeg"],
+  ".gif": ["image/gif"],
+  ".webp": ["image/webp"],
+  ".pdf": ["application/pdf"],
+  ".txt": ["text/plain"],
+  ".csv": ["text/csv", "application/csv", "text/plain"],
+};
 
 // eslint-disable-next-line import/prefer-default-export
 export async function POST(request: NextRequest) {
@@ -19,26 +31,37 @@ export async function POST(request: NextRequest) {
 
     const formData = await request.formData();
 
-    const file = formData.get("file") as File;
+    const file = formData.get("file");
 
-    if (!file) {
+    if (!(file instanceof File)) {
       return NextResponse.json({ error: "No files received." }, { status: 400, headers: getCorsHeaders(request) });
     }
 
-    const filename = path.basename(file.name).replaceAll(" ", "_");
-    const filePath = path.join(process.cwd(), "public", "assets", filename);
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ error: "File is too large." }, { status: 400, headers: getCorsHeaders(request) });
+    }
 
-    // Guard against path traversal
+    const extension = path.extname(file.name).toLowerCase();
+    const allowedMimeTypes = ALLOWED_FILE_TYPES[extension];
+
+    if (!allowedMimeTypes || !allowedMimeTypes.includes(file.type)) {
+      return NextResponse.json({ error: "Invalid file type." }, { status: 400, headers: getCorsHeaders(request) });
+    }
+
+    const filename = `${randomUUID()}${extension}`;
     const assetsDir = path.join(process.cwd(), "public", "assets");
+    const filePath = path.join(assetsDir, filename);
+
     if (!filePath.startsWith(assetsDir)) {
       return NextResponse.json({ error: "Invalid file name." }, { status: 400, headers: getCorsHeaders(request) });
     }
 
     try {
+      await fs.promises.mkdir(assetsDir, { recursive: true });
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       await pump(file.stream(), fs.createWriteStream(filePath));
-      return NextResponse.json({ path: filePath, status: 200 }, { headers: getCorsHeaders(request) });
+      return NextResponse.json({ path: `/assets/${filename}`, status: 200 }, { headers: getCorsHeaders(request) });
     } catch (error) {
       console.error(error);
       return NextResponse.json(


### PR DESCRIPTION
## Summary

Security: Unrestricted file upload to publicly served directory

## Problem

**Severity**: `High` | **File**: `app/api/upload/route.ts:L24`

Uploaded files are written directly into `public/assets`, which is web-accessible. There is no file type/content validation, extension allowlist, malware scanning, or size limits. This enables authenticated users to upload active content (e.g., HTML/SVG/JS-capable files depending on serving behavior) and potentially deliver stored XSS/phishing payloads from trusted origin paths.

## Solution

Store uploads outside the public web root, enforce strict MIME/extension allowlists, set maximum file size, generate random server-side filenames, and serve via a download endpoint with safe `Content-Type`/`Content-Disposition`. If public serving is required, deny executable/active formats.

## Changes

- `app/api/upload/route.ts` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved upload flow: size limits, content-and-extension validation, safe stored IDs, and API download URLs; upload/download endpoints support CORS preflight and return attachment-style downloads with cache and nosniff protections.
* **Bug Fixes**
  * Oversized, invalid, missing, or missing-file uploads now return appropriate error statuses; storage failures return safe errors and attempt cleanup; missing downloads return 404.
* **Chores**
  * .gitignore updated to exclude uploaded files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->