### PR TITLE
Add encryption key management to Helm chart

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -56,6 +56,46 @@ jobs:
           
           echo "Testing with serviceAccount.create=false..."
           helm template test helm/falkordb-browser --set serviceAccount.create=false > /dev/null
+
+          echo "Testing generated encryption key..."
+          GENERATED_KEY=$(helm template test helm/falkordb-browser --show-only templates/secret.yaml | awk -F'"' '/ENCRYPTION_KEY:/ {print $2}')
+          if ! echo "$GENERATED_KEY" | grep -Eq '^[0-9a-fA-F]{64}$'; then
+            echo "Generated ENCRYPTION_KEY must be 64 hexadecimal characters"
+            exit 1
+          fi
+
+          echo "Testing supplied encryption key..."
+          helm template test helm/falkordb-browser \
+            --set encryption.key=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+            --show-only templates/secret.yaml | grep -q 'ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"'
+
+          echo "Testing existing encryption key Secret reference..."
+          helm template test helm/falkordb-browser \
+            --set encryption.existingSecret.name=existing-encryption-secret \
+            --set encryption.existingSecret.key=key \
+            --show-only templates/deployment.yaml | grep -A 4 'name: ENCRYPTION_KEY' | grep -q 'name: "existing-encryption-secret"'
+
+          if helm template test helm/falkordb-browser \
+            --set encryption.existingSecret.name=existing-encryption-secret \
+            --show-only templates/secret.yaml | grep -q 'ENCRYPTION_KEY:'; then
+            echo "Chart-managed Secret should not include ENCRYPTION_KEY when an existing Secret is configured"
+            exit 1
+          fi
+
+          echo "Testing conflicting encryption key settings rejection..."
+          if helm template test helm/falkordb-browser \
+            --set encryption.existingSecret.name=existing-encryption-secret \
+            --set encryption.key=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+            > /dev/null 2>&1; then
+            echo "encryption.key and encryption.existingSecret.name should be mutually exclusive"
+            exit 1
+          fi
+
+          echo "Testing invalid encryption key rejection..."
+          if helm template test helm/falkordb-browser --set encryption.key=bad-key > /dev/null 2>&1; then
+            echo "Invalid ENCRYPTION_KEY should fail Helm rendering"
+            exit 1
+          fi
           
           echo "✅ All configuration tests passed"
 

--- a/helm/falkordb-browser/README.md
+++ b/helm/falkordb-browser/README.md
@@ -70,6 +70,9 @@ The following table lists the configurable parameters of the FalkorDB Browser ch
 | `image.tag` | Image tag | `""` (uses chart appVersion) |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `browser.basePath` | Path prefix for hosting the browser, for example `/browser` | `""` |
+| `encryption.key` | 64-character hex key for server-side encryption. Generated and reused from the release Secret when empty. | `""` |
+| `encryption.existingSecret.name` | Existing Secret name for `ENCRYPTION_KEY`. Mutually exclusive with `encryption.key`. | `""` |
+| `encryption.existingSecret.key` | Key in `encryption.existingSecret.name` that contains the encryption key. | `ENCRYPTION_KEY` |
 | `service.type` | Kubernetes service type | `ClusterIP` |
 | `service.port` | Service port for browser | `3000` |
 | `service.restPort` | Service port for REST API | `8080` |
