### PR TITLE
fix: bundle Monaco editor loader

### DIFF
--- a/app/components/EditorComponent.tsx
+++ b/app/components/EditorComponent.tsx
@@ -9,6 +9,8 @@ import { useEffect, useLayoutEffect, useRef } from "react";
 import { useTheme } from "next-themes";
 import { getTheme } from "@/lib/utils";
 
+loader.config({ monaco });
+
 export const LINE_HEIGHT = 22;
 
 export const DEFAULT_MONACO_OPTIONS: monaco.editor.IStandaloneEditorConstructionOptions = {


### PR DESCRIPTION
Configure @monaco-editor/react to use the bundled Monaco package instead of loading the editor from the default CDN. This keeps the query editor compatible with CSP environments that block external scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor component initialization to ensure consistent and reliable loading of the editor interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-browser/pull/1737)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->