### PR TITLE
fix: sanitize forwarded headers for Auth.js behind reverse proxy

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,8 +1,26 @@
 import type { NextRequest } from "next/server";
-import { enableAutoNextAuthUrl, isRequestOriginTrusted, rejectUntrustedOrigin } from "../../utils";
+import { enableAutoNextAuthUrl, firstHeaderValue, isRequestOriginTrusted, rejectUntrustedOrigin } from "../../utils";
 import { handlers } from "@/auth";
 
 enableAutoNextAuthUrl();
+
+function sanitizeForwardedHeaders(request: NextRequest): Request {
+  const headers = new Headers(request.headers);
+
+  const forwardedHost = firstHeaderValue(headers.get("x-forwarded-host"));
+  if (forwardedHost) {
+    headers.set("x-forwarded-host", forwardedHost);
+  }
+
+  const forwardedProto = firstHeaderValue(headers.get("x-forwarded-proto"));
+  if (forwardedProto === "http" || forwardedProto === "https") {
+    headers.set("x-forwarded-proto", forwardedProto);
+  } else {
+    headers.delete("x-forwarded-proto");
+  }
+
+  return new Request(request, { headers });
+}
 
 async function authHandler(request: NextRequest) {
   if (!isRequestOriginTrusted(request)) {
@@ -10,7 +28,7 @@ async function authHandler(request: NextRequest) {
   }
 
   const method = request.method === "POST" ? handlers.POST : handlers.GET;
-  return method(request);
+  return method(sanitizeForwardedHeaders(request));
 }
 
 export { authHandler as GET, authHandler as POST };

--- a/app/api/utils.ts
+++ b/app/api/utils.ts
@@ -65,7 +65,7 @@ function normalizeOrigin(origin: string): string | null {
     }
 }
 
-function firstHeaderValue(value: string | null): string | null {
+export function firstHeaderValue(value: string | null): string | null {
     return value?.split(",")[0]?.trim() || null;
 }
 


### PR DESCRIPTION
## Problem
When running behind Snowflake SPCS (or any reverse proxy), `x-forwarded-host` and `x-forwarded-proto` headers can arrive as comma-separated multi-values (e.g. `app.snowflakecomputing.app, internal-host`). Auth.js v5 tries to build a URL directly from these headers and throws `TypeError: Invalid URL`, causing `/api/auth/session` to return 500 with an empty body.

## Fix
- Sanitize `x-forwarded-host` and `x-forwarded-proto` in the auth route before passing the request to Auth.js handlers — taking only the first value and removing proto if it is not `http` or `https`.
- Export `firstHeaderValue` from `utils.ts` and import it in `route.ts` to remove code duplication.

## Changes
- `app/api/utils.ts`: export `firstHeaderValue`
- `app/api/auth/[...nextauth]/route.ts`: import `firstHeaderValue` from utils, remove local duplicate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication security through stricter validation of forwarded headers to prevent unauthorized access attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-browser/pull/1789?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->