@@ -208,6 +211,32 @@ persistence:
 env:
   nextauthSecret: "your-secure-secret-here"
 ```
+
+### Encryption key management
+
+`ENCRYPTION_KEY` is required by the browser for server-side encryption of stored credentials and tokens. The key must be 64 hexadecimal characters (32 bytes).
+
+By default, the chart generates a random key and stores it in the release Secret as `ENCRYPTION_KEY`. On upgrades, the chart reuses the existing Secret value so restarted or rescheduled containers keep using the same key.
+
+To supply your own key:
+
+```bash
+helm install falkordb-browser ./falkordb-browser \
+  --set encryption.key="$(openssl rand -hex 32)"
+```
+
+To reference an existing Secret in the release namespace instead:
+
+```bash
+kubectl create secret generic falkordb-browser-encryption \
+  --from-literal=ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
+helm install falkordb-browser ./falkordb-browser \
+  --set encryption.existingSecret.name=falkordb-browser-encryption \
+  --set encryption.existingSecret.key=ENCRYPTION_KEY
+```
+
+Do not rotate this key unless you are prepared to invalidate or migrate data encrypted with the previous key.
 
 ### Installation with resource limits
 

--- a/helm/falkordb-browser/README.md
+++ b/helm/falkordb-browser/README.md
@@ -218,6 +218,8 @@ env:
 
 By default, the chart generates a random key and stores it in the release Secret as `ENCRYPTION_KEY`. On upgrades, the chart reuses the existing Secret value so restarted or rescheduled containers keep using the same key.
 
+Preserve or restore the same `ENCRYPTION_KEY` across upgrades, reinstalls, and chart-managed Secret recreation. If the release Secret is deleted or the chart is reinstalled without the previous key, the chart generates a new key and existing encrypted credentials and tokens become unreadable.
+
 To supply your own key:
 
 ```bash

