### PR TITLE
1790 revert changes - allow browser to be served on a sub path

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -56,7 +56,7 @@ jobs:
           
           echo "Testing with serviceAccount.create=false..."
           helm template test helm/falkordb-browser --set serviceAccount.create=false > /dev/null
-          
+
           echo "✅ All configuration tests passed"
 
   kind-test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,6 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-ARG NEXT_PUBLIC_BASE_PATH=""
-ENV NEXT_PUBLIC_BASE_PATH=$NEXT_PUBLIC_BASE_PATH
-
 # Disable Next.js telemetry during build and runtime.
 ENV NEXT_TELEMETRY_DISABLED=1
 

--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -6,7 +6,7 @@ import { Check, ChevronDown, LogOut, Plus } from "lucide-react";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/components/ui/use-toast";
-import { securedFetch, setActiveConnectionIdGlobal, withBasePath } from "@/lib/utils";
+import { securedFetch, setActiveConnectionIdGlobal } from "@/lib/utils";
 
 import { ConnectionContext, IndicatorContext, SessionConnection } from "./provider";
 import Button from "./ui/Button";
@@ -69,7 +69,7 @@ export default function ConnectionManager() {
     try {
       // If this is the last connection, sign out instead.
       if (isLast) {
-        await signOut({ callbackUrl: withBasePath("/login") });
+        await signOut({ callbackUrl: "/login" });
         return;
       }
 

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -5,7 +5,7 @@
 import { ArrowUpRight, FileCode, LogOut, Monitor, Moon, Sun, Settings, FunctionSquare, GitGraph } from "lucide-react";
 import { useState, useEffect } from "react";
 import Image from "next/image";
-import { cn, getTheme, withBasePath } from "@/lib/utils";
+import { cn, getTheme } from "@/lib/utils";
 import { useRouter, usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
 import pkg from '@/package.json';
@@ -76,7 +76,7 @@ export default function Navbar({ showUDF }: Props) {
                         href="https://www.falkordb.com"
                         target="_blank" rel="noreferrer"
                     >
-                        <Image style={{ width: 'auto', height: '48px' }} priority src={withBasePath(`/icons/F-${currentTheme}.svg`)} alt="FalkorDB Logo" width={0} height={0} />
+                        <Image style={{ width: 'auto', height: '48px' }} priority src={`/icons/F-${currentTheme}.svg`} alt="FalkorDB Logo" width={0} height={0} />
                     </Link>
                 }
                 <div data-testid="NavigationButtons" className="p-1 flex flex-col items-center gap-2 bg-foreground/5 rounded-lg">
@@ -149,7 +149,7 @@ export default function Navbar({ showUDF }: Props) {
                                 <DropdownMenuSeparator />
                                 <DropdownMenuItem className="focus:bg-transparent">
                                     <a className="flex gap-2 items-center" href="https://discord.com/invite/jyUgBweNQz" target="_blank" rel="noreferrer noreferrer">
-                                        <Image style={{ width: 'auto', height: currentTheme === "dark" ? '14px' : '18px' }} src={withBasePath(`/icons/Discord-${currentTheme}.svg`)} alt="" width={0} height={0} />
+                                        <Image style={{ width: 'auto', height: currentTheme === "dark" ? '14px' : '18px' }} src={`/icons/Discord-${currentTheme}.svg`} alt="" width={0} height={0} />
                                         <span>
                                             Get Support
                                         </span>
@@ -175,7 +175,7 @@ export default function Navbar({ showUDF }: Props) {
                         </VisuallyHidden>
                         <div className="h-full flex flex-col gap-8 max-w-[30rem] p-4">
                             <div className="h-1 grow flex flex-col gap-8 items-center justify-center">
-                                {mounted && currentTheme && <Image style={{ width: 'auto', height: '50px' }} priority src={withBasePath(`/icons/Falkordb-${currentTheme}.svg`)} alt="" width={0} height={0} />}
+                                {mounted && currentTheme && <Image style={{ width: 'auto', height: '50px' }} priority src={`/icons/Falkordb-${currentTheme}.svg`} alt="" width={0} height={0} />}
                                 <h1 className="text-3xl font-bold">We Make AI Reliable</h1>
                                 <p className="text-xl text-center">
                                     Delivering a scalable,

--- a/app/graph/Chat.tsx
+++ b/app/graph/Chat.tsx
@@ -1,4 +1,4 @@
-import { cn, getTheme, Message, toUserFriendlyMessage, withBasePath } from "@/lib/utils";
+import { cn, getTheme, Message, toUserFriendlyMessage } from "@/lib/utils";
 import { memo, useContext, useEffect, useMemo, useRef, useState, useCallback } from "react";
 import MarkdownIt from "markdown-it";
 import DOMPurify from "dompurify";
@@ -263,7 +263,7 @@ export default function Chat({ onClose }: Props) {
         }
 
         try {
-            const response = await fetch(withBasePath("/api/chat"), {
+            const response = await fetch("/api/chat", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -598,7 +598,7 @@ export default function Chat({ onClose }: Props) {
                                     <p className="text-foreground text-sm truncate text-center">{message.role.charAt(0).toUpperCase()}</p>
                                 </div>
                                 : <div className="h-8 w-8 relative">
-                                    {mounted && currentTheme && <Image className="rounded-full" src={withBasePath(`/icons/F-${currentTheme}.svg`)} alt="Assistant" fill />}
+                                    {mounted && currentTheme && <Image className="rounded-full" src={`/icons/F-${currentTheme}.svg`} alt="Assistant" fill />}
                                 </div>;
                             return (
                                 <li

--- a/app/login/LoginPage.tsx
+++ b/app/login/LoginPage.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { FileText } from "lucide-react";
 import { useTheme } from "next-themes";
-import { getTheme, withBasePath } from "@/lib/utils";
+import { getTheme } from "@/lib/utils";
 import LoginForm, { LoginFormCredentials } from "./LoginForm";
 
 export default function LoginPage() {
@@ -60,14 +60,14 @@ export default function LoginPage() {
       throw new Error("Invalid credentials please recheck username and password or your connection settings. Check server logs for more info.");
     }
 
-    router.push(withBasePath("/graph"));
+    router.push("/graph");
   };
 
   return (
     <div className="relative h-full w-full flex flex-col">
       <div className="grow basis-0 flex items-center justify-center overflow-auto">
         <div className="flex flex-col gap-2 items-center max-h-full w-[500px]">
-          {mounted && currentTheme && <Image style={{ width: 'auto', height: '80px' }} priority src={withBasePath(`/icons/Browser-${currentTheme}.svg`)} alt="FalkorDB Browser Logo" width={0} height={0} />}
+          {mounted && currentTheme && <Image style={{ width: 'auto', height: '80px' }} priority src={`/icons/Browser-${currentTheme}.svg`} alt="FalkorDB Browser Logo" width={0} height={0} />}
           <LoginForm
             onSubmit={handleLogin}
             submitButtonLabel="Log in"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import Spinning from "@/app/components/ui/spinning";
 import Image from "next/image";
 import pkg from '@/package.json';
 import { useTheme } from "next-themes";
-import { getTheme, withBasePath } from "@/lib/utils";
+import { getTheme } from "@/lib/utils";
 import { useEffect, useState } from "react";
 
 export default function Home() {
@@ -19,7 +19,7 @@ export default function Home() {
   return (
     <div className="h-full w-full bg-background flex flex-col gap-4">
       <main className="grow flex flex-col gap-10 items-center justify-center">
-        {mounted && currentTheme && <Image style={{ width: 'auto', height: '100px' }} priority src={withBasePath(`/icons/Browser-${currentTheme}.svg`)} alt="FalkorDB Logo" width={0} height={0} />}
+        {mounted && currentTheme && <Image style={{ width: 'auto', height: '100px' }} priority src={`/icons/Browser-${currentTheme}.svg`} alt="FalkorDB Logo" width={0} height={0} />}
         <Spinning />
       </main>
       <div className="flex flex-col gap-8 justify-center items-center">

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,7 +3,7 @@
 import { SessionProvider, useSession } from "next-auth/react";
 import { ThemeProvider } from 'next-themes';
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { fetchOptions, getDefaultQuery, getQueryWithLimit, getSSEGraphResult, prepareArg, securedFetch, setActiveConnectionIdGlobal, getActiveConnectionIdGlobal, Tab, getMemoryUsage, GraphRef, ConnectionType, ConnectionInfo, UDFEntry, UDFEntryWithCode, getMetaStats, HistoryQuery, GraphData, Label, Relationship, Query, Data, MemoryValue, SyntaxErrorInfo, parseSyntaxError, withBasePath } from "@/lib/utils";
+import { fetchOptions, getDefaultQuery, getQueryWithLimit, getSSEGraphResult, prepareArg, securedFetch, setActiveConnectionIdGlobal, getActiveConnectionIdGlobal, Tab, getMemoryUsage, GraphRef, ConnectionType, ConnectionInfo, UDFEntry, UDFEntryWithCode, getMetaStats, HistoryQuery, GraphData, Label, Relationship, Query, Data, MemoryValue, SyntaxErrorInfo, parseSyntaxError } from "@/lib/utils";
 import { serverEncrypt, serverDecrypt, isLegacyEncrypted, legacyDecrypt, clearLegacyEncryptionKey } from "@/lib/server-encryption";
 import { getConnectionItem, setConnectionItem, removeConnectionItem, setConnectionPrefix, clearConnectionPrefix, migrateToScopedStorage } from "@/lib/connection-storage";
 import { usePathname, useRouter } from "next/navigation";
@@ -586,7 +586,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     // where activeConnectionId is null on page load and the check never fires.
     (async () => {
       try {
-        const result = await fetch(withBasePath("/api/DBVersion"), { method: "GET" });
+        const result = await fetch("/api/DBVersion", { method: "GET" });
         if (!result.ok) {
           setShowMemoryUsage(false);
           return;
@@ -861,7 +861,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     if (status !== "authenticated") return;
     // Use plain fetch with no X-Connection-Id — server resolves via JWT.
     (async () => {
-      const res = await fetch(withBasePath("/api/udf"), { method: "GET" });
+      const res = await fetch("/api/udf", { method: "GET" });
       if (!res.ok) { setShowUDF(false); return; }
 
       const json = await res.json();

--- a/app/settings/Configurations.tsx
+++ b/app/settings/Configurations.tsx
@@ -6,7 +6,7 @@
 "use client";
 
 import { useEffect, useState, useContext } from "react";
-import { prepareArg, securedFetch, Row, DataCell, withBasePath } from "@/lib/utils";
+import { prepareArg, securedFetch, Row, DataCell } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import TableComponent from "../components/TableComponent";
 import ToastButton from "../components/ToastButton";
@@ -217,7 +217,7 @@ export default function Configurations() {
         // The server uses session.activeConnectionId from the JWT as the
         // authoritative connection (set by every handleSelect call), so
         // this is always correct regardless of client-side global state.
-        const result = await fetch(withBasePath("/api/graph/config"), { method: "GET" });
+        const result = await fetch("/api/graph/config", { method: "GET" });
         if (!result.ok) {
             const body = await result.text().catch(() => "");
             let message = "Failed to load DB configurations";

--- a/app/settings/users/Users.tsx
+++ b/app/settings/users/Users.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect, useState, useContext, useCallback } from "react";
 import { CreateUser, User } from "@/app/api/user/model";
-import { prepareArg, securedFetch, Row, ToastFn, withBasePath } from "@/lib/utils";
+import { prepareArg, securedFetch, Row, ToastFn } from "@/lib/utils";
 import TableComponent from "@/app/components/TableComponent";
 import { useToast } from "@/components/ui/use-toast";
 import { IndicatorContext, ConnectionContext } from "@/app/components/provider";
@@ -32,7 +32,7 @@ export default function Users() {
             // Use plain fetch with no X-Connection-Id header.
             // The server resolves the correct connection via session.activeConnectionId
             // from the JWT (updated by every handleSelect call).
-            const result = await fetch(withBasePath("/api/user"), { method: 'GET' });
+            const result = await fetch("/api/user", { method: 'GET' });
             if (!result.ok) return;
             const data = await result.json();
             setUsers(data.result.map((user: User) => ({ ...user, selected: false })));

--- a/helm/falkordb-browser/README.md
+++ b/helm/falkordb-browser/README.md
@@ -69,14 +69,12 @@ The following table lists the configurable parameters of the FalkorDB Browser ch
 | `image.repository` | Image repository | `falkordb/falkordb-browser` |
 | `image.tag` | Image tag | `""` (uses chart appVersion) |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
-| `browser.basePath` | Path prefix for hosting the browser, for example `/browser` | `""` |
 | `service.type` | Kubernetes service type | `ClusterIP` |
 | `service.port` | Service port for browser | `3000` |
 | `service.restPort` | Service port for REST API | `8080` |
 | `service.mcpPort` | Service port for MCP | `3001` |
 | `ingress.enabled` | Enable ingress | `false` |
 | `ingress.className` | Ingress class name | `""` |
-| `ingress.rewriteRootToBasePath` | Rewrite ingress path `/` to `browser.basePath` if set (required for sub-path hosting) | `false` |
 | `ingress.hosts` | Ingress hosts configuration | `[{host: falkordb-browser.local, paths: [{path: /, pathType: ImplementationSpecific}]}]` |
 | `ingress.tls` | Ingress TLS configuration | `[]` |
 | `resources` | CPU/Memory resource requests/limits | `{}` |
@@ -134,68 +132,6 @@ Install:
 ```bash
 helm install falkordb-browser ./falkordb-browser -f ingress-values.yaml
 ```
-
-### Installation Under a Path Prefix (Sub-path Hosting)
-
-To host the full browser under a subpath such as `/browser`, you must:
-
-1. **Build the image with the base path:**
-
-    `NEXT_PUBLIC_BASE_PATH` is a Next.js build-time setting. The running container must use an image built with the same path as `browser.basePath`; do not change this value only at deployment time.
-
-   ```bash
-   docker build \
-     --build-arg NEXT_PUBLIC_BASE_PATH=/browser \
-     -t your-registry/falkordb-browser:browser-path .
-   ```
-
-2. **Set the base path and ingress rewrite in your values:**
-
-   ```yaml
-   image:
-     repository: your-registry/falkordb-browser
-     tag: browser-path
-
-   browser:
-     basePath: /browser
-
-   ingress:
-     enabled: true
-     className: nginx
-     rewriteRootToBasePath: true  # Required for sub-path hosting
-     hosts:
-       - host: falkordb-browser.example.com
-         paths:
-           - path: /
-             pathType: Prefix
-
-   env:
-     nextauthUrl: https://falkordb-browser.example.com/browser
-     nextauthSecret: "your-secure-secret-here"
-   ```
-
-3. **Ingress/proxy routing:**
-
-    You must route both the app route `${browser.basePath}/*` and the auth callback route `${browser.basePath}/api/auth/*` to the app service. A single prefix route such as `/browser` is sufficient only if your ingress/proxy forwards all nested paths under that prefix, including `/browser/api/auth/*`. For example, in NGINX:
-
-   ```nginx
-   location /browser/ {
-     proxy_pass http://falkordb-browser-service;
-   }
-   location /browser/api/auth/ {
-     proxy_pass http://falkordb-browser-service;
-   }
-   ```
-
-    > **Note:** Auth/session callbacks must be reachable at `${browser.basePath}/api/auth/*`. If ingress/proxy does not forward this path, login/logout will fail even when the main app route loads.
-
-4. **Validation:**
-
-   The chart will fail to render if `env.nextauthUrl`'s path does not match `browser.basePath`.
-
-5. **Migration:**
-
-   The chart no longer rewrites ingress `/` to the base path by default. Set `ingress.rewriteRootToBasePath: true` to enable this for sub-path hosting. Review your ingress rules if upgrading.
 
 ### Installation with persistence
 

--- a/helm/falkordb-browser/templates/_helpers.tpl
+++ b/helm/falkordb-browser/templates/_helpers.tpl
@@ -4,7 +4,6 @@ Expand the name of the chart.
 {{- define "falkordb-browser.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
-
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -59,46 +58,4 @@ Create the name of the service account to use
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
-{{- end }}
-
-{{/*
-Normalize the optional browser base path used when hosting the app under a subpath.
-*/}}
-{{- define "falkordb-browser.basePath" -}}
-{{- $rawBasePath := default "" .Values.browser.basePath -}}
-{{- $basePath := trim $rawBasePath -}}
-{{- if and $basePath (ne $basePath "/") -}}
-{{- if or (ne $basePath $rawBasePath) (regexMatch "\\s" $basePath) -}}
-{{- fail "browser.basePath must not contain whitespace" -}}
-{{- end -}}
-{{- if not (hasPrefix "/" $basePath) -}}
-{{- fail "browser.basePath must start with /" -}}
-{{- end -}}
-{{- $basePath = trimSuffix "/" $basePath -}}
-{{- if contains "//" $basePath -}}
-{{- fail "browser.basePath must not contain empty path segments" -}}
-{{- end -}}
-{{- $basePath -}}
-{{- end -}}
-{{- end }}
-
-{{/*
-Validate that env.nextauthUrl path matches browser.basePath if set.
-*/}}
-{{- define "falkordb-browser.validateNextAuthUrl" -}}
-{{- $basePath := include "falkordb-browser.basePath" . -}}
-{{- $nextauthUrl := .Values.env.nextauthUrl | default "" -}}
-{{- if and $basePath $nextauthUrl (ne $basePath "") (ne $basePath "/") -}}
-  {{- $requiredMessage := printf "env.nextauthUrl must be an absolute http(s) URL whose path matches browser.basePath (%s), for example https://host%s" $basePath $basePath -}}
-  {{- if not (regexMatch "^https?://[^/?#]+(/[^?#]*)?([?#].*)?$" $nextauthUrl) -}}
-    {{- fail $requiredMessage -}}
-  {{- end -}}
-  {{- $urlPath := regexReplaceAll "^https?://[^/?#]+([^?#]*).*$" $nextauthUrl "${1}" | trimSuffix "/" -}}
-  {{- if eq $urlPath "" -}}
-    {{- fail $requiredMessage -}}
-  {{- end -}}
-  {{- if ne $urlPath $basePath -}}
-    {{- fail (printf "env.nextauthUrl path (%s) must match browser.basePath (%s) when basePath is set" $urlPath $basePath) -}}
-  {{- end -}}
-{{- end -}}
 {{- end }}

--- a/helm/falkordb-browser/templates/configmap.yaml
+++ b/helm/falkordb-browser/templates/configmap.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ include "falkordb-browser.fullname" . }}
   labels:
     {{- include "falkordb-browser.labels" . | nindent 4 }}
-{{ include "falkordb-browser.validateNextAuthUrl" . }}
 data:
   CHAT_URL: {{ .Values.env.chatUrl | quote }}
   NEXTAUTH_URL: {{ .Values.env.nextauthUrl | quote }}

--- a/helm/falkordb-browser/templates/deployment.yaml
+++ b/helm/falkordb-browser/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{ include "falkordb-browser.validateNextAuthUrl" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/falkordb-browser/templates/ingress.yaml
+++ b/helm/falkordb-browser/templates/ingress.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "falkordb-browser.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- $basePath := include "falkordb-browser.basePath" . -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -43,11 +42,7 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          {{- $path := .path }}
-          {{- if and $basePath (eq $path "/") $.Values.ingress.rewriteRootToBasePath }}
-          {{- $path = $basePath }}
-          {{- end }}
-          - path: {{ $path }}
+          - path: {{ .path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
             {{- end }}

--- a/helm/falkordb-browser/values.yaml
+++ b/helm/falkordb-browser/values.yaml
@@ -14,11 +14,6 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-browser:
-  # Host the browser under a path prefix such as /browser.
-  # Images must be built with the same NEXT_PUBLIC_BASE_PATH value.
-  basePath: ""
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -60,9 +55,6 @@ service:
 ingress:
   enabled: false
   className: ""
-  # If true, rewrite any ingress rule with path: / to browser.basePath (if set).
-  # This is required for sub-path hosting but is off by default for backward compatibility.
-  rewriteRootToBasePath: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/lib/server-encryption.ts
+++ b/lib/server-encryption.ts
@@ -4,15 +4,13 @@
  * Includes legacy migration support for old client-side encrypted values.
  */
 
-import { withBasePath } from './utils';
-
 const LEGACY_ENCRYPTED_PREFIX = 'enc:';
 const LEGACY_KEY_STORAGE_KEY = 'falkordb-key';
 
 export async function serverEncrypt(value: string): Promise<string> {
   if (!value) return '';
 
-  const res = await fetch(withBasePath('/api/encrypt'), {
+  const res = await fetch('/api/encrypt', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ value, action: 'encrypt' }),
@@ -29,7 +27,7 @@ export async function serverEncrypt(value: string): Promise<string> {
 export async function serverDecrypt(encryptedValue: string): Promise<string> {
   if (!encryptedValue) return '';
 
-  const res = await fetch(withBasePath('/api/encrypt'), {
+  const res = await fetch('/api/encrypt', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ value: encryptedValue, action: 'decrypt' }),

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -243,43 +243,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-function normalizeAppBasePath(value: string): string {
-  const normalized = value.trim();
-  if (!normalized || normalized === "/") return "";
-  if (normalized !== value || /\s/.test(normalized)) {
-    throw new Error("NEXT_PUBLIC_BASE_PATH must not contain whitespace");
-  }
-  if (!normalized.startsWith("/")) {
-    throw new Error("NEXT_PUBLIC_BASE_PATH must be empty, /, or start with /");
-  }
-  const basePath = normalized.replace(/\/$/, "");
-  if (basePath.includes("//")) {
-    throw new Error("NEXT_PUBLIC_BASE_PATH must not contain empty path segments");
-  }
-  return basePath;
-}
-
-const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
-export const appBasePath = normalizeAppBasePath(rawBasePath);
-
-export function withBasePath(url: string): string {
-  if (!appBasePath || url.startsWith("//") || /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url)) return url;
-
-  // Already prefixed with basePath
-  if (url === appBasePath || url.startsWith(`${appBasePath}/`)) return url;
-
-  // Relative URLs: trim leading './' and prefix with basePath
-  if (url.startsWith("/")) return `${appBasePath}${url}`;
-  if (url.startsWith("./")) return `${appBasePath}/${url.slice(2)}`;
-  if (url.startsWith("api/")) return `${appBasePath}/${url}`;
-
-  // For other relative URLs (without leading / or ./), prefix with basePath
-  if (!url.startsWith("#") && url.length > 0) return `${appBasePath}/${url}`;
-
-  // Fragments and empty strings pass through unchanged
-  return url;
-}
-
 export async function getSSEGraphResult(
   url: string,
   toast: ToastFn,
@@ -295,7 +258,7 @@ export async function getSSEGraphResult(
       effectiveUrl += `${sep}connectionId=${encodeURIComponent(_activeConnectionId)}`;
     }
 
-    const evtSource = new EventSource(withBasePath(effectiveUrl));
+    const evtSource = new EventSource(effectiveUrl);
     evtSource.addEventListener("result", (event: MessageEvent) => {
       const result = JSON.parse(event.data);
       evtSource.close();
@@ -554,7 +517,7 @@ let sessionInvalidationInFlight = false;
 function triggerSessionInvalidationSignOut(): void {
   if (sessionInvalidationInFlight) return;
   sessionInvalidationInFlight = true;
-  signOut({ callbackUrl: withBasePath("/login") }).catch(() => {
+  signOut({ callbackUrl: "/login" }).catch(() => {
     sessionInvalidationInFlight = false;
   });
 }
@@ -598,7 +561,7 @@ export async function securedFetch(
   }
   effectiveInit.headers = existingHeaders;
 
-  const response = await fetch(withBasePath(input), effectiveInit);
+  const response = await fetch(input, effectiveInit);
   const { status } = response;
 
   // The server signals "your session is orphaned, sign out now" via this
@@ -746,7 +709,7 @@ export const getMemoryUsage = async (
     if (effectiveConnId) {
       headers.set("X-Connection-Id", effectiveConnId);
     }
-    const result = await fetch(withBasePath(`/api/graph/${prepareArg(name)}/memory`), { headers });
+    const result = await fetch(`/api/graph/${prepareArg(name)}/memory`, { headers });
     if (!result.ok) return new Map();
     const json = await result.json();
     return processEntries(json.result);

--- a/next.config.js
+++ b/next.config.js
@@ -1,30 +1,7 @@
 /** @type {import('next').NextConfig} */
 const path = require('path');
 
-function normalizeBasePath(value) {
-  const normalized = (value || '').trim();
-  if (!normalized || normalized === '/') return '';
-
-  if (normalized !== value || /\s/.test(normalized)) {
-    throw new Error('NEXT_PUBLIC_BASE_PATH must not contain whitespace');
-  }
-
-  if (!normalized.startsWith('/')) {
-    throw new Error('NEXT_PUBLIC_BASE_PATH must be empty, /, or start with /');
-  }
-
-  const basePath = normalized.replace(/\/$/, '');
-  if (basePath.includes('//')) {
-    throw new Error('NEXT_PUBLIC_BASE_PATH must not contain empty path segments');
-  }
-
-  return basePath;
-}
-
-const basePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH);
-
 const nextConfig = {
-  basePath,
   allowedDevOrigins: ['127.0.0.1', '0.0.0.0'],
   output: 'standalone',
   reactStrictMode: true,


### PR DESCRIPTION
revert #1790 
reverting the changes as there's no way to fully perform this in a clean manner. NextJS apps must be served at the root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed support for sub-path deployments. The application now requires root-path hosting only.

* **Documentation**
  * Removed sub-path hosting documentation and configuration examples from Helm chart README.

* **Chores**
  * Simplified Helm chart configuration by removing `browser.basePath` and `ingress.rewriteRootToBasePath` settings.
  * Updated deployment configurations to reflect root-path-only requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-browser/pull/1797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->