### PR TITLE
chore: bump dependencies and version to 2.0.2

### DIFF
--- a/app/components/Export.tsx
+++ b/app/components/Export.tsx
@@ -58,7 +58,7 @@ export default function Export({
         onClick={handleExport}
         variant={variant}
         >
-            <Download size={20} />
+            <Download size={16} />
         </Button>
     );
 }

--- a/app/graph/TableView.tsx
+++ b/app/graph/TableView.tsx
@@ -92,6 +92,7 @@ export default function TableView() {
             onExpandChange={setExpand}
         >
             <Export
+                className="p-1 text-sm"
                 data-testid="exportTableViewButton"
                 content={csvContent}
                 filename={`${graph.Id}_table_export.csv`}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "d3": "^7.9.0",
         "date-fns": "^4.1.0",
         "depcheck": "^1.4.7",
-        "dompurify": "^3.4.0",
+        "dompurify": "^3.4.2",
         "echarts": "^6.0.0",
         "echarts-for-react": "^3.0.2",
         "embla-carousel-react": "^8.5.2",
@@ -75,8 +75,8 @@
         "tailwindcss": "^4.2.3",
         "uuid": "^14.0.0",
         "vaul": "^1.1.2",
-        "yaml": "^2.8.3",
-        "zod": "^4.4.1"
+        "yaml": "^2.8.4",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -7265,9 +7265,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -13754,9 +13754,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -13845,9 +13845,9 @@
       "license": "Unlicense"
     },
     "node_modules/zod": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
-      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "@types/swagger-ui-react": "^5.18.0",
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
-        "eslint": "^10.2.1",
+        "eslint": "^10.3.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-airbnb-typescript": "^18.0.0",
         "eslint-config-next": "^16.2.4",
@@ -7598,9 +7598,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
-      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "falkordb-browser",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "falkordb-browser",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
         "@falkordb/canvas": "^0.0.49",
         "@falkordb/text-to-cypher": "^0.1.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "react-gtm-module": "^2.0.11",
         "react-hook-form": "^7.74.0",
         "react-json-tree": "^0.20.0",
-        "react-resizable-panels": "^4.9.0",
+        "react-resizable-panels": "^4.11.0",
         "swagger-ui-react": "^5.32.5",
         "swr": "^2.4.1",
         "tailwind-merge": "^3.5.0",
@@ -11663,9 +11663,9 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.10.0.tgz",
-      "integrity": "sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.11.0.tgz",
+      "integrity": "sha512-LPk/AkFDGkg7SsbOyL93ojrE6E7lhrxxDwnYNjfmnSeI6BE7Sje6dB24PXgZk8DeugdeXNk1LO+ohRqIjhxiLw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "react-dom": "^19.2.5",
         "react-dropzone": "^15.0.0",
         "react-gtm-module": "^2.0.11",
-        "react-hook-form": "^7.74.0",
+        "react-hook-form": "^7.75.0",
         "react-json-tree": "^0.20.0",
         "react-resizable-panels": "^4.9.0",
         "swagger-ui-react": "^5.32.5",
@@ -11525,9 +11525,9 @@
       "license": "MIT"
     },
     "node_modules/react-hook-form": {
-      "version": "7.74.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
-      "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
+      "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "d3": "^7.9.0",
     "date-fns": "^4.1.0",
     "depcheck": "^1.4.7",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.2",
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.2",
     "embla-carousel-react": "^8.5.2",
@@ -82,8 +82,8 @@
     "tailwindcss": "^4.2.3",
     "uuid": "^14.0.0",
     "vaul": "^1.1.2",
-    "yaml": "^2.8.3",
-    "zod": "^4.4.1"
+    "yaml": "^2.8.4",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-dom": "^19.2.5",
     "react-dropzone": "^15.0.0",
     "react-gtm-module": "^2.0.11",
-    "react-hook-form": "^7.74.0",
+    "react-hook-form": "^7.75.0",
     "react-json-tree": "^0.20.0",
     "react-resizable-panels": "^4.9.0",
     "swagger-ui-react": "^5.32.5",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react-gtm-module": "^2.0.11",
     "react-hook-form": "^7.74.0",
     "react-json-tree": "^0.20.0",
-    "react-resizable-panels": "^4.9.0",
+    "react-resizable-panels": "^4.11.0",
     "swagger-ui-react": "^5.32.5",
     "swr": "^2.4.1",
     "tailwind-merge": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "falkordb-browser",
   "author": "FalkorDB",
   "description": "FalkorDB Browser",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "engines": {
     "node": ">=20.19.0"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@types/swagger-ui-react": "^5.18.0",
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",
-    "eslint": "^10.2.1",
+    "eslint": "^10.3.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-next": "^16.2.4",


### PR DESCRIPTION
## Summary

Consolidates all open Dependabot PRs into a single PR and bumps the version to **2.0.2**.

### Dependency updates
- **react-hook-form** 7.74.0 → 7.75.0 (#1706)
- **eslint** 10.2.1 → 10.3.0 (#1705)
- **react-resizable-panels** 4.10.0 → 4.11.0 (#1704)
- **dompurify** 3.4.0 → 3.4.2, **yaml** 2.8.3 → 2.8.4, **zod** 4.4.1 → 4.4.3 (#1703)

### Version bump
- `package.json` version: 2.0.1 → **2.0.2**

Once this PR is merged, the individual Dependabot PRs (#1703, #1704, #1705, #1706) can be closed.