--- a/helm/falkordb-browser/templates/_helpers.tpl
+++ b/helm/falkordb-browser/templates/_helpers.tpl
@@ -102,3 +102,65 @@ Validate that env.nextauthUrl path matches browser.basePath if set.
   {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Return a valid 64-character hexadecimal ENCRYPTION_KEY.
+Uses .Values.encryption.key when set, otherwise reuses the existing release
+Secret value or generates a new key for first install.
+*/}}
+{{- define "falkordb-browser.encryptionKey" -}}
+{{- $providedKey := .Values.encryption.key | default "" -}}
+{{- $existingSecretName := .Values.encryption.existingSecret.name | default "" -}}
+{{- if and $providedKey $existingSecretName -}}
+{{- fail "set either encryption.key or encryption.existingSecret.name, not both" -}}
+{{- end -}}
+{{- if $providedKey -}}
+{{- if not (regexMatch "^[0-9a-fA-F]{64}$" $providedKey) -}}
+{{- fail "encryption.key must be 64 hexadecimal characters (32 bytes)" -}}
+{{- end -}}
+{{- $providedKey -}}
+{{- else -}}
+{{- $secretName := include "falkordb-browser.fullname" . -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $existingKey := "" -}}
+{{- if and $existingSecret (hasKey $existingSecret.data "ENCRYPTION_KEY") -}}
+{{- $existingKey = index $existingSecret.data "ENCRYPTION_KEY" | b64dec -}}
+{{- end -}}
+{{- if $existingKey -}}
+{{- if not (regexMatch "^[0-9a-fA-F]{64}$" $existingKey) -}}
+{{- fail (printf "existing Secret %s ENCRYPTION_KEY must be 64 hexadecimal characters (32 bytes)" $secretName) -}}
+{{- end -}}
+{{- $existingKey -}}
+{{- else -}}
+{{- randBytes 32 | sha256sum -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate existing Secret based ENCRYPTION_KEY configuration.
+*/}}
+{{- define "falkordb-browser.validateEncryptionKeySecret" -}}
+{{- $providedKey := .Values.encryption.key | default "" -}}
+{{- $existingSecretName := .Values.encryption.existingSecret.name | default "" -}}
+{{- $existingSecretKey := .Values.encryption.existingSecret.key | default "ENCRYPTION_KEY" -}}
+{{- $chartSecretName := include "falkordb-browser.fullname" . -}}
+{{- if and $providedKey $existingSecretName -}}
+{{- fail "set either encryption.key or encryption.existingSecret.name, not both" -}}
+{{- end -}}
+{{- if and $existingSecretName (not $existingSecretKey) -}}
+{{- fail "encryption.existingSecret.key is required when encryption.existingSecret.name is set" -}}
+{{- end -}}
+{{- if and $existingSecretName (eq $existingSecretName $chartSecretName) -}}
+{{- fail "encryption.existingSecret.name must reference a Secret not managed by this chart" -}}
+{{- end -}}
+{{- if $existingSecretName -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
+{{- if and $existingSecret (hasKey $existingSecret.data $existingSecretKey) -}}
+{{- $existingKey := index $existingSecret.data $existingSecretKey | b64dec -}}
+{{- if not (regexMatch "^[0-9a-fA-F]{64}$" $existingKey) -}}
+{{- fail (printf "existing Secret %s key %s must be 64 hexadecimal characters (32 bytes)" $existingSecretName $existingSecretKey) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/helm/falkordb-browser/templates/_helpers.tpl
+++ b/helm/falkordb-browser/templates/_helpers.tpl
@@ -143,21 +143,26 @@ Validate existing Secret based ENCRYPTION_KEY configuration.
 {{- define "falkordb-browser.validateEncryptionKeySecret" -}}
 {{- $providedKey := .Values.encryption.key | default "" -}}
 {{- $existingSecretName := .Values.encryption.existingSecret.name | default "" -}}
-{{- $existingSecretKey := .Values.encryption.existingSecret.key | default "ENCRYPTION_KEY" -}}
+{{- $rawExistingSecretKey := .Values.encryption.existingSecret.key -}}
 {{- $chartSecretName := include "falkordb-browser.fullname" . -}}
 {{- if and $providedKey $existingSecretName -}}
 {{- fail "set either encryption.key or encryption.existingSecret.name, not both" -}}
 {{- end -}}
-{{- if and $existingSecretName (not $existingSecretKey) -}}
+{{- if and $existingSecretName (not $rawExistingSecretKey) -}}
 {{- fail "encryption.existingSecret.key is required when encryption.existingSecret.name is set" -}}
 {{- end -}}
 {{- if and $existingSecretName (eq $existingSecretName $chartSecretName) -}}
 {{- fail "encryption.existingSecret.name must reference a Secret not managed by this chart" -}}
 {{- end -}}
 {{- if $existingSecretName -}}
+{{- $existingSecretKey := $rawExistingSecretKey | default "ENCRYPTION_KEY" -}}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
-{{- if and $existingSecret (hasKey $existingSecret.data $existingSecretKey) -}}
-{{- $existingKey := index $existingSecret.data $existingSecretKey | b64dec -}}
+{{- if $existingSecret -}}
+{{- $existingSecretData := $existingSecret.data | default dict -}}
+{{- if not (hasKey $existingSecretData $existingSecretKey) -}}
+{{- fail (printf "existing Secret %s must contain key %s" $existingSecretName $existingSecretKey) -}}
+{{- end -}}
+{{- $existingKey := index $existingSecretData $existingSecretKey | b64dec -}}
 {{- if not (regexMatch "^[0-9a-fA-F]{64}$" $existingKey) -}}
 {{- fail (printf "existing Secret %s key %s must be 64 hexadecimal characters (32 bytes)" $existingSecretName $existingSecretKey) -}}
 {{- end -}}

--- a/helm/falkordb-browser/templates/deployment.yaml
+++ b/helm/falkordb-browser/templates/deployment.yaml
@@ -53,16 +53,22 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "falkordb-browser.fullname" . }}
-        - secretRef:
-            name: {{ include "falkordb-browser.fullname" . }}
-        {{- if .Values.encryption.existingSecret.name }}
         env:
+        - name: NEXTAUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "falkordb-browser.fullname" . }}
+              key: NEXTAUTH_SECRET
         - name: ENCRYPTION_KEY
           valueFrom:
             secretKeyRef:
+              {{- if .Values.encryption.existingSecret.name }}
               name: {{ .Values.encryption.existingSecret.name | quote }}
               key: {{ .Values.encryption.existingSecret.key | default "ENCRYPTION_KEY" | quote }}
