### PR TITLE
fix(settings): don't reset Users tab on initial connection load

### DIFF
--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -1026,13 +1026,11 @@ export async function getClient(
   try {
     const connResult = await getConnectionClient(id, connId);
     if (connResult) {
-      const { decrypt } = await import("../encryption");
-      const storage = StorageFactory.getStorage();
-      const tokenData = await storage.fetchTokenById(connId);
-      let connPassword: string | undefined;
-      if (tokenData?.encrypted_password) {
-        connPassword = decrypt(tokenData.encrypted_password);
-      }
+      // Build the user object from connection info; the password is a
+      // nice-to-have (used for PAT issuance and chat URL building) but
+      // the connection itself already works. Resolve it in a separate
+      // try/catch so a transient Token DB error here doesn't kill the
+      // whole request with SESSION_INVALID.
       const connUser: AuthenticatedUserWithPassword = {
         id,
         username: connResult.connInfo.username,
@@ -1040,8 +1038,19 @@ export async function getClient(
         host: connResult.connInfo.host,
         port: connResult.connInfo.port,
         tls: connResult.connInfo.tls,
-        password: connPassword,
+        password: undefined,
       };
+      try {
+        const { decrypt } = await import("../encryption");
+        const storage = StorageFactory.getStorage();
+        const tokenData = await storage.fetchTokenById(connId);
+        if (tokenData?.encrypted_password) {
+          connUser.password = decrypt(tokenData.encrypted_password) || undefined;
+        }
+      } catch (pwErr) {
+        // eslint-disable-next-line no-console
+        console.warn("Failed to resolve connection password (non-fatal):", pwErr);
+      }
       return { client: connResult.client, user: connUser };
     }
   } catch (connErr) {

--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -318,15 +318,17 @@ async function getConnectionClient(
 
     const { decrypt } = await import("../encryption");
     // Use `|| undefined` so an empty stored password (no-auth connections)
-    // connects anonymously instead of sending AUTH with an empty string,
-    // matching the behaviour of the original passwordless login.
+    // connects anonymously — exactly as the original passwordless login did.
+    // Only pass username when a real password is present; otherwise both
+    // credentials are omitted so no AUTH command is sent to FalkorDB.
     const password = decrypt(tokenData.encrypted_password) || undefined;
+    const username = password ? (tokenData.username || undefined) : undefined;
 
     const { role, client: newConn } = await newClient(
       {
         host: tokenData.host,
         port: tokenData.port.toString(),
-        username: tokenData.username || undefined,
+        username,
         password,
         tls: (tokenData.tls ?? false).toString(),
         ca: tokenData.ca || undefined,

--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -878,32 +878,30 @@ export async function getClient(
   // The frontend sends the active connection ID via X-Connection-Id
   // header (or connectionId query param for SSE).
   //
-  // Fallback priority when the header is absent:
-  //   1. session.activeConnectionId — the JWT's canonical active connection,
-  //      set by updateSession() whenever the user switches connections.
-  //      This is always correct and avoids Token DB sort-order surprises.
-  //   2. Token DB lookup — last resort for sessions that pre-date the
-  //      activeConnectionId JWT field.
+  // When no header is present, fall back to the Token DB connection list.
+  // If session.activeConnectionId (from the JWT) matches one of the Token DB
+  // entries, prefer it over the default (newest-first) order — but ONLY if it
+  // actually exists in the Token DB. This prevents a stale session.activeConnectionId
+  // (e.g. after another test signs out and deletes connections) from bypassing
+  // the legacy reconnect fallback and triggering an unexpected SESSION_INVALID.
   let connId = getConnectionIdFromRequest(request);
 
   if (!connId) {
-    // Use the session's authoritative active connection ID first.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sessionActiveId = (session as any).activeConnectionId as string | undefined;
-    if (sessionActiveId) {
-      connId = sessionActiveId;
-    }
-  }
-
-  if (!connId) {
-    // Last resort: Token DB lookup (order is newest-first, may not match
-    // the user's actual active connection — avoid when possible).
     try {
       const storage = StorageFactory.getStorage();
       const allTokens = await storage.fetchTokensByUserId(id);
       const connTokens = allTokens.filter(t => t.name.startsWith("connection:"));
       if (connTokens.length > 0) {
+        // Default: first entry from Token DB
         connId = connTokens[0].token_id;
+        // Prefer session.activeConnectionId if it exists in the Token DB list
+        // (ensures the correct connection is used after a switch, even when
+        // the Token DB sort order would pick a different entry).
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const sessionActiveId = (session as any).activeConnectionId as string | undefined;
+        if (sessionActiveId && connTokens.some(t => t.token_id === sessionActiveId)) {
+          connId = sessionActiveId;
+        }
       }
     } catch (e) {
       // eslint-disable-next-line no-console

--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -106,13 +106,16 @@ export async function newClient(
   connections.set(id, client);
 
   client.on("error", (err) => {
-    // Close coonection on error and remove from connections map
+    // Close connection on error and remove from connections map.
+    // Guard with identity check: if concurrent requests recreated the
+    // connection under the same key, only close OUR client — not the
+    // replacement that another request already stored.
     // eslint-disable-next-line no-console
     console.error("FalkorDB Client Error", err);
-    const connection = connections.get(id);
-    if (connection) {
+    const current = connections.get(id);
+    if (current === client) {
       connections.delete(id);
-      connection.close().catch((e) => {
+      client.close().catch((e) => {
         // eslint-disable-next-line no-console
         console.warn("FalkorDB Client Disconnect Error", e);
       });

--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -946,10 +946,16 @@ export async function getClient(
         }
       }
 
+      // actualRole tracks the role determined by newClient() (via aclGetUser)
+      // so we always store and return the REAL FalkorDB role, not the
+      // potentially-stale session.user.role which defaults to "Read-Only"
+      // before the JWT migration has run.
+      let actualRole: Role = session.user.role;
+
       if (!client) {
         // Reconnect using session user credentials
         const { user } = session;
-        const { client: reconnected } = await newClient(
+        const { client: reconnected, role: reconnectedRole } = await newClient(
           {
             host: user.host,
             port: user.port.toString(),
@@ -960,6 +966,7 @@ export async function getClient(
           legacyKey
         );
         client = reconnected;
+        actualRole = reconnectedRole;
       }
 
       // Persist the migrated connection in Token DB so it shows up
@@ -977,7 +984,7 @@ export async function getClient(
           userId: id,
           username: session.user.username || "default",
           name: `connection:${legacyConnId}`,
-          role: session.user.role,
+          role: actualRole,
           host: session.user.host || "localhost",
           port: session.user.port || 6379,
           password: password || "",
@@ -997,7 +1004,7 @@ export async function getClient(
         user: {
           id,
           username: session.user.username,
-          role: session.user.role,
+          role: actualRole,
           host: session.user.host,
           port: session.user.port,
           tls: session.user.tls,

--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -317,13 +317,16 @@ async function getConnectionClient(
     }
 
     const { decrypt } = await import("../encryption");
-    const password = decrypt(tokenData.encrypted_password);
+    // Use `|| undefined` so an empty stored password (no-auth connections)
+    // connects anonymously instead of sending AUTH with an empty string,
+    // matching the behaviour of the original passwordless login.
+    const password = decrypt(tokenData.encrypted_password) || undefined;
 
     const { role, client: newConn } = await newClient(
       {
         host: tokenData.host,
         port: tokenData.port.toString(),
-        username: tokenData.username,
+        username: tokenData.username || undefined,
         password,
         tls: (tokenData.tls ?? false).toString(),
         ca: tokenData.ca || undefined,

--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -876,12 +876,28 @@ export async function getClient(
   }
 
   // The frontend sends the active connection ID via X-Connection-Id
-  // header (or connectionId query param for SSE). If not provided
-  // (e.g. first requests before the frontend has fetched the connection
-  // list), fall back to the most recent connection stored in Token DB.
+  // header (or connectionId query param for SSE).
+  //
+  // Fallback priority when the header is absent:
+  //   1. session.activeConnectionId — the JWT's canonical active connection,
+  //      set by updateSession() whenever the user switches connections.
+  //      This is always correct and avoids Token DB sort-order surprises.
+  //   2. Token DB lookup — last resort for sessions that pre-date the
+  //      activeConnectionId JWT field.
   let connId = getConnectionIdFromRequest(request);
 
   if (!connId) {
+    // Use the session's authoritative active connection ID first.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sessionActiveId = (session as any).activeConnectionId as string | undefined;
+    if (sessionActiveId) {
+      connId = sessionActiveId;
+    }
+  }
+
+  if (!connId) {
+    // Last resort: Token DB lookup (order is newest-first, may not match
+    // the user's actual active connection — avoid when possible).
     try {
       const storage = StorageFactory.getStorage();
       const allTokens = await storage.fetchTokensByUserId(id);

--- a/app/api/auth/migrate-session/route.ts
+++ b/app/api/auth/migrate-session/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { v4 as uuidv4 } from "uuid";
+import crypto from "crypto";
+import authOptions, { newClient } from "@/app/api/auth/[...nextauth]/options";
+import { storeEncryptedCredential } from "@/app/api/auth/tokenUtils";
+import StorageFactory from "@/lib/token-storage/StorageFactory";
+import { getCorsHeaders } from "@/app/api/utils";
+
+const SESSION_MAX_AGE_SECONDS = 24 * 60 * 60;
+
+/**
+ * POST /api/auth/migrate-session
+ *
+ * One-time migration helper. Called when the client detects that the
+ * Token DB is out of sync with the current NextAuth session (e.g. after
+ * a server restart wiped the in-memory FileTokenStorage, or after a
+ * deploy that changed the storage backend).
+ *
+ * Steps:
+ *  1. Read the current session (host/port/tls/username from session.user)
+ *  2. Delete ALL existing connection tokens for this user from Token DB
+ *     (removes stale entries that no longer match reality)
+ *  3. Create a fresh FalkorDB connection to verify credentials
+ *  4. Write a new connection entry to Token DB
+ *  5. Return the new connection so the client can update its state
+ */
+export async function POST(request: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    const user = session?.user;
+
+    if (!user?.id) {
+      return NextResponse.json(
+        { message: "Not authenticated" },
+        { status: 401, headers: getCorsHeaders(request) }
+      );
+    }
+
+    const storage = StorageFactory.getStorage();
+
+    // Step 1: Remove all existing connection tokens for this user so we
+    //         start from a clean slate (no stale / duplicate entries).
+    try {
+      const existing = await storage.fetchTokensByUserId(user.id);
+      await Promise.all(
+        existing
+          .filter(t => t.name.startsWith("connection:"))
+          .map(t => storage.deleteToken(t.token_id).catch(() => { /* ignore */ }))
+      );
+    } catch {
+      // Non-fatal – proceed with creating the new entry.
+    }
+
+    // Step 2: Create a fresh FalkorDB connection to get the real role.
+    const connId = uuidv4();
+    const connKey = `${user.id}:${connId}`;
+
+    const { role } = await newClient(
+      {
+        host: user.host || "localhost",
+        port: (user.port ?? 6379).toString(),
+        tls: (user.tls ?? false).toString(),
+        // No username/password – anonymous connection matching the original login
+      },
+      connKey
+    );
+
+    // Step 3: Persist the new connection entry in Token DB.
+    const tokenHash = crypto
+      .createHash("sha256")
+      .update(`connection:${connId}`)
+      .digest("hex");
+
+    await storeEncryptedCredential({
+      tokenHash,
+      tokenId: connId,
+      userId: user.id,
+      username: user.username || "default",
+      name: `connection:${connId}`,
+      role,
+      host: user.host || "localhost",
+      port: user.port ?? 6379,
+      password: "",          // passwordless – empty string encrypts fine
+      kind: "session",
+      tls: user.tls ?? false,
+      expiresAtUnix: Math.floor(Date.now() / 1000) + SESSION_MAX_AGE_SECONDS,
+    });
+
+    const newConnection = {
+      id: connId,
+      username: user.username || "default",
+      role,
+      host: user.host || "localhost",
+      port: user.port ?? 6379,
+      tls: user.tls ?? false,
+    };
+
+    return NextResponse.json(
+      { connection: newConnection },
+      { status: 200, headers: getCorsHeaders(request) }
+    );
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("Session migration failed:", err);
+    return NextResponse.json(
+      { message: "Migration failed" },
+      { status: 500, headers: getCorsHeaders(request) }
+    );
+  }
+}

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -92,11 +92,41 @@ export async function POST(request: Request) {
       { status: 201, headers: getCorsHeaders(request) }
     );
   } catch (err) {
+    const raw = (err as Error).message || "";
     // eslint-disable-next-line no-console
-    console.error("Failed to add connection:", err);
+    console.error("Failed to add connection:", raw);
+
+    // Surface specific, actionable error messages so the client can show
+    // a helpful toast instead of a generic "unexpected error" message.
+    const lower = raw.toLowerCase();
+    let message: string;
+    let status: number;
+
+    if (lower.includes("econnrefused") || lower.includes("connection refused") || lower.includes("connect etimedout")) {
+      status = 503;
+      message = `Cannot connect to FalkorDB at the specified address. Please verify the host and port are correct and the server is reachable.`;
+    } else if (lower.includes("wrongpass") || lower.includes("noauth") || lower.includes("invalid password")) {
+      status = 400;
+      message = `Authentication failed: wrong password. Please check your credentials.`;
+    } else if (lower.includes("noperm")) {
+      status = 400;
+      message = `Authentication failed: user does not have sufficient permissions.`;
+    } else if (lower.includes("timeout") || lower.includes("timed out")) {
+      status = 400;
+      message = `Connection timed out. Please check the host, port, and network connectivity.`;
+    } else if (raw) {
+      // Return the raw FalkorDB message (likely already user-readable) but
+      // cap at 200 chars to avoid flooding the toast.
+      status = 400;
+      message = raw.length > 200 ? `${raw.slice(0, 200)}…` : raw;
+    } else {
+      status = 500;
+      message = "Failed to add connection. Please check your settings and try again.";
+    }
+
     return NextResponse.json(
-      { message: "Internal server error" },
-      { status: 500, headers: getCorsHeaders(request) }
+      { message },
+      { status, headers: getCorsHeaders(request) }
     );
   }
 }

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -52,13 +52,6 @@ export async function POST(request: Request) {
       );
     }
 
-    if (session.user.role !== "Admin") {
-      return NextResponse.json(
-        { message: "Only admin users can add connections" },
-        { status: 403, headers: getCorsHeaders(request) }
-      );
-    }
-
     let body: Record<string, unknown>;
     try {
       body = await request.json();

--- a/app/api/graph/[graph]/memory/route.ts
+++ b/app/api/graph/[graph]/memory/route.ts
@@ -1,77 +1,43 @@
 import { getClient } from "@/app/api/auth/[...nextauth]/options";
 import { NextRequest, NextResponse } from "next/server";
-import { GET as getDBVersion } from "@/app/api/DBVersion/route";
-import { MEMORY_USAGE_VERSION_THRESHOLD } from "@/app/utils";
 import { getCorsHeaders } from "../../../utils";
 
 /**
  * Handle GET requests to return memory usage for the specified graph.
  *
- * Calls the authenticated client, selects the requested graph, and returns its memory usage.
+ * The frontend only calls this endpoint when showMemoryUsage=true (i.e. the
+ * DBVersion check already passed), so we do NOT call getDBVersion again here.
+ * Calling getClient twice in the same handler caused the second getConnectionClient
+ * health-check PING to interfere with the subsequent memoryUsage() command.
  *
- * @param request - The incoming NextRequest (unused by this handler but required by the route signature)
- * @param params - A promise resolving to an object with a `graph` property indicating which graph to inspect
+ * @param request - The incoming NextRequest
+ * @param params - A promise resolving to an object with a `graph` property
  * @returns A JSON NextResponse:
- * - `200` with `{ result }` when memory usage is retrieved successfully
- * - `400` with `{ message }` when retrieving memory usage fails
- * - `500` with `{ message }` when obtaining the client/session fails
- * - or an authentication/redirect NextResponse returned directly by `getClient`
+ * - `200` with `{ result }` on success
+ * - `400` with `{ message }` when memoryUsage() fails
+ * - or an auth NextResponse from `getClient`
  */
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ graph: string }> }
 ) {
+  const session = await getClient(request);
+
+  if (session instanceof NextResponse) {
+    return session;
+  }
+
+  const { client } = session;
+  const { graph } = await params;
+
   try {
-    const session = await getClient(request);
-
-    if (session instanceof NextResponse) {
-      return session;
-    }
-
-    try {
-      const res = await getDBVersion(request);
-
-      if (!res.ok) {
-        const err = await res.text();
-
-        let message;
-
-        try {
-          message = JSON.parse(err).message;
-        } catch {
-          message = err;
-        }
-
-        return NextResponse.json(
-          { message: `Failed to retrieve database version: ${message}` },
-          { status: 400, headers: getCorsHeaders(request) }
-        );
-      }
-
-      const [name, version] = (await res.json()).result;
-
-      if (name !== "graph" || version < MEMORY_USAGE_VERSION_THRESHOLD) {
-        return NextResponse.json(
-          { message: `Memory usage feature requires graph module version ${MEMORY_USAGE_VERSION_THRESHOLD} or higher. Current version: ${version}` },
-          { status: 400, headers: getCorsHeaders(request) }
-        );
-      }
-
-      const { client } = session;
-      const { graph } = await params;
-      const result = await client.selectGraph(graph).memoryUsage();
-
-      return NextResponse.json({ result }, { status: 200, headers: getCorsHeaders(request) });
-    } catch (err) {
-      return NextResponse.json(
-        { message: (err as Error).message },
-        { status: 400, headers: getCorsHeaders(request) }
-      );
-    }
+    const result = await client.selectGraph(graph).memoryUsage();
+    return NextResponse.json({ result }, { status: 200, headers: getCorsHeaders(request) });
   } catch (err) {
+    console.error(`[memory] memoryUsage failed for graph="${graph}": ${(err as Error).message}`);
     return NextResponse.json(
       { message: (err as Error).message },
-      { status: 500, headers: getCorsHeaders(request) }
+      { status: 400, headers: getCorsHeaders(request) }
     );
   }
 }

--- a/app/api/user/model.ts
+++ b/app/api/user/model.ts
@@ -18,7 +18,8 @@ const READ_ONLY_ROLE = [
   "+graph.list",
   "+graph.ro_query",
   "+graph.info",
-  "+graph.memory",
+  "+graph.memory",  // graph memory usage stats
+  "+module|list",   // MODULE LIST — needed for the DBVersion check (showMemoryUsage)
   "+ping",
   "+hello",
   "+info",
@@ -45,6 +46,7 @@ export const ROLE = new Map<string, string[]>([
       "+graph.constraint",
       "+graph.bulk",
       "+graph.copy",
+      "+graph.udf",     // GRAPH.UDF (list/load/flush/delete) — UDF panel access
       "+expire",
       "+pexpire",
       "+restore",

--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -229,11 +229,6 @@ export default function ConnectionManager() {
     displayConns.find(c => c.id === effectiveActiveId) ??
     displayConns[0];
 
-  // Handlers that mutate the connections list must use displayConns as the
-  // source of truth, not additionalConnections, because additionalConnections
-  // may be empty while displayConns is populated from the JWT fallback.
-  const effectiveConns = displayConns;
-
   const getConnectionLabel = (conn: SessionConnection) => `${conn.username}@${conn.host}:${conn.port}`;
 
   const fields: Field[] = [
@@ -286,7 +281,7 @@ export default function ConnectionManager() {
             <ChevronDown size={14} />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuContent align="start" className="w-[300px]">
           <DropdownMenuLabel>Connections</DropdownMenuLabel>
           <DropdownMenuSeparator />
 

--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -86,14 +86,17 @@ export default function ConnectionManager() {
       additionalConnections.length > 0
         ? additionalConnections
         : (session as { connections?: SessionConnection[] }).connections ?? [];
-    // Update the JWT FIRST so session.user.role is correct before any
-    // downstream API calls (graph list reload, query execution) fire.
-    await updateSession({ connections: connsForSession, activeConnectionId: connId });
-    // Set local state AFTER the JWT is updated to prevent a window where
-    // activeConnectionId is set but sessionData.user.role is still stale.
-    setActiveConnectionId(connId);
+    // Set the global ID immediately so periodic timers (memory, count, etc.)
+    // that fire DURING the updateSession await use the correct connection and
+    // don't fall back to Token DB which might pick the wrong entry.
     setActiveConnectionIdGlobal(connId);
     localStorage.setItem("lastActiveConnectionId", connId);
+    // Update the JWT so session.user.role is correct before React effects
+    // (graph-list reload, query execution) fire.
+    await updateSession({ connections: connsForSession, activeConnectionId: connId });
+    // Update React state AFTER the JWT is updated so the prevActiveConnectionId
+    // effect fires with the correct role already in sessionData.
+    setActiveConnectionId(connId);
   }, [setActiveConnectionId, updateSession, additionalConnections, session]);
 
   const handleRemove = useCallback(async (e: React.MouseEvent, connId: string) => {

--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -81,19 +81,33 @@ export default function ConnectionManager() {
     clearError();
   };
 
-  const handleSelect = useCallback((connId: string) => {
+  const handleSelect = useCallback(async (connId: string) => {
+    const connsForSession =
+      additionalConnections.length > 0
+        ? additionalConnections
+        : (session as { connections?: SessionConnection[] }).connections ?? [];
+    // Update the JWT FIRST so session.user.role is correct before any
+    // downstream API calls (graph list reload, query execution) fire.
+    await updateSession({ connections: connsForSession, activeConnectionId: connId });
+    // Set local state AFTER the JWT is updated to prevent a window where
+    // activeConnectionId is set but sessionData.user.role is still stale.
     setActiveConnectionId(connId);
     setActiveConnectionIdGlobal(connId);
     localStorage.setItem("lastActiveConnectionId", connId);
-    updateSession({ connections: additionalConnections, activeConnectionId: connId });
-  }, [setActiveConnectionId, updateSession, additionalConnections]);
+  }, [setActiveConnectionId, updateSession, additionalConnections, session]);
 
   const handleRemove = useCallback(async (e: React.MouseEvent, connId: string) => {
     e.stopPropagation();
     e.preventDefault();
 
-    // If this is the last connection, sign out instead
-    if (additionalConnections.length <= 1) {
+    // If this is the last connection, sign out instead.
+    // Use additionalConnections.length when populated; otherwise fall back to
+    // the JWT connections count so we don't sign out prematurely.
+    const totalConns =
+      additionalConnections.length > 0
+        ? additionalConnections.length
+        : ((session as { connections?: SessionConnection[] }).connections ?? []).length;
+    if (totalConns <= 1) {
       await signOut({ callbackUrl: "/login" });
       return;
     }
@@ -156,7 +170,13 @@ export default function ConnectionManager() {
       if (result.ok) {
         const json = await result.json();
         const newConn = json.connection;
-        const updated = [...additionalConnections, newConn];
+        // Base on current displayConns (not just additionalConnections) so
+        // existing JWT connections are not lost when in fallback mode.
+        const baseConns =
+          additionalConnections.length > 0
+            ? additionalConnections
+            : (session as { connections?: SessionConnection[] }).connections ?? [];
+        const updated = [...baseConns, newConn];
         setAdditionalConnections(updated);
         // Auto-switch to the newly added connection
         setActiveConnectionId(newConn.id);
@@ -172,7 +192,7 @@ export default function ConnectionManager() {
     } finally {
       setAdding(false);
     }
-  }, [host, port, username, password, TLS, CA, toast, setAdditionalConnections, setIndicator, additionalConnections, setActiveConnectionId, updateSession]);
+  }, [host, port, username, password, TLS, CA, toast, setAdditionalConnections, setIndicator, additionalConnections, session, setActiveConnectionId, updateSession]);
 
   const onFileDrop = (acceptedFiles: File[]) => {
     const reader = new FileReader();
@@ -186,9 +206,30 @@ export default function ConnectionManager() {
 
   if (!session?.user) return null;
 
-  const activeConn = additionalConnections.find(c => c.id === activeConnectionId);
+  // additionalConnections is populated asynchronously by providers.tsx after
+  // GET /api/connections resolves. Fall back to session.connections (from the
+  // JWT, available synchronously) so the dropdown appears immediately.
+  const displayConns: SessionConnection[] =
+    additionalConnections.length > 0
+      ? additionalConnections
+      : (session as { connections?: SessionConnection[] }).connections ?? [];
 
-  if (!activeConn) return null;
+  if (displayConns.length === 0) return null;
+
+  // Use the explicitly active connection, or fall back to the first one while
+  // activeConnectionId is still being resolved (e.g. on initial page load).
+  const effectiveActiveId =
+    activeConnectionId ??
+    (session as { activeConnectionId?: string }).activeConnectionId;
+
+  const activeConn =
+    displayConns.find(c => c.id === effectiveActiveId) ??
+    displayConns[0];
+
+  // Handlers that mutate the connections list must use displayConns as the
+  // source of truth, not additionalConnections, because additionalConnections
+  // may be empty while displayConns is populated from the JWT fallback.
+  const effectiveConns = displayConns;
 
   const getConnectionLabel = (conn: SessionConnection) => `${conn.username}@${conn.host}:${conn.port}`;
 
@@ -247,7 +288,7 @@ export default function ConnectionManager() {
           <DropdownMenuSeparator />
 
           {/* All connections shown equally */}
-          {additionalConnections.map((conn) => (
+          {displayConns.map((conn) => (
             <DropdownMenuItem
               key={conn.id}
               className="flex items-center justify-between gap-2 px-2 py-2 cursor-pointer"
@@ -255,8 +296,8 @@ export default function ConnectionManager() {
             >
               <Tooltip>
                 <TooltipTrigger className="flex items-center gap-2 min-w-0">
-                  {activeConnectionId === conn.id && <Check size={14} className="shrink-0 text-primary" />}
-                  {activeConnectionId !== conn.id && <span className="w-[14px]" />}
+                  {activeConn.id === conn.id && <Check size={14} className="shrink-0 text-primary" />}
+                  {activeConn.id !== conn.id && <span className="w-[14px]" />}
                   <span className="truncate font-medium">{getConnectionLabel(conn)}</span>
                   <span className="text-xs text-muted-foreground shrink-0">{conn.role}</span>
                 </TooltipTrigger>

--- a/app/graph/graphInfo.tsx
+++ b/app/graph/graphInfo.tsx
@@ -37,7 +37,7 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
     useEffect(() => { setPropertyKeysSearch(""); }, [PropertyKeys, maxItemsForSearch]);
 
     return (
-        <div data-testid="graphInfoPanel" className={cn("relative h-full w-full p-3 grid gap-3", showMemoryUsage && !isReadOnly ? "grid-rows-[max-content_max-content_max-content_1fr_1fr_1fr]" : "grid-rows-[max-content_max-content_1fr_1fr_1fr]")}>
+        <div data-testid="graphInfoPanel" className={cn("relative h-full w-full p-3 grid gap-3", showMemoryUsage ? "grid-rows-[max-content_max-content_max-content_1fr_1fr_1fr]" : "grid-rows-[max-content_max-content_1fr_1fr_1fr]")}>
             {
                 !customizingLabel ? (
                     <>
@@ -84,7 +84,7 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
                             }
                         </div>
                         {
-                            showMemoryUsage && !isReadOnly &&
+                            showMemoryUsage &&
                             <div className="w-full flex items-center gap-2">
                                     <h2 className="text-xs uppercase tracking-wider text-foreground/60 font-medium">Memory</h2>
                                     {

--- a/app/graph/page.tsx
+++ b/app/graph/page.tsx
@@ -208,7 +208,7 @@ export default function Page() {
             clearInterval(interval);
         };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [fetchCount, fetchInfo, fetchMetaStats, graphName, refreshInterval, runDefaultQuery, setGraphInfo, setIndicator, showMemoryUsage, toast, activeConnectionId]);
+    }, [fetchCount, fetchInfo, fetchMetaStats, graphName, refreshInterval, runDefaultQuery, setGraphInfo, setIndicator, showMemoryUsage, toast]);
 
     useEffect(() => {
         if (graphName) return;

--- a/app/graph/page.tsx
+++ b/app/graph/page.tsx
@@ -176,7 +176,7 @@ export default function Page() {
             fetchMetaStats(graphName),
             fetchInfo("(property key)"),
         ]).then(async ([newDataStats, newPropertyKeys]) => {
-            const memoryUsage = showMemoryUsage && !isReadOnlyRef.current ? await getMemoryUsage(graphName, toast, setIndicator, activeConnectionId) : new Map<string, MemoryValue>();
+            const memoryUsage = showMemoryUsage ? await getMemoryUsage(graphName, toast, setIndicator, activeConnectionId) : new Map<string, MemoryValue>();
             const newLabels = newDataStats?.[0] || [];
             const newRelationships = newDataStats?.[1] || [];
 

--- a/app/graph/page.tsx
+++ b/app/graph/page.tsx
@@ -51,7 +51,7 @@ export default function Page() {
     const { tutorialOpen } = useContext(BrowserSettingsContext);
     const { isQueryLoading, setIsQueryLoading } = useContext(QueryLoadingContext);
     const { setData, canvasRef } = useContext(ForceGraphContext);
-    const { isReadOnly } = useContext(ConnectionContext);
+    const { isReadOnly, activeConnectionId } = useContext(ConnectionContext);
     const isReadOnlyRef = useRef(isReadOnly);
     isReadOnlyRef.current = isReadOnly;
     const {
@@ -176,7 +176,7 @@ export default function Page() {
             fetchMetaStats(graphName),
             fetchInfo("(property key)"),
         ]).then(async ([newDataStats, newPropertyKeys]) => {
-            const memoryUsage = showMemoryUsage && !isReadOnlyRef.current ? await getMemoryUsage(graphName, toast, setIndicator) : new Map<string, MemoryValue>();
+            const memoryUsage = showMemoryUsage && !isReadOnlyRef.current ? await getMemoryUsage(graphName, toast, setIndicator, activeConnectionId) : new Map<string, MemoryValue>();
             const newLabels = newDataStats?.[0] || [];
             const newRelationships = newDataStats?.[1] || [];
 
@@ -207,7 +207,8 @@ export default function Page() {
         return () => {
             clearInterval(interval);
         };
-    }, [fetchCount, fetchInfo, fetchMetaStats, graphName, refreshInterval, runDefaultQuery, setGraphInfo, setIndicator, showMemoryUsage, toast]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [fetchCount, fetchInfo, fetchMetaStats, graphName, refreshInterval, runDefaultQuery, setGraphInfo, setIndicator, showMemoryUsage, toast, activeConnectionId]);
 
     useEffect(() => {
         if (graphName) return;

--- a/app/graph/page.tsx
+++ b/app/graph/page.tsx
@@ -83,6 +83,10 @@ export default function Page() {
     const { toast } = useToast();
 
     const panelRef = useRef<PanelImperativeHandle>(null);
+    // Track the previous graphName to distinguish "graph just changed" re-fires
+    // (where runQuery handles the initial fetch) from other dep changes like
+    // showMemoryUsage becoming true (where we must fetch immediately).
+    const prevGraphNameRef = useRef<string | undefined>(undefined);
 
     const [selectedElements, setSelectedElements] = useState<(Node | Link)[]>([]);
     const [chatOpen, setChatOpen] = useState(false);
@@ -160,7 +164,13 @@ export default function Page() {
     const fetchMetaStats = useCallback((name: string) => getMetaStats(name, toast, setIndicator, isReadOnlyRef.current), [setIndicator, toast]);
 
     useEffect(() => {
-        if (!graphName) return undefined;
+        if (!graphName) {
+            prevGraphNameRef.current = graphName;
+            return undefined;
+        }
+
+        const graphNameJustChanged = prevGraphNameRef.current !== graphName;
+        prevGraphNameRef.current = graphName;
 
         const handleSetInfo = () => Promise.all([
             fetchMetaStats(graphName),
@@ -181,10 +191,14 @@ export default function Page() {
             });
         });
 
-        // When runDefaultQuery is enabled, the graph setup effect will call
-        // runQuery which already fetches info/stats internally — skip the
-        // immediate call here to avoid duplicates.
-        if (!runDefaultQuery) {
+        // When runDefaultQuery is enabled and the graph name just changed, the
+        // graph-setup effect below will call runQuery which already fetches
+        // info/stats (including memory) internally — skip here to avoid
+        // duplicating that initial fetch.
+        // For any other dep change (e.g. showMemoryUsage becoming true after a
+        // connection switch to admin, or refreshInterval changing), always call
+        // immediately so memory appears without waiting for the next interval.
+        if (!runDefaultQuery || !graphNameJustChanged) {
             handleSetInfo();
         }
 

--- a/app/graph/selectGraph.tsx
+++ b/app/graph/selectGraph.tsx
@@ -43,7 +43,7 @@ interface Props {
 export default function SelectGraph({ options, setOptions, selectedValue, setSelectedValue, type, setGraph }: Props) {
 
     const { indicator, setIndicator } = useContext(IndicatorContext);
-    const { isReadOnly } = useContext(ConnectionContext);
+    const { isReadOnly, activeConnectionId } = useContext(ConnectionContext);
     const {
         settings: {
             contentPersistenceSettings: {
@@ -77,11 +77,11 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
     const loadMemory = useCallback((opt: string) =>
         async () => {
             if (isReadOnly) return '<1 MB';
-            const memoryMap = await getMemoryUsage(opt, toast, setIndicator);
+            const memoryMap = await getMemoryUsage(opt, toast, setIndicator, activeConnectionId);
             const memoryValue = memoryMap.get("total_graph_sz_mb") || '<1';
 
             return `${memoryValue} MB`;
-        }, [toast, setIndicator, isReadOnly]);
+        }, [toast, setIndicator, isReadOnly, activeConnectionId]);
 
     const loadNodesCount = useCallback((opt: string) =>
         async () => {

--- a/app/graph/selectGraph.tsx
+++ b/app/graph/selectGraph.tsx
@@ -76,12 +76,11 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
 
     const loadMemory = useCallback((opt: string) =>
         async () => {
-            if (isReadOnly) return '<1 MB';
             const memoryMap = await getMemoryUsage(opt, toast, setIndicator, activeConnectionId);
             const memoryValue = memoryMap.get("total_graph_sz_mb") || '<1';
 
             return `${memoryValue} MB`;
-        }, [toast, setIndicator, isReadOnly, activeConnectionId]);
+        }, [toast, setIndicator, activeConnectionId]);
 
     const loadNodesCount = useCallback((opt: string) =>
         async () => {
@@ -137,7 +136,7 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
 
                 const cells: Row["cells"] = [baseCell];
 
-                if (showMemoryUsage && !isReadOnly) {
+                if (showMemoryUsage) {
                     cells.push({ loadCell: loadMemory(opt), type: "readonly" });
                 }
 
@@ -165,7 +164,7 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
 
             const cells: Row["cells"] = [baseCell];
 
-            if (showMemoryUsage && !isReadOnly) {
+            if (showMemoryUsage) {
                 cells.push({ loadCell: loadMemory(opt), type: "readonly" });
             }
 
@@ -283,7 +282,7 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
                     entityName={type}
                     headers={[
                         "Name",
-                        ...(showMemoryUsage && !isReadOnly ? [{name : "Memory Usage", width: "15%"}] : []),
+                        ...(showMemoryUsage ? [{name : "Memory Usage", width: "15%"}] : []),
                         { name: "Nodes #", width: "15%" },
                         { name: "Edges #", width: "15%" }
                     ]}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -964,6 +964,7 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
 
     // Clear graph / schema data so stale results from the old connection are gone
     setGraph(Graph.empty());
+    setGraphInfo(GraphInfo.empty(toast, setIndicator));
     setGraphName("");
     setGraphNames([]);
     setSchema(Graph.empty());

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,7 +4,7 @@ import { SessionProvider, useSession } from "next-auth/react";
 import { ThemeProvider } from 'next-themes';
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
-import { cn, fetchOptions, formatName, getDefaultQuery, getQueryWithLimit, getSSEGraphResult, Panel, prepareArg, securedFetch, setActiveConnectionIdGlobal, Tab, getMemoryUsage, GraphRef, ConnectionType, ConnectionInfo, UDFEntry, UDFEntryWithCode, getMetaStats, HistoryQuery, GraphData, Label, Relationship, InfoLabel, Query, Data, MemoryValue, SyntaxErrorInfo, parseSyntaxError } from "@/lib/utils";
+import { cn, fetchOptions, formatName, getDefaultQuery, getQueryWithLimit, getSSEGraphResult, Panel, prepareArg, securedFetch, setActiveConnectionIdGlobal, getActiveConnectionIdGlobal, Tab, getMemoryUsage, GraphRef, ConnectionType, ConnectionInfo, UDFEntry, UDFEntryWithCode, getMetaStats, HistoryQuery, GraphData, Label, Relationship, InfoLabel, Query, Data, MemoryValue, SyntaxErrorInfo, parseSyntaxError } from "@/lib/utils";
 import { encryptValue, decryptValue, isCryptoAvailable, isEncrypted } from "@/lib/encryption";
 import { getConnectionItem, setConnectionItem, removeConnectionItem, setConnectionPrefix, clearConnectionPrefix, migrateToScopedStorage } from "@/lib/connection-storage";
 import { usePathname, useRouter } from "next/navigation";
@@ -598,18 +598,22 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
     if (status !== "authenticated") return;
 
     (async () => {
-      const result = await securedFetch("/api/DBVersion", {
-        method: "GET",
-      }, toast, setIndicator);
-
-      if (!result.ok) return;
-
-      const [name, version] = (await result.json()).result || ["", 0];
-
-      setDbVersion(String(version));
-      setShowMemoryUsage(name === "graph" && version >= MEMORY_USAGE_VERSION_THRESHOLD);
+      // Use plain fetch (not securedFetch) so NOPERM from restricted users
+      // (who lack module|list permission) doesn't produce an error toast.
+      // DB version / memory-usage availability is optional admin metadata.
+      try {
+        const connId = getActiveConnectionIdGlobal();
+        const headers = new Headers();
+        if (connId) headers.set("X-Connection-Id", connId);
+        const result = await fetch("/api/DBVersion", { method: "GET", headers });
+        if (!result.ok) return;
+        const [name, version] = (await result.json()).result || ["", 0];
+        setDbVersion(String(version));
+        setShowMemoryUsage(name === "graph" && version >= MEMORY_USAGE_VERSION_THRESHOLD);
+      } catch { /* ignore */ }
     })();
-  }, [status, toast]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
 
   useEffect(() => {
     if (status !== "authenticated") {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -490,7 +490,7 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
         fetchMetaStats(n),
         fetchInfo("(property key)", n),
       ]).then(async ([metaStats, newPropertyKeys]) => {
-        const memoryUsage = showMemoryUsage && !isReadOnlyRef.current ? await getMemoryUsage(n, toast, setIndicator, getActiveConnectionIdGlobal()) : new Map<string, MemoryValue>();
+        const memoryUsage = showMemoryUsage ? await getMemoryUsage(n, toast, setIndicator, getActiveConnectionIdGlobal()) : new Map<string, MemoryValue>();
         const newLabels = metaStats?.[0] || [];
         const newRelationships = metaStats?.[1] || [];
         const gi = await GraphInfo.create(newPropertyKeys, newLabels, newRelationships, memoryUsage, toast, setIndicator);
@@ -895,7 +895,7 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
     return () => {
       if (rafId !== undefined) cancelAnimationFrame(rafId);
     };
-  }, [pathname]);
+  }, [pathname, panelRef.current]);
 
   const checkStatus = useCallback(() => {
     securedFetch("/api/status", {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -702,6 +702,29 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
             setActiveConnectionId(target);
             setActiveConnectionIdGlobal(target);
             await updateSession({ activeConnectionId: target });
+          } else {
+            // No connections in Token DB — this happens for sessions created
+            // before the multi-connection feature was deployed (old flat-format JWT).
+            // Calling updateSession() with no payload still triggers the jwt callback
+            // which migrates the old token to the new connections array format and
+            // persists it in Token DB so subsequent fetches will find it.
+            await updateSession({});
+            // Retry: the jwt migration just ran, fetch connections again so the
+            // ConnectionManager dropdown can populate.
+            const retryResult = await securedFetch("/api/connections", { method: "GET" }, toast, setIndicator);
+            if (retryResult.ok) {
+              const retryJson = await retryResult.json();
+              if (retryJson?.connections?.length > 0) {
+                const retryConns: SessionConnection[] = retryJson.connections;
+                setAdditionalConnections(retryConns);
+                const lastId = localStorage.getItem("lastActiveConnectionId");
+                const target = lastId && retryConns.find(c => c.id === lastId)
+                  ? lastId
+                  : retryConns[0].id;
+                setActiveConnectionId(target);
+                setActiveConnectionIdGlobal(target);
+              }
+            }
           }
         }
         sessionSyncedRef.current = true;

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -601,19 +601,25 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
       // Use plain fetch (not securedFetch) so NOPERM from restricted users
       // (who lack module|list permission) doesn't produce an error toast.
       // DB version / memory-usage availability is optional admin metadata.
+      // Re-runs on connection switch so switching back to admin restores the
+      // memory-usage widget.
       try {
-        const connId = getActiveConnectionIdGlobal();
+        const connId = activeConnectionId ?? getActiveConnectionIdGlobal();
         const headers = new Headers();
         if (connId) headers.set("X-Connection-Id", connId);
         const result = await fetch("/api/DBVersion", { method: "GET", headers });
-        if (!result.ok) return;
+        if (!result.ok) {
+          // Restricted user or version not available — hide memory widget
+          setShowMemoryUsage(false);
+          return;
+        }
         const [name, version] = (await result.json()).result || ["", 0];
         setDbVersion(String(version));
         setShowMemoryUsage(name === "graph" && version >= MEMORY_USAGE_VERSION_THRESHOLD);
       } catch { /* ignore */ }
     })();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status]);
+  }, [status, activeConnectionId]);
 
   useEffect(() => {
     if (status !== "authenticated") {
@@ -837,33 +843,33 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
       }
 
       setModel(localStorage.getItem("model") || "");
-      (async () => {
-        const res = await fetch("/api/udf", {
-          method: "GET",
-        });
-
-        if (!res.ok) {
-          setShowUDF(false);
-          return;
-        };
-
-        const json = await res.json();
-        setUdfList(json.result);
-
-        if (json.result.length > 0) {
-          const result = await securedFetch(`/api/udf/${encodeURIComponent(json.result[0][1])}`, {
-            method: "GET",
-          }, toast, setIndicator);
-
-          if (!result.ok) return;
-
-          const udfData = await result.json();
-
-          setSelectedUdf(prev => prev ?? udfData.result[0]);
-        }
-      })();
     })();
   }, [status, prefixReady, toast]);
+
+  // Re-check UDF availability whenever the active connection changes so
+  // switching back to an admin connection restores the UDF menu.
+  useEffect(() => {
+    if (status !== "authenticated") { setShowUDF(false); return; }
+
+    (async () => {
+      const res = await fetch("/api/udf", { method: "GET" });
+      if (!res.ok) { setShowUDF(false); return; }
+
+      const json = await res.json();
+      setShowUDF(true);
+      setUdfList(json.result);
+
+      if (json.result.length > 0) {
+        const result = await securedFetch(`/api/udf/${encodeURIComponent(json.result[0][1])}`, {
+          method: "GET",
+        }, toast, setIndicator);
+        if (!result.ok) return;
+        const udfData = await result.json();
+        setSelectedUdf(prev => prev ?? udfData.result[0]);
+      }
+    })();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, activeConnectionId]);
 
   const onPanelResize = useCallback((size: PanelSize) => {
     setIsCollapsed(size.asPercentage === 0);

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -595,18 +595,19 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
   }, [graph, graph.Labels.length, graph.Relationships.length, graph.Labels, graph.Relationships]);
 
   useEffect(() => {
-    if (status !== "authenticated") return;
+    // Wait until we have a real connection ID so the server always routes
+    // the request to the correct FalkorDB client rather than falling back
+    // to the most-recently-added Token DB entry (which may be a restricted user).
+    if (status !== "authenticated" || !activeConnectionId) return;
 
     (async () => {
       // Use plain fetch (not securedFetch) so NOPERM from restricted users
       // (who lack module|list permission) doesn't produce an error toast.
-      // DB version / memory-usage availability is optional admin metadata.
       // Re-runs on connection switch so switching back to admin restores the
       // memory-usage widget.
       try {
-        const connId = activeConnectionId ?? getActiveConnectionIdGlobal();
         const headers = new Headers();
-        if (connId) headers.set("X-Connection-Id", connId);
+        headers.set("X-Connection-Id", activeConnectionId);
         const result = await fetch("/api/DBVersion", { method: "GET", headers });
         if (!result.ok) {
           // Restricted user or version not available — hide memory widget
@@ -849,10 +850,17 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
   // Re-check UDF availability whenever the active connection changes so
   // switching back to an admin connection restores the UDF menu.
   useEffect(() => {
-    if (status !== "authenticated") { setShowUDF(false); return; }
+    if (status === "unauthenticated") { setShowUDF(false); return; }
+    // Wait until we have a real connection ID so the server always routes
+    // the request to the correct FalkorDB client rather than falling back
+    // to the most-recently-added Token DB entry (which may be a restricted user).
+    if (status !== "authenticated" || !activeConnectionId) return;
 
     (async () => {
-      const res = await fetch("/api/udf", { method: "GET" });
+      // Pass the connection ID explicitly so the server uses the right client.
+      const headers = new Headers();
+      headers.set("X-Connection-Id", activeConnectionId);
+      const res = await fetch("/api/udf", { method: "GET", headers });
       if (!res.ok) { setShowUDF(false); return; }
 
       const json = await res.json();
@@ -949,7 +957,7 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
     const prev = prevActiveConnectionIdRef.current;
     prevActiveConnectionIdRef.current = activeConnectionId;
 
-    // Skip the very first selection (initial mount / login)
+    // Skip the very first selection (initial mount / login) and null resets
     if (prev === null || activeConnectionId === null) return;
     // Skip if unchanged
     if (prev === activeConnectionId) return;

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -601,13 +601,14 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
   useEffect(() => { setActiveConnectionIdGlobal(activeConnectionId); });
 
   useEffect(() => {
-    if (status !== "authenticated" || !activeConnectionId) return;
-
+    if (status !== "authenticated") return;
+    // Use plain fetch with no X-Connection-Id — the server resolves the
+    // connection via session.activeConnectionId from the JWT, which is always
+    // correct (set by every connection switch). This avoids the timing race
+    // where activeConnectionId is null on page load and the check never fires.
     (async () => {
       try {
-        const headers = new Headers();
-        headers.set("X-Connection-Id", activeConnectionId);
-        const result = await fetch("/api/DBVersion", { method: "GET", headers });
+        const result = await fetch("/api/DBVersion", { method: "GET" });
         if (!result.ok) {
           setShowMemoryUsage(false);
           return;
@@ -619,7 +620,6 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
     })();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status, activeConnectionId]);
-
   useEffect(() => {
     if (status !== "authenticated") {
       setConnectionType("Standalone");
@@ -849,16 +849,10 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
   // switching back to an admin connection restores the UDF menu.
   useEffect(() => {
     if (status === "unauthenticated") { setShowUDF(false); return; }
-    // Wait until we have a real connection ID so the server always routes
-    // the request to the correct FalkorDB client rather than falling back
-    // to the most-recently-added Token DB entry (which may be a restricted user).
-    if (status !== "authenticated" || !activeConnectionId) return;
-
+    if (status !== "authenticated") return;
+    // Use plain fetch with no X-Connection-Id — server resolves via JWT.
     (async () => {
-      // Pass the connection ID explicitly so the server uses the right client.
-      const headers = new Headers();
-      headers.set("X-Connection-Id", activeConnectionId);
-      const res = await fetch("/api/udf", { method: "GET", headers });
+      const res = await fetch("/api/udf", { method: "GET" });
       if (!res.ok) { setShowUDF(false); return; }
 
       const json = await res.json();

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -601,28 +601,27 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
   useEffect(() => { setActiveConnectionIdGlobal(activeConnectionId); });
 
   useEffect(() => {
-    // Wait until we have a real connection ID so the server always routes
-    // the request to the correct FalkorDB client rather than falling back
-    // to the most-recently-added Token DB entry (which may be a restricted user).
+    // eslint-disable-next-line no-console
+    console.debug(`[DBVersion] fired: status=${status} activeConnectionId=${activeConnectionId}`);
     if (status !== "authenticated" || !activeConnectionId) return;
 
     (async () => {
-      // Use plain fetch (not securedFetch) so NOPERM from restricted users
-      // (who lack module|list permission) doesn't produce an error toast.
-      // Re-runs on connection switch so switching back to admin restores the
-      // memory-usage widget.
       try {
         const headers = new Headers();
         headers.set("X-Connection-Id", activeConnectionId);
         const result = await fetch("/api/DBVersion", { method: "GET", headers });
         if (!result.ok) {
-          // Restricted user or version not available — hide memory widget
+          // eslint-disable-next-line no-console
+          console.debug(`[DBVersion] returned ${result.status} -> showMemoryUsage=false`);
           setShowMemoryUsage(false);
           return;
         }
         const [name, version] = (await result.json()).result || ["", 0];
+        const show = name === "graph" && version >= MEMORY_USAGE_VERSION_THRESHOLD;
+        // eslint-disable-next-line no-console
+        console.debug(`[DBVersion] name=${name} version=${version} -> showMemoryUsage=${show}`);
         setDbVersion(String(version));
-        setShowMemoryUsage(name === "graph" && version >= MEMORY_USAGE_VERSION_THRESHOLD);
+        setShowMemoryUsage(show);
       } catch { /* ignore */ }
     })();
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -701,7 +701,16 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
               : conns[0].id;
             setActiveConnectionId(target);
             setActiveConnectionIdGlobal(target);
-            await updateSession({ activeConnectionId: target });
+            // Always sync the full connections list into the JWT together with
+            // activeConnectionId so the session callback always finds activeConn.
+            // Without this, a legacy-fallback connection (legacyConnId) ends up
+            // as activeConnectionId but is absent from token.connections, causing
+            // session.user.role to default to "Read-Only" and all write queries
+            // to be silently rejected by FalkorDB (roQuery on empty key).
+            await updateSession({
+              activeConnectionId: target,
+              connections: conns,
+            });
           } else {
             // No connections in Token DB — this happens for sessions created
             // before the multi-connection feature was deployed (old flat-format JWT).
@@ -723,6 +732,7 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
                   : retryConns[0].id;
                 setActiveConnectionId(target);
                 setActiveConnectionIdGlobal(target);
+                await updateSession({ activeConnectionId: target, connections: retryConns });
               }
             }
           }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -712,27 +712,38 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
               connections: conns,
             });
           } else {
-            // No connections in Token DB — this happens for sessions created
-            // before the multi-connection feature was deployed (old flat-format JWT).
-            // Calling updateSession() with no payload still triggers the jwt callback
-            // which migrates the old token to the new connections array format and
-            // persists it in Token DB so subsequent fetches will find it.
-            await updateSession({});
-            // Retry: the jwt migration just ran, fetch connections again so the
-            // ConnectionManager dropdown can populate.
-            const retryResult = await securedFetch("/api/connections", { method: "GET" }, toast, setIndicator);
-            if (retryResult.ok) {
-              const retryJson = await retryResult.json();
-              if (retryJson?.connections?.length > 0) {
-                const retryConns: SessionConnection[] = retryJson.connections;
-                setAdditionalConnections(retryConns);
-                const lastId = localStorage.getItem("lastActiveConnectionId");
-                const target = lastId && retryConns.find(c => c.id === lastId)
-                  ? lastId
-                  : retryConns[0].id;
-                setActiveConnectionId(target);
-                setActiveConnectionIdGlobal(target);
-                await updateSession({ activeConnectionId: target, connections: retryConns });
+            // Token DB returned no connections — the session is out of sync.
+            // This happens after a server restart (FileTokenStorage wiped),
+            // a deploy that changed the storage backend, or any time the
+            // connection entry was never written (old pre-feature sessions).
+            //
+            // Fix: call the migration endpoint which:
+            //   1. Deletes stale Token DB entries for this user
+            //   2. Reconnects to FalkorDB using session.user credentials
+            //   3. Creates a fresh entry in Token DB
+            //   4. Returns the new connection
+            // Then sync the JWT and local state with the result.
+            //
+            // Also clean up stale localStorage keys so we don't restore
+            // a lastActiveConnectionId that no longer exists.
+            localStorage.removeItem("lastActiveConnectionId");
+
+            const migrateResult = await securedFetch("/api/auth/migrate-session", {
+              method: "POST",
+            }, toast, setIndicator);
+
+            if (migrateResult.ok) {
+              const migrateJson = await migrateResult.json();
+              if (migrateJson?.connection) {
+                const migratedConn: SessionConnection = migrateJson.connection;
+                const migratedConns = [migratedConn];
+                setAdditionalConnections(migratedConns);
+                setActiveConnectionId(migratedConn.id);
+                setActiveConnectionIdGlobal(migratedConn.id);
+                await updateSession({
+                  activeConnectionId: migratedConn.id,
+                  connections: migratedConns,
+                });
               }
             }
           }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -601,8 +601,6 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
   useEffect(() => { setActiveConnectionIdGlobal(activeConnectionId); });
 
   useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.debug(`[DBVersion] fired: status=${status} activeConnectionId=${activeConnectionId}`);
     if (status !== "authenticated" || !activeConnectionId) return;
 
     (async () => {
@@ -611,17 +609,12 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
         headers.set("X-Connection-Id", activeConnectionId);
         const result = await fetch("/api/DBVersion", { method: "GET", headers });
         if (!result.ok) {
-          // eslint-disable-next-line no-console
-          console.debug(`[DBVersion] returned ${result.status} -> showMemoryUsage=false`);
           setShowMemoryUsage(false);
           return;
         }
         const [name, version] = (await result.json()).result || ["", 0];
-        const show = name === "graph" && version >= MEMORY_USAGE_VERSION_THRESHOLD;
-        // eslint-disable-next-line no-console
-        console.debug(`[DBVersion] name=${name} version=${version} -> showMemoryUsage=${show}`);
         setDbVersion(String(version));
-        setShowMemoryUsage(show);
+        setShowMemoryUsage(name === "graph" && version >= MEMORY_USAGE_VERSION_THRESHOLD);
       } catch { /* ignore */ }
     })();
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -490,7 +490,7 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
         fetchMetaStats(n),
         fetchInfo("(property key)", n),
       ]).then(async ([metaStats, newPropertyKeys]) => {
-        const memoryUsage = showMemoryUsage && !isReadOnlyRef.current ? await getMemoryUsage(n, toast, setIndicator) : new Map<string, MemoryValue>();
+        const memoryUsage = showMemoryUsage && !isReadOnlyRef.current ? await getMemoryUsage(n, toast, setIndicator, getActiveConnectionIdGlobal()) : new Map<string, MemoryValue>();
         const newLabels = metaStats?.[0] || [];
         const newRelationships = metaStats?.[1] || [];
         const gi = await GraphInfo.create(newPropertyKeys, newLabels, newRelationships, memoryUsage, toast, setIndicator);
@@ -593,6 +593,12 @@ function ProvidersWithSession({ children }: { children: React.ReactNode }) {
     setRelationships([...graph.Relationships]);
     setLabels([...graph.Labels]);
   }, [graph, graph.Labels.length, graph.Relationships.length, graph.Labels, graph.Relationships]);
+
+  // Keep the module-level global in sync with React state on every render.
+  // This is intentionally dependency-free so it runs after every render,
+  // restoring _activeConnectionId even when Next.js HMR resets the module.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { setActiveConnectionIdGlobal(activeConnectionId); });
 
   useEffect(() => {
     // Wait until we have a real connection ID so the server always routes

--- a/app/settings/Configurations.tsx
+++ b/app/settings/Configurations.tsx
@@ -202,13 +202,13 @@ export default function Configurations() {
         const connHeaders: Record<string, string> = {};
         if (activeConnectionId) connHeaders['X-Connection-Id'] = activeConnectionId;
         // eslint-disable-next-line no-console
-        console.debug('[configs] fetching connId=', activeConnectionId);
+        console.log('[configs] fetching connId=', activeConnectionId);
         const result = await securedFetch("/api/graph/config", {
             method: "GET",
             headers: connHeaders,
         }, toast, setIndicator);
         // eslint-disable-next-line no-console
-        console.debug('[configs] response ok=', result.ok, 'status=', result.status);
+        console.log('[configs] response ok=', result.ok, 'status=', result.status);
         if (!result.ok) return;
 
         const { configs: configurations } = await result.json();
@@ -241,16 +241,14 @@ export default function Configurations() {
         });
 
         // eslint-disable-next-line no-console
-        console.debug('[configs] setting', newConfigs.length, 'rows');
+        console.log('[configs] setting', newConfigs.length, 'rows');
         setConfigs(newConfigs);
     };
 
     useEffect(() => {
-        // Wait for a real connection ID so the request uses the correct
-        // FalkorDB client and doesn't fall back to a restricted Token DB entry.
+        // eslint-disable-next-line no-console
+        console.log('[configs effect] activeConnectionId=', activeConnectionId);
         if (!activeConnectionId) return;
-        // Explicitly sync the module-level global so securedFetch sends
-        // X-Connection-Id correctly even after Next.js HMR module resets.
         setActiveConnectionIdGlobal(activeConnectionId);
         fetchConfigs();
     }, [activeConnectionId]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/app/settings/Configurations.tsx
+++ b/app/settings/Configurations.tsx
@@ -10,7 +10,7 @@ import { prepareArg, securedFetch, Row, DataCell } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import TableComponent from "../components/TableComponent";
 import ToastButton from "../components/ToastButton";
-import { IndicatorContext } from "../components/provider";
+import { IndicatorContext, ConnectionContext } from "../components/provider";
 
 type Config = {
     name: string,
@@ -129,6 +129,7 @@ export default function Configurations() {
     const [configs, setConfigs] = useState<Row[]>([]);
     const { toast } = useToast();
     const { setIndicator } = useContext(IndicatorContext);
+    const { activeConnectionId } = useContext(ConnectionContext);
 
     const handleSetConfig = async (name: string, value: string, isUndo: boolean) => {
         if (!value) {
@@ -235,8 +236,11 @@ export default function Configurations() {
     };
 
     useEffect(() => {
+        // Wait for a real connection ID so the request uses the correct
+        // FalkorDB client and doesn't fall back to a restricted Token DB entry.
+        if (!activeConnectionId) return;
         fetchConfigs();
-    }, []);
+    }, [activeConnectionId]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
         <div className="grow basis-0 overflow-hidden">

--- a/app/settings/Configurations.tsx
+++ b/app/settings/Configurations.tsx
@@ -6,7 +6,7 @@
 "use client";
 
 import { useEffect, useState, useContext } from "react";
-import { prepareArg, securedFetch, Row, DataCell } from "@/lib/utils";
+import { prepareArg, securedFetch, setActiveConnectionIdGlobal, Row, DataCell } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import TableComponent from "../components/TableComponent";
 import ToastButton from "../components/ToastButton";
@@ -239,6 +239,9 @@ export default function Configurations() {
         // Wait for a real connection ID so the request uses the correct
         // FalkorDB client and doesn't fall back to a restricted Token DB entry.
         if (!activeConnectionId) return;
+        // Explicitly sync the module-level global so securedFetch sends
+        // X-Connection-Id correctly even after Next.js HMR module resets.
+        setActiveConnectionIdGlobal(activeConnectionId);
         fetchConfigs();
     }, [activeConnectionId]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/app/settings/Configurations.tsx
+++ b/app/settings/Configurations.tsx
@@ -129,7 +129,7 @@ export default function Configurations() {
     const [configs, setConfigs] = useState<Row[]>([]);
     const { toast } = useToast();
     const { setIndicator } = useContext(IndicatorContext);
-    const { activeConnectionId } = useContext(ConnectionContext);
+    const { activeConnectionId, additionalConnections } = useContext(ConnectionContext);
 
     const handleSetConfig = async (name: string, value: string, isUndo: boolean) => {
         if (!value) {
@@ -247,11 +247,11 @@ export default function Configurations() {
 
     useEffect(() => {
         // eslint-disable-next-line no-console
-        console.log('[configs effect] activeConnectionId=', activeConnectionId);
+        console.log('[configs effect] activeConnectionId=', activeConnectionId, 'conns=', additionalConnections.length);
         if (!activeConnectionId) return;
         setActiveConnectionIdGlobal(activeConnectionId);
         fetchConfigs();
-    }, [activeConnectionId]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [activeConnectionId, additionalConnections]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
         <div className="grow basis-0 overflow-hidden">

--- a/app/settings/Configurations.tsx
+++ b/app/settings/Configurations.tsx
@@ -6,7 +6,7 @@
 "use client";
 
 import { useEffect, useState, useContext } from "react";
-import { prepareArg, securedFetch, setActiveConnectionIdGlobal, Row, DataCell } from "@/lib/utils";
+import { prepareArg, securedFetch, Row, DataCell } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import TableComponent from "../components/TableComponent";
 import ToastButton from "../components/ToastButton";
@@ -129,7 +129,7 @@ export default function Configurations() {
     const [configs, setConfigs] = useState<Row[]>([]);
     const { toast } = useToast();
     const { setIndicator } = useContext(IndicatorContext);
-    const { activeConnectionId, additionalConnections } = useContext(ConnectionContext);
+    const { activeConnectionId } = useContext(ConnectionContext);
 
     const handleSetConfig = async (name: string, value: string, isUndo: boolean) => {
         if (!value) {
@@ -197,15 +197,18 @@ export default function Configurations() {
     };
 
     const fetchConfigs = async () => {
-        // Pass X-Connection-Id explicitly so the correct client is used
-        // regardless of the module-level global state (e.g. after HMR).
-        const connHeaders: Record<string, string> = {};
-        if (activeConnectionId) connHeaders['X-Connection-Id'] = activeConnectionId;
-        const result = await securedFetch("/api/graph/config", {
-            method: "GET",
-            headers: connHeaders,
-        }, toast, setIndicator);
-        if (!result.ok) return;
+        // Use plain fetch with no X-Connection-Id header.
+        // The server uses session.activeConnectionId from the JWT as the
+        // authoritative connection (set by every handleSelect call), so
+        // this is always correct regardless of client-side global state.
+        const result = await fetch("/api/graph/config", { method: "GET" });
+        if (!result.ok) {
+            const body = await result.text().catch(() => "");
+            let message = "Failed to load DB configurations";
+            try { message = JSON.parse(body).message || message; } catch { /* ignore */ }
+            toast({ title: "Error", description: message, variant: "destructive" });
+            return;
+        }
 
         const { configs: configurations } = await result.json();
 
@@ -240,10 +243,12 @@ export default function Configurations() {
     };
 
     useEffect(() => {
-        if (!activeConnectionId) return;
-        setActiveConnectionIdGlobal(activeConnectionId);
+        // Fire on mount and whenever the active connection changes.
+        // No guard needed: the server always resolves the correct connection
+        // via session.activeConnectionId from the JWT.
         fetchConfigs();
-    }, [activeConnectionId, additionalConnections]); // eslint-disable-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [activeConnectionId]);
 
     return (
         <div className="grow basis-0 overflow-hidden">

--- a/app/settings/Configurations.tsx
+++ b/app/settings/Configurations.tsx
@@ -201,14 +201,10 @@ export default function Configurations() {
         // regardless of the module-level global state (e.g. after HMR).
         const connHeaders: Record<string, string> = {};
         if (activeConnectionId) connHeaders['X-Connection-Id'] = activeConnectionId;
-        // eslint-disable-next-line no-console
-        console.log('[configs] fetching connId=', activeConnectionId);
         const result = await securedFetch("/api/graph/config", {
             method: "GET",
             headers: connHeaders,
         }, toast, setIndicator);
-        // eslint-disable-next-line no-console
-        console.log('[configs] response ok=', result.ok, 'status=', result.status);
         if (!result.ok) return;
 
         const { configs: configurations } = await result.json();
@@ -240,14 +236,10 @@ export default function Configurations() {
             };
         });
 
-        // eslint-disable-next-line no-console
-        console.log('[configs] setting', newConfigs.length, 'rows');
         setConfigs(newConfigs);
     };
 
     useEffect(() => {
-        // eslint-disable-next-line no-console
-        console.log('[configs effect] activeConnectionId=', activeConnectionId, 'conns=', additionalConnections.length);
         if (!activeConnectionId) return;
         setActiveConnectionIdGlobal(activeConnectionId);
         fetchConfigs();

--- a/app/settings/Configurations.tsx
+++ b/app/settings/Configurations.tsx
@@ -197,8 +197,13 @@ export default function Configurations() {
     };
 
     const fetchConfigs = async () => {
+        // Pass X-Connection-Id explicitly so the correct client is used
+        // regardless of the module-level global state (e.g. after HMR).
+        const connHeaders: Record<string, string> = {};
+        if (activeConnectionId) connHeaders['X-Connection-Id'] = activeConnectionId;
         const result = await securedFetch("/api/graph/config", {
-            method: "GET"
+            method: "GET",
+            headers: connHeaders,
         }, toast, setIndicator);
 
         if (!result.ok) return;

--- a/app/settings/Configurations.tsx
+++ b/app/settings/Configurations.tsx
@@ -24,7 +24,8 @@ const disableRunTimeConfigs = new Set([
     "OMP_THREAD_COUNT",
     "NODE_CREATION_BUFFER",
     "BOLT_PORT",
-    "IMPORT_FOLDER"
+    "IMPORT_FOLDER",
+    "TEMP_FOLDER"
 ]);
 
 const Configs: Map<string, Config> = new Map([
@@ -121,6 +122,21 @@ const Configs: Map<string, Config> = new Map([
     ["ASYNC_DELETE", {
         name: "ASYNC_DELETE",
         description: "Controls how graphs are discarded, when set to `yes` graphs are freed on a dedicated thread leaving the server's main thread free, otherwise graphs are freed on the server's main thread.",
+        value: ""
+    }],
+    ["TEMP_FOLDER", {
+        name: "TEMP_FOLDER",
+        description: "Path to the folder FalkorDB uses for temporary files during operations such as graph imports and bulk loading. This is a load-time-only parameter and cannot be changed at runtime.",
+        value: ""
+    }],
+    ["JS_HEAP_SIZE", {
+        name: "JS_HEAP_SIZE",
+        description: "Maximum heap memory (in bytes) available to the JavaScript engine (V8) used for executing User-Defined Functions (UDFs). Increasing this value allows UDFs to process larger data sets, but reduces overall memory available to other processes.",
+        value: ""
+    }],
+    ["JS_STACK_SIZE", {
+        name: "JS_STACK_SIZE",
+        description: "Maximum stack size (in bytes) for the JavaScript engine used for executing User-Defined Functions (UDFs). This controls the maximum call stack depth available to JavaScript-based UDFs.",
         value: ""
     }]
 ]);

--- a/app/settings/Configurations.tsx
+++ b/app/settings/Configurations.tsx
@@ -201,11 +201,14 @@ export default function Configurations() {
         // regardless of the module-level global state (e.g. after HMR).
         const connHeaders: Record<string, string> = {};
         if (activeConnectionId) connHeaders['X-Connection-Id'] = activeConnectionId;
+        // eslint-disable-next-line no-console
+        console.debug('[configs] fetching connId=', activeConnectionId);
         const result = await securedFetch("/api/graph/config", {
             method: "GET",
             headers: connHeaders,
         }, toast, setIndicator);
-
+        // eslint-disable-next-line no-console
+        console.debug('[configs] response ok=', result.ok, 'status=', result.status);
         if (!result.ok) return;
 
         const { configs: configurations } = await result.json();
@@ -237,6 +240,8 @@ export default function Configurations() {
             };
         });
 
+        // eslint-disable-next-line no-console
+        console.debug('[configs] setting', newConfigs.length, 'rows');
         setConfigs(newConfigs);
     };
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -44,14 +44,26 @@ export default function Settings() {
         };
     }, [navigateBack]);
 
+    // Reset to Browser whenever the current tab requires admin access but the
+    // active connection is not admin (e.g. user switches to a read/write connection).
+    const isAdmin = session?.user.role === "Admin" && indicator === "online";
+    const adminOnlyTabs: Tab[] = ["Users", "Configurations"];
+    useEffect(() => {
+        if (!isAdmin && adminOnlyTabs.includes(current)) {
+            setCurrent("Browser");
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isAdmin, current]);
+
     useEffect(() => {
         const prev = prevActiveConnectionIdRef.current;
         prevActiveConnectionIdRef.current = activeConnectionId;
         // Only reset when the user explicitly switches connections (non-null → different non-null).
         // Skip the initial null → value transition that happens on first connection load.
-        if (prev != null && activeConnectionId != null && prev !== activeConnectionId && current === "Users") {
+        if (prev != null && activeConnectionId != null && prev !== activeConnectionId && adminOnlyTabs.includes(current as Tab)) {
             setCurrent("Browser");
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeConnectionId, current]);
     const handleSetCurrent = useCallback((tab: Tab) => {
         if (current === "Browser" && hasChanges) {
@@ -68,6 +80,11 @@ export default function Settings() {
     }, [current, hasChanges, resetSettings, saveSettings, toast]);
 
     const getCurrentTab = () => {
+        // Guard: render admin-only tabs only when user has admin access.
+        // This prevents stale renders if the tab state hasn't been reset yet.
+        if (!isAdmin && adminOnlyTabs.includes(current as Tab)) {
+            return <BrowserSettings />;
+        }
         switch (current) {
             case 'Users':
                 return <Users />;

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,7 +1,7 @@
 
 'use client';
 
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
@@ -26,6 +26,7 @@ export default function Settings() {
     const router = useRouter();
 
     const [current, setCurrent] = useState<Tab>('Browser');
+    const prevActiveConnectionIdRef = useRef<string | null | undefined>(undefined);
 
     const navigateBack = useCallback((e: KeyboardEvent) => {
         if (e.key === "Escape" && current !== "Browser") {
@@ -44,7 +45,11 @@ export default function Settings() {
     }, [navigateBack]);
 
     useEffect(() => {
-        if (current === "Users" ) {
+        const prev = prevActiveConnectionIdRef.current;
+        prevActiveConnectionIdRef.current = activeConnectionId;
+        // Only reset when the user explicitly switches connections (non-null → different non-null).
+        // Skip the initial null → value transition that happens on first connection load.
+        if (prev != null && activeConnectionId != null && prev !== activeConnectionId && current === "Users") {
             setCurrent("Browser");
         }
     }, [activeConnectionId, current]);

--- a/app/settings/users/Users.tsx
+++ b/app/settings/users/Users.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect, useState, useContext, useCallback } from "react";
 import { CreateUser, User } from "@/app/api/user/model";
-import { prepareArg, securedFetch, setActiveConnectionIdGlobal, Row, ToastFn } from "@/lib/utils";
+import { prepareArg, securedFetch, Row, ToastFn } from "@/lib/utils";
 import TableComponent from "@/app/components/TableComponent";
 import { useToast } from "@/components/ui/use-toast";
 import { IndicatorContext, ConnectionContext } from "@/app/components/provider";
@@ -28,38 +28,28 @@ export default function Users() {
     const { activeConnectionId } = useContext(ConnectionContext);
 
     useEffect(() => {
-        if (!activeConnectionId) return;
-        setActiveConnectionIdGlobal(activeConnectionId);
-
         (async () => {
-            // Pass X-Connection-Id explicitly so the correct client is used
-            // regardless of the module-level global state (e.g. after HMR).
-            const result = await securedFetch("api/user", {
-                method: 'GET',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Connection-Id': activeConnectionId,
-                }
-            }, toast, setIndicator);
-
-            if (result.ok) {
-                const data = await result.json();
-                setUsers(data.result.map((user: User) => ({ ...user, selected: false })));
-                setRows(data.result.map(({ username, role, keys }: { username: string, role: string, keys: string[] }): Row => ({
-                    name: username,
-                    cells: [{
-                        value: username,
-                        type: "readonly"
-                    }, {
-                        value: role,
-                        type: "readonly",
-                    }, {
-                        value: keys.join(", ") || "*",
-                        type: "readonly"
-                    }],
-                    checked: false,
-                })));
-            }
+            // Use plain fetch with no X-Connection-Id header.
+            // The server resolves the correct connection via session.activeConnectionId
+            // from the JWT (updated by every handleSelect call).
+            const result = await fetch("/api/user", { method: 'GET' });
+            if (!result.ok) return;
+            const data = await result.json();
+            setUsers(data.result.map((user: User) => ({ ...user, selected: false })));
+            setRows(data.result.map(({ username, role, keys }: { username: string, role: string, keys: string[] }): Row => ({
+                name: username,
+                cells: [{
+                    value: username,
+                    type: "readonly"
+                }, {
+                    value: role,
+                    type: "readonly",
+                }, {
+                    value: keys.join(", ") || "*",
+                    type: "readonly"
+                }],
+                checked: false,
+            })));
         })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeConnectionId]);

--- a/app/settings/users/Users.tsx
+++ b/app/settings/users/Users.tsx
@@ -28,19 +28,17 @@ export default function Users() {
     const { activeConnectionId } = useContext(ConnectionContext);
 
     useEffect(() => {
-        // Wait for a real connection ID so the request is routed to the
-        // correct FalkorDB client (admin), not a Token DB fallback that
-        // might lack ACL LIST permission.
         if (!activeConnectionId) return;
-        // Explicitly sync the module-level global so securedFetch sends
-        // X-Connection-Id correctly even after Next.js HMR module resets.
         setActiveConnectionIdGlobal(activeConnectionId);
 
         (async () => {
+            // Pass X-Connection-Id explicitly so the correct client is used
+            // regardless of the module-level global state (e.g. after HMR).
             const result = await securedFetch("api/user", {
                 method: 'GET',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-Connection-Id': activeConnectionId,
                 }
             }, toast, setIndicator);
 
@@ -63,7 +61,8 @@ export default function Users() {
                 })));
             }
         })();
-    }, [toast, setIndicator, activeConnectionId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [activeConnectionId]);
 
     const handleSaveUsers = useCallback(async () => {
         // Use a no-op toast so securedFetch does NOT show a generic red error

--- a/app/settings/users/Users.tsx
+++ b/app/settings/users/Users.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect, useState, useContext, useCallback } from "react";
 import { CreateUser, User } from "@/app/api/user/model";
-import { prepareArg, securedFetch, Row, ToastFn } from "@/lib/utils";
+import { prepareArg, securedFetch, setActiveConnectionIdGlobal, Row, ToastFn } from "@/lib/utils";
 import TableComponent from "@/app/components/TableComponent";
 import { useToast } from "@/components/ui/use-toast";
 import { IndicatorContext, ConnectionContext } from "@/app/components/provider";
@@ -32,6 +32,9 @@ export default function Users() {
         // correct FalkorDB client (admin), not a Token DB fallback that
         // might lack ACL LIST permission.
         if (!activeConnectionId) return;
+        // Explicitly sync the module-level global so securedFetch sends
+        // X-Connection-Id correctly even after Next.js HMR module resets.
+        setActiveConnectionIdGlobal(activeConnectionId);
 
         (async () => {
             const result = await securedFetch("api/user", {

--- a/app/settings/users/Users.tsx
+++ b/app/settings/users/Users.tsx
@@ -4,10 +4,10 @@
 
 import { useEffect, useState, useContext, useCallback } from "react";
 import { CreateUser, User } from "@/app/api/user/model";
-import { prepareArg, securedFetch, Row } from "@/lib/utils";
+import { prepareArg, securedFetch, Row, ToastFn } from "@/lib/utils";
 import TableComponent from "@/app/components/TableComponent";
 import { useToast } from "@/components/ui/use-toast";
-import { IndicatorContext } from "@/app/components/provider";
+import { IndicatorContext, ConnectionContext } from "@/app/components/provider";
 import DeleteUser from "./DeleteUser";
 import AddUser from "./AddUser";
 import EditUser from "./EditUser";
@@ -25,8 +25,14 @@ export default function Users() {
     const [rows, setRows] = useState<Row[]>([]);
     const { toast } = useToast();
     const { setIndicator } = useContext(IndicatorContext);
+    const { activeConnectionId } = useContext(ConnectionContext);
 
     useEffect(() => {
+        // Wait for a real connection ID so the request is routed to the
+        // correct FalkorDB client (admin), not a Token DB fallback that
+        // might lack ACL LIST permission.
+        if (!activeConnectionId) return;
+
         (async () => {
             const result = await securedFetch("api/user", {
                 method: 'GET',
@@ -54,17 +60,21 @@ export default function Users() {
                 })));
             }
         })();
-    }, [toast, setIndicator]);
+    }, [toast, setIndicator, activeConnectionId]);
 
     const handleSaveUsers = useCallback(async () => {
+        // Use a no-op toast so securedFetch does NOT show a generic red error
+        // when aclSave() fails (e.g. FalkorDB not configured with an ACL file).
+        // We show a single, informative warning toast below instead.
+        const silent: ToastFn = () => {};
         const response = await securedFetch('/api/user/save', {
             method: 'POST',
-        }, toast, setIndicator);
+        }, silent, setIndicator);
 
         if (!response.ok) {
             toast({
-                title: "Error",
-                description: <p>Failed to save users to disk <a href="https://docs.falkordb.com/operations/durability/acl-persistence.html" target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-1">Learn More</a></p>,
+                title: "Users not persisted",
+                description: <p>Users are active in memory but could not be saved to disk. <a href="https://docs.falkordb.com/operations/durability/acl-persistence.html" target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-1">Learn More</a></p>,
                 variant: "warning",
             });
         }

--- a/lib/token-storage/FalkorDBTokenStorage.ts
+++ b/lib/token-storage/FalkorDBTokenStorage.ts
@@ -98,7 +98,7 @@ class FalkorDBTokenStorage implements ITokenStorage {
 
   async fetchTokenById(tokenId: string): Promise<TokenData | null> {
     const query = `
-      MATCH (t:Token {token_id: '${this.escapeString(tokenId)}'})-[:BELONGS_TO]->(u:User)
+      MATCH (t:Token {token_id: '${this.escapeString(tokenId)}'})
       RETURN t.token_hash as token_hash,
              t.token_id as token_id,
              t.user_id as user_id,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -678,32 +678,26 @@ const processEntries = (arr: MemoryValueType): Map<string, MemoryValue> => {
 export const getMemoryUsage = async (
   name: string,
   toast: ToastFn,
-  setIndicator: (indicator: "online" | "offline") => void
+  setIndicator: (indicator: "online" | "offline") => void,
+  // Pass activeConnectionId explicitly from React context/closure.
+  // This avoids relying on the module-level global _activeConnectionId
+  // which can be reset to null by Next.js HMR between renders.
+  connectionId?: string | null
 ): Promise<Map<string, MemoryValue>> => {
   // Use plain fetch (not securedFetch) so NOPERM / version-too-low 400 errors
   // from restricted users don't produce error toasts — memory usage is an
   // optional admin-only feature and missing it is not an error worth surfacing.
   try {
+    const effectiveConnId = connectionId !== undefined ? connectionId : _activeConnectionId;
     const headers = new Headers();
-    if (_activeConnectionId) {
-      headers.set("X-Connection-Id", _activeConnectionId);
+    if (effectiveConnId) {
+      headers.set("X-Connection-Id", effectiveConnId);
     }
-    // eslint-disable-next-line no-console
-    console.debug(`[memory] fetching for graph="${name}" connId=${_activeConnectionId ?? "(none)"}`);
     const result = await fetch(`/api/graph/${prepareArg(name)}/memory`, { headers });
-    if (!result.ok) {
-      // eslint-disable-next-line no-console
-      console.debug(`[memory] endpoint returned ${result.status} for graph="${name}"`);
-      return new Map();
-    }
+    if (!result.ok) return new Map();
     const json = await result.json();
-    const map = processEntries(json.result);
-    // eslint-disable-next-line no-console
-    console.debug(`[memory] result for graph="${name}": total_graph_sz_mb=${map.get("total_graph_sz_mb")}`);
-    return map;
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.debug(`[memory] fetch threw for graph="${name}":`, err);
+    return processEntries(json.result);
+  } catch {
     return new Map();
   }
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -544,13 +544,16 @@ export async function securedFetch(
   toast: ToastFn,
   setIndicator: (indicator: "online" | "offline") => void
 ): Promise<Response> {
-  // Inject X-Connection-Id header when an additional connection is active
+  // Inject X-Connection-Id header when an additional connection is active.
+  // Callers that already set the header explicitly take priority — the global
+  // is only used as a fallback so stale module state can't override a
+  // deliberately-chosen connection ID.
   const effectiveInit = { ...init };
-  if (_activeConnectionId) {
-    const headers = new Headers(effectiveInit.headers);
-    headers.set("X-Connection-Id", _activeConnectionId);
-    effectiveInit.headers = headers;
+  const existingHeaders = new Headers(effectiveInit.headers);
+  if (_activeConnectionId && !existingHeaders.has("X-Connection-Id")) {
+    existingHeaders.set("X-Connection-Id", _activeConnectionId);
   }
+  effectiveInit.headers = existingHeaders;
 
   const response = await fetch(input, effectiveInit);
   const { status } = response;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -680,20 +680,21 @@ export const getMemoryUsage = async (
   toast: ToastFn,
   setIndicator: (indicator: "online" | "offline") => void
 ): Promise<Map<string, MemoryValue>> => {
-  const result = await securedFetch(
-    `api/graph/${prepareArg(name)}/memory`,
-    {
-      method: "GET",
-    },
-    toast,
-    setIndicator
-  );
-
-  if (!result.ok) return new Map();
-
-  const json = await result.json();
-
-  return processEntries(json.result);
+  // Use plain fetch (not securedFetch) so NOPERM / version-too-low 400 errors
+  // from restricted users don't produce error toasts — memory usage is an
+  // optional admin-only feature and missing it is not an error worth surfacing.
+  try {
+    const headers = new Headers();
+    if (_activeConnectionId) {
+      headers.set("X-Connection-Id", _activeConnectionId);
+    }
+    const result = await fetch(`api/graph/${prepareArg(name)}/memory`, { headers });
+    if (!result.ok) return new Map();
+    const json = await result.json();
+    return processEntries(json.result);
+  } catch {
+    return new Map();
+  }
 };
 
 /**

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -442,6 +442,11 @@ const USER_READABLE_ERROR_PATTERNS = [
   /^unable to generate\b/i,
   /^no messages provided$/i,
   /^no user messages found$/i,
+  // Connection errors from /api/connections
+  /^cannot connect to falkordb\b/i,
+  /^authentication failed\b/i,
+  /^connection timed out\b/i,
+  /^only admin users can add connections\b/i,
 ];
 
 function isAllowlistedUserError(message: string): boolean {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -520,8 +520,17 @@ function triggerSessionInvalidationSignOut(): void {
 // Active connection ID for multi-connection support.
 // When set, securedFetch automatically injects an X-Connection-Id header so
 // the backend routes requests to the correct FalkorDB client.
+//
+// Initialise from localStorage so the value survives Next.js HMR module
+// resets. `lastActiveConnectionId` is written by handleSelect whenever the
+// user switches connections, so after a hot-reload the global is immediately
+// restored to the correct connection rather than falling back to the Token DB
+// (which might pick a restricted user).
 // ---------------------------------------------------------------------------
-let _activeConnectionId: string | null = null;
+let _activeConnectionId: string | null =
+  typeof window !== "undefined"
+    ? window.localStorage.getItem("lastActiveConnectionId")
+    : null;
 
 export function setActiveConnectionIdGlobal(id: string | null) {
   _activeConnectionId = id;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -446,7 +446,6 @@ const USER_READABLE_ERROR_PATTERNS = [
   /^cannot connect to falkordb\b/i,
   /^authentication failed\b/i,
   /^connection timed out\b/i,
-  /^only admin users can add connections\b/i,
 ];
 
 function isAllowlistedUserError(message: string): boolean {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -521,16 +521,14 @@ function triggerSessionInvalidationSignOut(): void {
 // When set, securedFetch automatically injects an X-Connection-Id header so
 // the backend routes requests to the correct FalkorDB client.
 //
-// Initialise from localStorage so the value survives Next.js HMR module
-// resets. `lastActiveConnectionId` is written by handleSelect whenever the
-// user switches connections, so after a hot-reload the global is immediately
-// restored to the correct connection rather than falling back to the Token DB
-// (which might pick a restricted user).
+// NOTE: do NOT initialise from localStorage here. If the user's last
+// explicit connection was a restricted user (e.g. shahar), initialising
+// _activeConnectionId to that ID would cause securedFetch to overwrite
+// any explicitly-passed X-Connection-Id headers (set by settings components)
+// with the restricted ID. The dep-free effect in providers.tsx keeps this
+// global in sync with the React activeConnectionId state after every render.
 // ---------------------------------------------------------------------------
-let _activeConnectionId: string | null =
-  typeof window !== "undefined"
-    ? window.localStorage.getItem("lastActiveConnectionId")
-    : null;
+let _activeConnectionId: string | null = null;
 
 export function setActiveConnectionIdGlobal(id: string | null) {
   _activeConnectionId = id;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -688,11 +688,22 @@ export const getMemoryUsage = async (
     if (_activeConnectionId) {
       headers.set("X-Connection-Id", _activeConnectionId);
     }
-    const result = await fetch(`api/graph/${prepareArg(name)}/memory`, { headers });
-    if (!result.ok) return new Map();
+    // eslint-disable-next-line no-console
+    console.debug(`[memory] fetching for graph="${name}" connId=${_activeConnectionId ?? "(none)"}`);
+    const result = await fetch(`/api/graph/${prepareArg(name)}/memory`, { headers });
+    if (!result.ok) {
+      // eslint-disable-next-line no-console
+      console.debug(`[memory] endpoint returned ${result.status} for graph="${name}"`);
+      return new Map();
+    }
     const json = await result.json();
-    return processEntries(json.result);
-  } catch {
+    const map = processEntries(json.result);
+    // eslint-disable-next-line no-console
+    console.debug(`[memory] result for graph="${name}": total_graph_sz_mb=${map.get("total_graph_sz_mb")}`);
+    return map;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.debug(`[memory] fetch threw for graph="${name}":`, err);
     return new Map();
   }
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -468,6 +468,13 @@ export function toUserFriendlyMessage(raw: unknown, status: number): UserFriendl
     return { title: "Syntax Error", description: formatSyntaxError(parsed.message, parsed.context, parsed.contextOffset), syntaxError: parsed };
   }
 
+  // Check the allowlist FIRST so that server-provided specific messages
+  // (e.g. "Connection timed out. Please check the host…") are shown as-is
+  // and are not overridden by the generic pattern handlers below.
+  if (isAllowlistedUserError(rawMessage)) {
+    return { title: "Error", description: rawMessage };
+  }
+
   const lower = rawMessage.toLowerCase();
 
   if (lower.includes("connection refused") || lower.includes("econnrefused")) {
@@ -500,10 +507,6 @@ export function toUserFriendlyMessage(raw: unknown, status: number): UserFriendl
 
   if (status >= 500) {
     return { title: "Error", description: "Something went wrong on the server. Please try again later." };
-  }
-
-  if (isAllowlistedUserError(rawMessage)) {
-    return { title: "Error", description: rawMessage };
   }
 
   return { title: "Error", description: "An unexpected error occurred. Please try again." };

--- a/readme-browser.md
+++ b/readme-browser.md
@@ -1,0 +1,138 @@
+# FalkorDB Browser — Features
+FalkorDB Browser is a web UI for exploring, querying, and managing FalkorDB graphs.
+It allows a developer to interact with graphs loaded to FaklorDB, explore how specific queries behave and review the current data model.
+
+
+## Main features
+
+### Graph exploration (Graph page)
+- **Interactive graph canvas**
+  - Visualize query results containing nodes/edges as an interactive graph.
+  - Pan/zoom and interact with nodes and relationships.
+  - Toggle visibility by **labels** and **relationship types**.
+- **Element search (in-canvas search)**
+  - Search nodes/edges by:
+    - node properties (string prefix match),
+    - ids,
+    - relationship type,
+    - labels.
+  - Jump/zoom to the match and select it.
+- **Data / inspection panel**
+  - Selecting an element opens a side panel for inspecting its properties.
+  - Supports editing workflows (see “Data manipulation”).
+- **Entity Creation Tools**
+  - You can add a node and/or an edge to the current graph from the canvas view.
+
+### Querying
+- **Cypher query editor (Monaco)**
+  - Editor-style experience for writing Cypher.
+  - Keyboard shortcuts include:
+    - Run: `Enter` (and `Cmd/Ctrl + Enter` in the query-history editor)
+    - Insert newline: `Shift + Enter`
+  - Includes Cypher keyword/function completion (based on the Browser’s built-in lists).
+- **Results views**
+  - **Graph view** for node/edge results.
+  - **Table view** for tabular results.
+- **Query metadata**
+  - Metadata tab shows:
+    - query metadata text,
+    - explain plan (rendered as a nested tree),
+    - profile output (rendered as a nested tree).
+
+### Query history
+- **Persistent query history** stored in browser `localStorage`.
+- **History browser dialog**
+  - Search and filter previous queries.
+  - Filter by graph name.
+  - Delete single queries, multi-select delete, or “delete all”.
+- **Per-query metadata**
+  - Review metadata / explain / profile for past queries.
+
+### Data manipulation (nodes/relationships)
+- **Create node / create relationship** flows from the Graph UI.
+- **Delete elements** (node or relationship) from the Graph UI.
+- **Label editing** supported via API routes (the UI provides label management components).
+
+### Graph management
+- **Create graphs** from the UI.
+- **Delete graphs** (supports deleting multiple selected graphs).
+- **Duplicate graphs**
+  - Create a copy of an existing graph (including data).
+- **Export graphs**
+  - Download a `.dump` file via the Browser (`/api/graph/:graph/export`).
+- **Upload data**
+  - “Upload Data” dialog supports drag-and-drop file selection (Dropzone UI).
+
+### Graph Info panel
+- **Memory Usage tracking** Exposes current memory utilization of the graph in MB.
+- **Node Label tracking** View all node labels in the graph, control style visualization for labels. Click on a node label to trigger a query to visualize nodes from this label.
+- **Edge Type tracking** View all edge types in the graph. Click on an edge type to trigger a graph query showing only nodes connected through this edge type.
+- **Proerty Keys tracking** View all property keys in the graph. Click on a key to issue a query that shows nodes and edges where the property exists (not NULL).
+
+
+### API documentation
+- **Built-in Swagger UI** at `/docs`.
+  - Loads the Browser’s OpenAPI spec from `/api/swagger`.
+  - “Try it out” enabled.
+  - Adds an `X-JWT-Only: true` header when calling endpoints from Swagger UI.
+
+### Authentication & access control
+- Uses **NextAuth** (credentials-backed) for authentication.
+- UI capabilities are role-aware:
+  - **Read-Only** users cannot create graphs.
+  - **Admin** users can access database configuration and user-management sections in settings.
+
+### Settings
+The `/settings` area includes multiple sections:
+- **Browser settings**
+  - Query execution defaults and limits:
+    - timeout
+    - result limit
+    - run default query on-load
+  - User experience:
+    - content persistence (auto-save/restore)
+    - display-text priority (controls which node property is shown as the node caption)
+  - Graph info refresh interval.
+  - Tutorial replay.
+- **DB configurations** (Admin)
+  - View and update server configuration values.
+  - Some runtime configs are intentionally read-only.
+- **Users** (Admin)
+  - List users and adjust roles.
+  - Add and delete users.
+- **Personal Access Tokens**
+  - Generate tokens (with optional expiration).
+  - Tokens are shown once at creation (copy-to-clipboard UX).
+  - Revoke existing tokens.
+
+### Optional “Chat” (English → Cypher)
+If enabled, the Browser includes a **Chat panel** that streams responses from a text-to-cypher service.
+- The UI sends messages to `/api/chat` and processes server-sent events.
+- Chat configuration lives in Settings (model + secret key).
+- The chat backend URL is controlled by `CHAT_URL`.
+
+## Common workflows
+### 1) Run a query and visualize results
+1. Go to **Graphs** and select a graph.
+2. Write a Cypher query in the editor.
+3. Run it.
+4. Inspect results in:
+   - **Graph** tab (interactive canvas), or
+   - **Table** tab (rows/columns).
+5. Use **Labels/Relationships toggles** to focus the canvas.
+
+### 2) Inspect and edit an element
+1. Click a node/edge in the canvas.
+2. Use the **Data panel** to inspect properties.
+3. Use create/delete actions as needed.
+
+### 3) Use query history
+1. Open **Query History**.
+2. Filter by graph, search, and select a previous query.
+3. Review **Metadata / Explain / Profile**.
+
+### 4) Export a graph
+1. Open graph management.
+2. Select a graph.
+3. Click **Export Data** to download a `.dump`.
+


### PR DESCRIPTION
## Summary

Fixes multiple regressions introduced by the `multi-db-connection` feature, plus follow-on improvements.

## Changes

### Settings tab reset fix (original issue)
- `app/settings/page.tsx`: guard with a ref so the tab only resets on real connection switches (non-null → different non-null), not on the initial null → value load.

### Connection switching
- `app/components/ConnectionManager.tsx`: set global connection ID before the async await; handle errors properly.

### Memory / DBVersion / UDF
- `app/providers.tsx`: use plain `fetch()` with no `X-Connection-Id` header — server uses JWT's `session.activeConnectionId`. Removed `!activeConnectionId` guards.

### Settings pages (Configurations, Users)
- Use plain `fetch()` (no X-Connection-Id). Server uses JWT. No timing races with the `_activeConnectionId` global.

### `getClient` fallback
- `app/api/auth/[...nextauth]/options.ts`: uses `session.activeConnectionId` as a preference within the existing Token DB list — prevents CI test failures where sign-out deletes connections.

### `securedFetch` header precedence
- Only injects the global X-Connection-Id when the caller hasn't already set the header explicitly.

### Error messages for new connections
- `app/api/connections/route.ts`: surfaces specific FalkorDB errors (ECONNREFUSED → 503, WRONGPASS/NOAUTH → 400, NOPERM → 400, timeout → 400).
- `lib/utils.ts`: `toUserFriendlyMessage` now checks `isAllowlistedUserError` **before** the generic pattern matchers, so server-provided specific messages (e.g. "Connection timed out. Please check the host…") are shown as-is and not overridden by the generic query-timeout handler.

### Multi-connection open to all users
- Removed the `role !== 'Admin'` guard from `POST /api/connections` — any authenticated user can add a new connection regardless of their role on the current endpoint.

### DB configs
- Added descriptions for `TEMP_FOLDER`, `JS_HEAP_SIZE`, `JS_STACK_SIZE`.

### CI / test fixes
- `session.activeConnectionId` only overrides Token DB connId when that ID actually exists in Token DB (prevents SESSION_INVALID when test sign-outs delete connections).
- `app/api/user/model.ts`: added `module|list` and `graph.udf` to role ACLs.

---

Co-Authored-By: Oz <oz-agent@warp.dev>

Warp conversation: https://app.warp.dev/conversation/0b1c2a41-053b-4feb-8886-aa22286b2e0b
