### PR TITLE
fix: restore bundled Monaco loader

### DIFF
--- a/app/components/EditorComponent.tsx
+++ b/app/components/EditorComponent.tsx
@@ -9,6 +9,8 @@ import { useEffect, useLayoutEffect, useRef } from "react";
 import { useTheme } from "next-themes";
 import { getTheme } from "@/lib/utils";
 
+loader.config({ monaco });
+
 export const LINE_HEIGHT = 22;
 
 export const DEFAULT_MONACO_OPTIONS: monaco.editor.IStandaloneEditorConstructionOptions = {


### PR DESCRIPTION
## Summary
- Restore Monaco loader configuration to use the bundled monaco-editor package instead of the default CDN loader.
- Prevent the query editor from attempting to load jsDelivr scripts in CSP-restricted environments like Snowflake.

## Validation
- npm run lint -- --quiet
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Monaco editor loader configuration issue to ensure proper initialization and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-browser/pull/1780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->