-        {{- end }}
+              {{- else }}
+              name: {{ include "falkordb-browser.fullname" . }}
+              key: ENCRYPTION_KEY
+              {{- end }}
         livenessProbe:
           {{- toYaml .Values.livenessProbe | nindent 12 }}
         readinessProbe:

--- a/helm/falkordb-browser/templates/deployment.yaml
+++ b/helm/falkordb-browser/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{ include "falkordb-browser.validateNextAuthUrl" . }}
+{{ include "falkordb-browser.validateEncryptionKeySecret" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,6 +55,14 @@ spec:
             name: {{ include "falkordb-browser.fullname" . }}
         - secretRef:
             name: {{ include "falkordb-browser.fullname" . }}
+        {{- if .Values.encryption.existingSecret.name }}
+        env:
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.encryption.existingSecret.name | quote }}
+              key: {{ .Values.encryption.existingSecret.key | default "ENCRYPTION_KEY" | quote }}
+        {{- end }}
         livenessProbe:
           {{- toYaml .Values.livenessProbe | nindent 12 }}
         readinessProbe:

--- a/helm/falkordb-browser/templates/secret.yaml
+++ b/helm/falkordb-browser/templates/secret.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "falkordb-browser.fullname" . }}
   labels:
     {{- include "falkordb-browser.labels" . | nindent 4 }}
+{{ include "falkordb-browser.validateEncryptionKeySecret" . }}
 type: Opaque
 stringData:
   NEXTAUTH_SECRET: {{ .Values.env.nextauthSecret | quote }}
+  {{- if not .Values.encryption.existingSecret.name }}
+  ENCRYPTION_KEY: {{ include "falkordb-browser.encryptionKey" . | quote }}
+  {{- end }}

--- a/helm/falkordb-browser/values.yaml
+++ b/helm/falkordb-browser/values.yaml
@@ -21,8 +21,10 @@ browser:
 
 encryption:
   # Server-side encryption key for stored credentials and tokens.
-  # Must be 64 hexadecimal characters (32 bytes). If empty, the chart generates
-  # one and reuses the existing Secret value on upgrades.
+  # Precedence is: existingSecret.name, then key, then a generated key. Set only
+  # one of existingSecret.name or key. Generated keys are reused from the release
+  # Secret on upgrades.
+  # Must be 64 hexadecimal characters (32 bytes).
   # You can generate one with: openssl rand -hex 32
   key: ""
   # Use an existing Secret in the release namespace for ENCRYPTION_KEY instead

--- a/helm/falkordb-browser/values.yaml
+++ b/helm/falkordb-browser/values.yaml
@@ -19,6 +19,18 @@ browser:
   # Images must be built with the same NEXT_PUBLIC_BASE_PATH value.
   basePath: ""
 
+encryption:
+  # Server-side encryption key for stored credentials and tokens.
+  # Must be 64 hexadecimal characters (32 bytes). If empty, the chart generates
+  # one and reuses the existing Secret value on upgrades.
+  # You can generate one with: openssl rand -hex 32
+  key: ""
+  # Use an existing Secret in the release namespace for ENCRYPTION_KEY instead
+  # of setting encryption.key or generating a key in the chart Secret.
+  existingSecret:
+    name: ""
+    key: "ENCRYPTION_KEY"
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
- Implement validation for encryption key settings in templates.
- Update README with encryption key configuration details.
- Modify deployment and secret templates to support existing encryption keys.
- Enhance CI/CD workflow to test encryption key generation and validation.
fix #1795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add encryption key configuration: supply a custom 64-hex key, reference an existing Kubernetes Secret, or rely on an automatically generated key that’s preserved across upgrades.

* **Documentation**
  * Document encryption key management, 64-hex requirement, precedence rules, how to supply/reference keys, and rotation guidance.

* **Tests**
  * Add validation tests for key format, existing-secret handling, and mutual-exclusivity between custom key and referenced secret.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-browser/pull/1796?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->