### PR TITLE
Improve release image build resilience

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -43,6 +43,7 @@ jobs:
   build-and-push:
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: amd64
@@ -84,6 +85,8 @@ jobs:
           tags: ${{ env.ARCH_TAGS }}
           build-args: |
             CYPHER_VERSION=${{ env.CYPHER_VERSION }}
+          cache-from: type=gha,scope=falkordb-browser-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=falkordb-browser-${{ matrix.arch }}
 
       - name: Run Trivy vulnerability scanner
         if: matrix.arch == 'amd64'

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -86,7 +86,7 @@ jobs:
           build-args: |
             CYPHER_VERSION=${{ env.CYPHER_VERSION }}
           cache-from: type=gha,scope=falkordb-browser-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=falkordb-browser-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,ignore-error=true,scope=falkordb-browser-${{ matrix.arch }}
 
       - name: Run Trivy vulnerability scanner
         if: matrix.arch == 'amd64'


### PR DESCRIPTION
## Summary
- Adds `fail-fast: false` to the release image architecture matrix so one runner interruption does not cancel the sibling architecture build.
- Enables per-architecture GitHub Actions BuildKit cache for `docker/build-push-action` to shorten rebuilds and reduce exposure to runner instability.

## Validation
- YAML syntax check for `.github/workflows/release-image.yml`
- `git diff --check`
- Rubber-duck review found no blocking issues; noted that this reduces impact/rebuild time but cannot prevent a GitHub-hosted runner shutdown itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker image build process with enhanced build-cache persistence and more resilient matrix builds to reduce build failures and speed up CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->