### PR TITLE
Add support for serving the browser under a sub-path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+ARG NEXT_PUBLIC_BASE_PATH=""
+ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
+
 # Disable Next.js telemetry during build and runtime.
 ENV NEXT_TELEMETRY_DISABLED=1
 

--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -6,7 +6,7 @@ import { Check, ChevronDown, LogOut, Plus } from "lucide-react";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/components/ui/use-toast";
-import { securedFetch, setActiveConnectionIdGlobal } from "@/lib/utils";
+import { securedFetch, setActiveConnectionIdGlobal, withBasePath } from "@/lib/utils";
 
 import { ConnectionContext, IndicatorContext, SessionConnection } from "./provider";
 import Button from "./ui/Button";
@@ -69,7 +69,7 @@ export default function ConnectionManager() {
     try {
       // If this is the last connection, sign out instead.
       if (isLast) {
-        await signOut({ callbackUrl: "/login" });
+        await signOut({ callbackUrl: withBasePath("/login") });
         return;
       }
 

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -5,7 +5,7 @@
 import { ArrowUpRight, FileCode, LogOut, Monitor, Moon, Sun, Settings, FunctionSquare, GitGraph } from "lucide-react";
 import { useState, useEffect } from "react";
 import Image from "next/image";
-import { cn, getTheme } from "@/lib/utils";
+import { cn, getTheme, withBasePath } from "@/lib/utils";
 import { useRouter, usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
 import pkg from '@/package.json';
@@ -76,7 +76,7 @@ export default function Navbar({ showUDF }: Props) {
                         href="https://www.falkordb.com"
                         target="_blank" rel="noreferrer"
                     >
-                        <Image style={{ width: 'auto', height: '48px' }} priority src={`/icons/F-${currentTheme}.svg`} alt="FalkorDB Logo" width={0} height={0} />
+                        <Image style={{ width: 'auto', height: '48px' }} priority src={withBasePath(`/icons/F-${currentTheme}.svg`)} alt="FalkorDB Logo" width={0} height={0} />
                     </Link>
                 }
                 <div data-testid="NavigationButtons" className="p-1 flex flex-col items-center gap-2 bg-foreground/5 rounded-lg">
@@ -149,7 +149,7 @@ export default function Navbar({ showUDF }: Props) {
                                 <DropdownMenuSeparator />
                                 <DropdownMenuItem className="focus:bg-transparent">
                                     <a className="flex gap-2 items-center" href="https://discord.com/invite/jyUgBweNQz" target="_blank" rel="noreferrer noreferrer">
-                                        <Image style={{ width: 'auto', height: currentTheme === "dark" ? '14px' : '18px' }} src={`/icons/Discord-${currentTheme}.svg`} alt="" width={0} height={0} />
+                                        <Image style={{ width: 'auto', height: currentTheme === "dark" ? '14px' : '18px' }} src={withBasePath(`/icons/Discord-${currentTheme}.svg`)} alt="" width={0} height={0} />
                                         <span>
                                             Get Support
                                         </span>
@@ -175,7 +175,7 @@ export default function Navbar({ showUDF }: Props) {
                         </VisuallyHidden>
                         <div className="h-full flex flex-col gap-8 max-w-[30rem] p-4">
                             <div className="h-1 grow flex flex-col gap-8 items-center justify-center">
-                                {mounted && currentTheme && <Image style={{ width: 'auto', height: '50px' }} priority src={`/icons/Falkordb-${currentTheme}.svg`} alt="" width={0} height={0} />}
+                                {mounted && currentTheme && <Image style={{ width: 'auto', height: '50px' }} priority src={withBasePath(`/icons/Falkordb-${currentTheme}.svg`)} alt="" width={0} height={0} />}
                                 <h1 className="text-3xl font-bold">We Make AI Reliable</h1>
                                 <p className="text-xl text-center">
                                     Delivering a scalable,

--- a/app/graph/Chat.tsx
+++ b/app/graph/Chat.tsx
@@ -1,4 +1,4 @@
-import { cn, getTheme, Message, toUserFriendlyMessage } from "@/lib/utils";
+import { cn, getTheme, Message, toUserFriendlyMessage, withBasePath } from "@/lib/utils";
 import { memo, useContext, useEffect, useMemo, useRef, useState, useCallback } from "react";
 import MarkdownIt from "markdown-it";
 import DOMPurify from "dompurify";
@@ -263,7 +263,7 @@ export default function Chat({ onClose }: Props) {
         }
 
         try {
-            const response = await fetch("/api/chat", {
+            const response = await fetch(withBasePath("/api/chat"), {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -598,7 +598,7 @@ export default function Chat({ onClose }: Props) {
                                     <p className="text-foreground text-sm truncate text-center">{message.role.charAt(0).toUpperCase()}</p>
                                 </div>
                                 : <div className="h-8 w-8 relative">
-                                    {mounted && currentTheme && <Image className="rounded-full" src={`/icons/F-${currentTheme}.svg`} alt="Assistant" fill />}
+                                    {mounted && currentTheme && <Image className="rounded-full" src={withBasePath(`/icons/F-${currentTheme}.svg`)} alt="Assistant" fill />}
                                 </div>;
                             return (
                                 <li

--- a/app/login/LoginPage.tsx
+++ b/app/login/LoginPage.tsx
@@ -60,7 +60,7 @@ export default function LoginPage() {
       throw new Error("Invalid credentials please recheck username and password or your connection settings. Check server logs for more info.");
     }
 
-    router.push("/graph");
+    router.push(withBasePath("/graph"));
   };
 
   return (

--- a/app/login/LoginPage.tsx
+++ b/app/login/LoginPage.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { FileText } from "lucide-react";
 import { useTheme } from "next-themes";
-import { getTheme } from "@/lib/utils";
+import { getTheme, withBasePath } from "@/lib/utils";
 import LoginForm, { LoginFormCredentials } from "./LoginForm";
 
 export default function LoginPage() {
@@ -67,7 +67,7 @@ export default function LoginPage() {
     <div className="relative h-full w-full flex flex-col">
       <div className="grow basis-0 flex items-center justify-center overflow-auto">
         <div className="flex flex-col gap-2 items-center max-h-full w-[500px]">
-          {mounted && currentTheme && <Image style={{ width: 'auto', height: '80px' }} priority src={`/icons/Browser-${currentTheme}.svg`} alt="FalkorDB Browser Logo" width={0} height={0} />}
+          {mounted && currentTheme && <Image style={{ width: 'auto', height: '80px' }} priority src={withBasePath(`/icons/Browser-${currentTheme}.svg`)} alt="FalkorDB Browser Logo" width={0} height={0} />}
           <LoginForm
             onSubmit={handleLogin}
             submitButtonLabel="Log in"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import Spinning from "@/app/components/ui/spinning";
 import Image from "next/image";
 import pkg from '@/package.json';
 import { useTheme } from "next-themes";
-import { getTheme } from "@/lib/utils";
+import { getTheme, withBasePath } from "@/lib/utils";
 import { useEffect, useState } from "react";
 
 export default function Home() {
@@ -19,7 +19,7 @@ export default function Home() {
   return (
     <div className="h-full w-full bg-background flex flex-col gap-4">
       <main className="grow flex flex-col gap-10 items-center justify-center">
-        {mounted && currentTheme && <Image style={{ width: 'auto', height: '100px' }} priority src={`/icons/Browser-${currentTheme}.svg`} alt="FalkorDB Logo" width={0} height={0} />}
+        {mounted && currentTheme && <Image style={{ width: 'auto', height: '100px' }} priority src={withBasePath(`/icons/Browser-${currentTheme}.svg`)} alt="FalkorDB Logo" width={0} height={0} />}
         <Spinning />
       </main>
       <div className="flex flex-col gap-8 justify-center items-center">

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,7 +3,7 @@
 import { SessionProvider, useSession } from "next-auth/react";
 import { ThemeProvider } from 'next-themes';
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { fetchOptions, getDefaultQuery, getQueryWithLimit, getSSEGraphResult, prepareArg, securedFetch, setActiveConnectionIdGlobal, getActiveConnectionIdGlobal, Tab, getMemoryUsage, GraphRef, ConnectionType, ConnectionInfo, UDFEntry, UDFEntryWithCode, getMetaStats, HistoryQuery, GraphData, Label, Relationship, Query, Data, MemoryValue, SyntaxErrorInfo, parseSyntaxError } from "@/lib/utils";
+import { fetchOptions, getDefaultQuery, getQueryWithLimit, getSSEGraphResult, prepareArg, securedFetch, setActiveConnectionIdGlobal, getActiveConnectionIdGlobal, Tab, getMemoryUsage, GraphRef, ConnectionType, ConnectionInfo, UDFEntry, UDFEntryWithCode, getMetaStats, HistoryQuery, GraphData, Label, Relationship, Query, Data, MemoryValue, SyntaxErrorInfo, parseSyntaxError, withBasePath } from "@/lib/utils";
 import { serverEncrypt, serverDecrypt, isLegacyEncrypted, legacyDecrypt, clearLegacyEncryptionKey } from "@/lib/server-encryption";
 import { getConnectionItem, setConnectionItem, removeConnectionItem, setConnectionPrefix, clearConnectionPrefix, migrateToScopedStorage } from "@/lib/connection-storage";
 import { usePathname, useRouter } from "next/navigation";
@@ -586,7 +586,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     // where activeConnectionId is null on page load and the check never fires.
     (async () => {
       try {
-        const result = await fetch("/api/DBVersion", { method: "GET" });
+        const result = await fetch(withBasePath("/api/DBVersion"), { method: "GET" });
         if (!result.ok) {
           setShowMemoryUsage(false);
           return;
@@ -861,7 +861,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     if (status !== "authenticated") return;
     // Use plain fetch with no X-Connection-Id — server resolves via JWT.
     (async () => {
-      const res = await fetch("/api/udf", { method: "GET" });
+      const res = await fetch(withBasePath("/api/udf"), { method: "GET" });
       if (!res.ok) { setShowUDF(false); return; }
 
       const json = await res.json();
@@ -1141,7 +1141,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
 
 export default function NextAuthProvider({ children, nonce }: { children: React.ReactNode; nonce?: string }) {
   return (
-    <SessionProvider>
+    <SessionProvider basePath={withBasePath("/api/auth")}>
       <Suspense fallback={null}>
         <ProvidersWithSession nonce={nonce}>{children}</ProvidersWithSession>
       </Suspense>

--- a/app/settings/Configurations.tsx
+++ b/app/settings/Configurations.tsx
@@ -6,7 +6,7 @@
 "use client";
 
 import { useEffect, useState, useContext } from "react";
-import { prepareArg, securedFetch, Row, DataCell } from "@/lib/utils";
+import { prepareArg, securedFetch, Row, DataCell, withBasePath } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import TableComponent from "../components/TableComponent";
 import ToastButton from "../components/ToastButton";
@@ -217,7 +217,7 @@ export default function Configurations() {
         // The server uses session.activeConnectionId from the JWT as the
         // authoritative connection (set by every handleSelect call), so
         // this is always correct regardless of client-side global state.
-        const result = await fetch("/api/graph/config", { method: "GET" });
+        const result = await fetch(withBasePath("/api/graph/config"), { method: "GET" });
         if (!result.ok) {
             const body = await result.text().catch(() => "");
             let message = "Failed to load DB configurations";

--- a/app/settings/users/Users.tsx
+++ b/app/settings/users/Users.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect, useState, useContext, useCallback } from "react";
 import { CreateUser, User } from "@/app/api/user/model";
-import { prepareArg, securedFetch, Row, ToastFn } from "@/lib/utils";
+import { prepareArg, securedFetch, Row, ToastFn, withBasePath } from "@/lib/utils";
 import TableComponent from "@/app/components/TableComponent";
 import { useToast } from "@/components/ui/use-toast";
 import { IndicatorContext, ConnectionContext } from "@/app/components/provider";
@@ -32,7 +32,7 @@ export default function Users() {
             // Use plain fetch with no X-Connection-Id header.
             // The server resolves the correct connection via session.activeConnectionId
             // from the JWT (updated by every handleSelect call).
-            const result = await fetch("/api/user", { method: 'GET' });
+            const result = await fetch(withBasePath("/api/user"), { method: 'GET' });
             if (!result.ok) return;
             const data = await result.json();
             setUsers(data.result.map((user: User) => ({ ...user, selected: false })));

--- a/helm/falkordb-browser/README.md
+++ b/helm/falkordb-browser/README.md
@@ -69,6 +69,7 @@ The following table lists the configurable parameters of the FalkorDB Browser ch
 | `image.repository` | Image repository | `falkordb/falkordb-browser` |
 | `image.tag` | Image tag | `""` (uses chart appVersion) |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `browser.basePath` | Path prefix for hosting the browser, for example `/browser` | `""` |
 | `service.type` | Kubernetes service type | `ClusterIP` |
 | `service.port` | Service port for browser | `3000` |
 | `service.restPort` | Service port for REST API | `8080` |
@@ -132,6 +133,40 @@ Install:
 ```bash
 helm install falkordb-browser ./falkordb-browser -f ingress-values.yaml
 ```
+
+### Installation Under a Path Prefix
+
+To host the full browser under a subpath such as `/browser`, build the image with the same base path and set `browser.basePath` in the chart:
+
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_BASE_PATH=/browser \
+  -t your-registry/falkordb-browser:browser-path .
+```
+
+```yaml
+image:
+  repository: your-registry/falkordb-browser
+  tag: browser-path
+
+browser:
+  basePath: /browser
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: falkordb-browser.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+env:
+  nextauthUrl: https://falkordb-browser.example.com/browser
+  nextauthSecret: "your-secure-secret-here"
+```
+
+When `browser.basePath` is set and an ingress path is `/`, the chart renders that path as the configured prefix.
 
 ### Installation with persistence
 

--- a/helm/falkordb-browser/README.md
+++ b/helm/falkordb-browser/README.md
@@ -76,6 +76,7 @@ The following table lists the configurable parameters of the FalkorDB Browser ch
 | `service.mcpPort` | Service port for MCP | `3001` |
 | `ingress.enabled` | Enable ingress | `false` |
 | `ingress.className` | Ingress class name | `""` |
+| `ingress.rewriteRootToBasePath` | Rewrite ingress path `/` to `browser.basePath` if set (required for sub-path hosting) | `false` |
 | `ingress.hosts` | Ingress hosts configuration | `[{host: falkordb-browser.local, paths: [{path: /, pathType: ImplementationSpecific}]}]` |
 | `ingress.tls` | Ingress TLS configuration | `[]` |
 | `resources` | CPU/Memory resource requests/limits | `{}` |
@@ -134,39 +135,65 @@ Install:
 helm install falkordb-browser ./falkordb-browser -f ingress-values.yaml
 ```
 
-### Installation Under a Path Prefix
+### Installation Under a Path Prefix (Sub-path Hosting)
 
-To host the full browser under a subpath such as `/browser`, build the image with the same base path and set `browser.basePath` in the chart:
+To host the full browser under a subpath such as `/browser`, you must:
 
-```bash
-docker build \
-  --build-arg NEXT_PUBLIC_BASE_PATH=/browser \
-  -t your-registry/falkordb-browser:browser-path .
-```
+1. **Build the image with the base path:**
 
-```yaml
-image:
-  repository: your-registry/falkordb-browser
-  tag: browser-path
+   ```bash
+   docker build \
+     --build-arg NEXT_PUBLIC_BASE_PATH=/browser \
+     -t your-registry/falkordb-browser:browser-path .
+   ```
 
-browser:
-  basePath: /browser
+2. **Set the base path and ingress rewrite in your values:**
 
-ingress:
-  enabled: true
-  className: nginx
-  hosts:
-    - host: falkordb-browser.example.com
-      paths:
-        - path: /
-          pathType: Prefix
+   ```yaml
+   image:
+     repository: your-registry/falkordb-browser
+     tag: browser-path
 
-env:
-  nextauthUrl: https://falkordb-browser.example.com/browser
-  nextauthSecret: "your-secure-secret-here"
-```
+   browser:
+     basePath: /browser
 
-When `browser.basePath` is set and an ingress path is `/`, the chart renders that path as the configured prefix.
+   ingress:
+     enabled: true
+     className: nginx
+     rewriteRootToBasePath: true  # Required for sub-path hosting
+     hosts:
+       - host: falkordb-browser.example.com
+         paths:
+           - path: /
+             pathType: Prefix
+
+   env:
+     nextauthUrl: https://falkordb-browser.example.com/browser
+     nextauthSecret: "your-secure-secret-here"
+   ```
+
+3. **Ingress/proxy routing:**
+
+   You must route both `${browser.basePath}/*` and `${browser.basePath}/api/auth/*` to the app service. For example, in NGINX:
+
+   ```nginx
+   location /browser/ {
+     proxy_pass http://falkordb-browser-service;
+   }
+   location /browser/api/auth/ {
+     proxy_pass http://falkordb-browser-service;
+   }
+   ```
+
+   > **Note:** Auth/session callbacks must be reachable at `${browser.basePath}/api/auth/*`. If ingress/proxy does not forward this path, login/logout will fail.
+
+4. **Validation:**
+
+   The chart will fail to render if `env.nextauthUrl`'s path does not match `browser.basePath`.
+
+5. **Migration:**
+
+   The chart no longer rewrites ingress `/` to the base path by default. Set `ingress.rewriteRootToBasePath: true` to enable this for sub-path hosting. Review your ingress rules if upgrading.
 
 ### Installation with persistence
 

--- a/helm/falkordb-browser/templates/_helpers.tpl
+++ b/helm/falkordb-browser/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Normalize the optional browser base path used when hosting the app under a subpath.
+*/}}
+{{- define "falkordb-browser.basePath" -}}
+{{- $basePath := default "" .Values.browser.basePath -}}
+{{- if and $basePath (ne $basePath "/") -}}
+{{- if not (hasPrefix "/" $basePath) -}}
+{{- fail "browser.basePath must start with /" -}}
+{{- end -}}
+{{- $basePath | trimSuffix "/" -}}
+{{- end -}}
+{{- end }}

--- a/helm/falkordb-browser/templates/_helpers.tpl
+++ b/helm/falkordb-browser/templates/_helpers.tpl
@@ -73,3 +73,18 @@ Normalize the optional browser base path used when hosting the app under a subpa
 {{- $basePath | trimSuffix "/" -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Validate that env.nextauthUrl path matches browser.basePath if set.
+*/}}
+{{- define "falkordb-browser.validateNextAuthUrl" -}}
+{{- $basePath := include "falkordb-browser.basePath" . -}}
+{{- $nextauthUrl := .Values.env.nextauthUrl | default "" -}}
+{{- if and $basePath $nextauthUrl (ne $basePath "") (ne $basePath "/") -}}
+  {{- $urlParts := splitList "/" $nextauthUrl -}}
+  {{- $urlPath := printf "/%s" (join "/" (slice $urlParts 3)) | trimSuffix "/" -}}
+  {{- if ne $urlPath $basePath -}}
+    {{- fail (printf "env.nextauthUrl path (%s) must match browser.basePath (%s) when basePath is set" $urlPath $basePath) -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/falkordb-browser/templates/configmap.yaml
+++ b/helm/falkordb-browser/templates/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "falkordb-browser.labels" . | nindent 4 }}
 data:
+  NEXT_PUBLIC_BASE_PATH: {{ include "falkordb-browser.basePath" . | quote }}
   CHAT_URL: {{ .Values.env.chatUrl | quote }}
   NEXTAUTH_URL: {{ .Values.env.nextauthUrl | quote }}
   NEXT_PUBLIC_GOOGLE_ANALYTICS: {{ .Values.env.googleAnalytics | quote }}

--- a/helm/falkordb-browser/templates/configmap.yaml
+++ b/helm/falkordb-browser/templates/configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "falkordb-browser.fullname" . }}
   labels:
     {{- include "falkordb-browser.labels" . | nindent 4 }}
+{{ include "falkordb-browser.validateNextAuthUrl" . }}
 data:
   NEXT_PUBLIC_BASE_PATH: {{ include "falkordb-browser.basePath" . | quote }}
   CHAT_URL: {{ .Values.env.chatUrl | quote }}

--- a/helm/falkordb-browser/templates/ingress.yaml
+++ b/helm/falkordb-browser/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "falkordb-browser.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- $basePath := include "falkordb-browser.basePath" . -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -42,7 +43,11 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          {{- $path := .path }}
+          {{- if and $basePath (eq $path "/") }}
+          {{- $path = $basePath }}
+          {{- end }}
+          - path: {{ $path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
             {{- end }}

--- a/helm/falkordb-browser/templates/ingress.yaml
+++ b/helm/falkordb-browser/templates/ingress.yaml
@@ -44,7 +44,7 @@ spec:
         paths:
           {{- range .paths }}
           {{- $path := .path }}
-          {{- if and $basePath (eq $path "/") }}
+          {{- if and $basePath (eq $path "/") $.Values.ingress.rewriteRootToBasePath }}
           {{- $path = $basePath }}
           {{- end }}
           - path: {{ $path }}

--- a/helm/falkordb-browser/values.yaml
+++ b/helm/falkordb-browser/values.yaml
@@ -14,6 +14,11 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+browser:
+  # Host the browser under a path prefix such as /browser.
+  # Images must be built with the same NEXT_PUBLIC_BASE_PATH value.
+  basePath: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/helm/falkordb-browser/values.yaml
+++ b/helm/falkordb-browser/values.yaml
@@ -60,6 +60,9 @@ service:
 ingress:
   enabled: false
   className: ""
+  # If true, rewrite any ingress rule with path: / to browser.basePath (if set).
+  # This is required for sub-path hosting but is off by default for backward compatibility.
+  rewriteRootToBasePath: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/lib/server-encryption.ts
+++ b/lib/server-encryption.ts
@@ -4,13 +4,15 @@
  * Includes legacy migration support for old client-side encrypted values.
  */
 
+import { withBasePath } from './utils';
+
 const LEGACY_ENCRYPTED_PREFIX = 'enc:';
 const LEGACY_KEY_STORAGE_KEY = 'falkordb-key';
 
 export async function serverEncrypt(value: string): Promise<string> {
   if (!value) return '';
 
-  const res = await fetch('/api/encrypt', {
+  const res = await fetch(withBasePath('/api/encrypt'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ value, action: 'encrypt' }),
@@ -27,7 +29,7 @@ export async function serverEncrypt(value: string): Promise<string> {
 export async function serverDecrypt(encryptedValue: string): Promise<string> {
   if (!encryptedValue) return '';
 
-  const res = await fetch('/api/encrypt', {
+  const res = await fetch(withBasePath('/api/encrypt'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ value: encryptedValue, action: 'decrypt' }),

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -243,6 +243,17 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+export const appBasePath = rawBasePath === "/" ? "" : rawBasePath.replace(/\/$/, "");
+
+export function withBasePath(url: string): string {
+  if (!appBasePath || /^https?:\/\//i.test(url)) return url;
+  if (url === appBasePath || url.startsWith(`${appBasePath}/`)) return url;
+  if (url.startsWith("/")) return `${appBasePath}${url}`;
+  if (url.startsWith("api/")) return `${appBasePath}/${url}`;
+  return url;
+}
+
 export async function getSSEGraphResult(
   url: string,
   toast: ToastFn,
@@ -258,7 +269,7 @@ export async function getSSEGraphResult(
       effectiveUrl += `${sep}connectionId=${encodeURIComponent(_activeConnectionId)}`;
     }
 
-    const evtSource = new EventSource(effectiveUrl);
+    const evtSource = new EventSource(withBasePath(effectiveUrl));
     evtSource.addEventListener("result", (event: MessageEvent) => {
       const result = JSON.parse(event.data);
       evtSource.close();
@@ -517,7 +528,7 @@ let sessionInvalidationInFlight = false;
 function triggerSessionInvalidationSignOut(): void {
   if (sessionInvalidationInFlight) return;
   sessionInvalidationInFlight = true;
-  signOut({ callbackUrl: "/login" }).catch(() => {
+  signOut({ callbackUrl: withBasePath("/login") }).catch(() => {
     sessionInvalidationInFlight = false;
   });
 }
@@ -561,7 +572,7 @@ export async function securedFetch(
   }
   effectiveInit.headers = existingHeaders;
 
-  const response = await fetch(input, effectiveInit);
+  const response = await fetch(withBasePath(input), effectiveInit);
   const { status } = response;
 
   // The server signals "your session is orphaned, sign out now" via this
@@ -709,7 +720,7 @@ export const getMemoryUsage = async (
     if (effectiveConnId) {
       headers.set("X-Connection-Id", effectiveConnId);
     }
-    const result = await fetch(`/api/graph/${prepareArg(name)}/memory`, { headers });
+    const result = await fetch(withBasePath(`/api/graph/${prepareArg(name)}/memory`), { headers });
     if (!result.ok) return new Map();
     const json = await result.json();
     return processEntries(json.result);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -247,10 +247,21 @@ const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
 export const appBasePath = rawBasePath === "/" ? "" : rawBasePath.replace(/\/$/, "");
 
 export function withBasePath(url: string): string {
+  // Absolute URLs and http(s) URLs pass through unchanged
   if (!appBasePath || /^https?:\/\//i.test(url)) return url;
+
+  // Already prefixed with basePath
   if (url === appBasePath || url.startsWith(`${appBasePath}/`)) return url;
+
+  // Relative URLs: trim leading './' and prefix with basePath
   if (url.startsWith("/")) return `${appBasePath}${url}`;
+  if (url.startsWith("./")) return `${appBasePath}/${url.slice(2)}`;
   if (url.startsWith("api/")) return `${appBasePath}/${url}`;
+
+  // For other relative URLs (without leading / or ./), prefix with basePath
+  if (!url.startsWith("#") && url.length > 0) return `${appBasePath}/${url}`;
+
+  // Fragments and empty strings pass through unchanged
   return url;
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,20 @@
 /** @type {import('next').NextConfig} */
 const path = require('path');
+
+function normalizeBasePath(value) {
+  if (!value || value === '/') return '';
+
+  if (!value.startsWith('/')) {
+    throw new Error('NEXT_PUBLIC_BASE_PATH must start with /');
+  }
+
+  return value.replace(/\/$/, '');
+}
+
+const basePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH);
+
 const nextConfig = {
+  basePath,
   allowedDevOrigins: ['127.0.0.1', '0.0.0.0'],
   output: 'standalone',
   reactStrictMode: true,


### PR DESCRIPTION
- Introduced NEXT_PUBLIC_BASE_PATH environment variable in Dockerfile.
- Updated various components to use withBasePath for URL handling.
- Modified README and Helm chart to document base path configuration.
- Enhanced configmap and ingress templates to utilize base path.

fix #1790
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App can be hosted under a URL path prefix (configurable) so UI, API and auth routes work when served from a subpath.

* **Bug Fixes**
  * Asset loading, redirects (login/sign-out) and client API calls now respect the configured path prefix, preventing broken icons and incorrect navigation when hosted under a subpath.

* **Documentation**
  * Helm README and chart values updated with guidance for sub-path hosting and required configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-browser/pull/1791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->