### PR TITLE
fix(export): return DUMP payload as Buffer to preserve binary bytes

### DIFF
--- a/app/api/graph/[graph]/export/route.ts
+++ b/app/api/graph/[graph]/export/route.ts
@@ -1,5 +1,6 @@
 import { getClient } from "@/app/api/auth/[...nextauth]/options";
 import { NextRequest, NextResponse } from "next/server";
+import { RESP_TYPES } from "@redis/client";
 import { getCorsHeaders } from "../../../utils";
 
 // eslint-disable-next-line import/prefer-default-export
@@ -18,18 +19,23 @@ export async function GET(
     const { graph: graphId } = await params;
 
     try {
-      const result = await (
-        await client.connection
-      ).dump(graphId);
+      // DUMP returns a binary BLOB_STRING. Without this type mapping,
+      // node-redis decodes it as UTF-8, corrupting any byte that isn't
+      // a valid UTF-8 sequence — which breaks RESTORE round-trips.
+      const connection = (await client.connection).withTypeMapping({
+        [RESP_TYPES.BLOB_STRING]: Buffer,
+      });
+      const result = await connection.dump(graphId);
 
-      if (!result)
+      if (!result || !Buffer.isBuffer(result))
         throw new Error(`Failed to retrieve graph data for ID: ${graphId}`);
 
-      return new NextResponse(result, {
+      return new NextResponse(new Uint8Array(result), {
         status: 200,
         headers: {
           ...getCorsHeaders(request),
           "Content-Type": "application/octet-stream",
+          "Content-Length": String(result.byteLength),
           "Content-Disposition": `attachment; filename="${graphId}.dump"`,
         },
       });


### PR DESCRIPTION
## Summary

The graph export route invokes node-redis `DUMP` without a type mapping, so `@redis/client` decodes the `BLOB_STRING` reply as UTF-8. `DUMP` returns an opaque RDB-serialized payload — it almost always contains bytes outside valid UTF-8, so the decode corrupts the binary and the emitted `.dump` file is no longer a valid `RESTORE` payload.

Repro on `staging`: export any graph → attempt to `RESTORE` the file via `redis-cli` or any client → Redis rejects with `DUMP payload version or checksum are wrong`. The export route silently produces garbage; nothing on the read path notices.

## Fix

Apply `withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer })` on the connection used for `DUMP` so the reply arrives as a `Buffer`. Tighten the null guard to `!Buffer.isBuffer(result)`, wrap the response body in `new Uint8Array(...)` for `NextResponse` compatibility, and add `Content-Length`.

```ts
const connection = (await client.connection).withTypeMapping({
  [RESP_TYPES.BLOB_STRING]: Buffer,
});
const result = await connection.dump(graphId);
```

The `withTypeMapping` call returns a typed proxy of the same connection; it does not open a new socket and does not affect any other caller.

## Why this is its own PR

Surfaced during review of #1803 (graph restore). It is independent, mergeable on its own, and required regardless of whether `RESTORE` ever ships in the browser — current `.dump` exports are silently corrupt today.

Once the FalkorDB core `GRAPH.RESTORE` primitive (FalkorDB/FalkorDB#2078) lands, this fix is also the precondition for the round-trip path in #1803 to work.

## Test plan

- [ ] Export a non-trivial graph (with at least one edge) from the browser
- [ ] `redis-cli -x RESTORE <key> 0 < downloaded.dump` against a fresh FalkorDB — should now succeed (currently fails with checksum error on `staging`)
- [ ] `Content-Length` header matches downloaded file size
- [ ] `npx tsc --noEmit` clean on changed files (pre-existing `@falkordb/canvas` errors on `staging` are unrelated)

## Notes

- No new dependencies. `RESP_TYPES` is re-exported from `@redis/client`, which is already a direct dependency.
- No behavior change for existing callers of unrelated routes — the type mapping is scoped to the local `connection` variable in this handler only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed graph export functionality to properly handle binary dump data, including correct encoding and an explicit content length header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->