### PR TITLE
fix: improve timeout handling by fetching server config for TIMEOUT_MAX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG CYPHER_VERSION=latest
 
-FROM node:24-alpine3.23@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS base
+FROM node:24-alpine3.23@sha256:9a2c6269f83d74af45665c0b738b78c7b5f07bf2374c72a4c540065a975b9693 AS base
 
 # Update all Alpine packages to fix security vulnerabilities
 RUN apk upgrade --no-cache --available

--- a/app/api/swagger/swagger-spec.ts
+++ b/app/api/swagger/swagger-spec.ts
@@ -1300,8 +1300,19 @@ const swaggerSpec = {
                   type: "object",
                   properties: {
                     configs: {
-                      type: "object",
-                      description: "Configuration parameters and their values"
+                      type: "array",
+                      description: "Configuration parameters and their values as [name, value] tuples",
+                      items: {
+                        type: "array",
+                        minItems: 2,
+                        maxItems: 2,
+                        items: {
+                          oneOf: [
+                            { type: "string" },
+                            { type: "number" }
+                          ]
+                        }
+                      }
                     }
                   }
                 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -808,7 +808,34 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
         console.error("Failed to parse captions keys from localStorage", error);
         setCaptionsKeys([['name', false], ['title', false]]);
       }
-      setTimeout(parseInt(localStorage.getItem("timeout") || "60", 10));
+      const storedTimeout = localStorage.getItem("timeout");
+      let timeoutVal: number;
+      if (storedTimeout) {
+        timeoutVal = parseInt(storedTimeout, 10);
+      } else {
+        // No user-set value: cap the default (60) with TIMEOUT_MAX from server config
+        let fallback = 60;
+        try {
+          const configRes = await fetch("/api/graph/config", { method: "GET" });
+          if (configRes.ok) {
+            const { configs } = await configRes.json();
+            const timeoutMaxEntry = configs.find((c: [string, string | number]) => c[0] === "TIMEOUT_MAX");
+            if (timeoutMaxEntry) {
+              const timeoutMaxMs = Number(timeoutMaxEntry[1]);
+              if (timeoutMaxMs > 0) {
+                const timeoutMaxSeconds = Math.floor(timeoutMaxMs / 1000);
+                if (fallback > timeoutMaxSeconds) {
+                  fallback = timeoutMaxSeconds;
+                }
+              }
+            }
+          }
+        } catch {
+          // If config fetch fails, use the default as-is
+        }
+        timeoutVal = fallback;
+      }
+      setTimeout(timeoutVal);
       const l = parseInt(localStorage.getItem("limit") || "300", 10);
       setLimit(l);
       setLastLimit(l);

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -811,7 +811,10 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
       const storedTimeout = localStorage.getItem("timeout");
       let timeoutVal: number;
       if (storedTimeout) {
-        timeoutVal = parseInt(storedTimeout, 10);
+        const parsedStoredTimeout = parseInt(storedTimeout, 10);
+        timeoutVal = Number.isFinite(parsedStoredTimeout) && parsedStoredTimeout > 0
+          ? parsedStoredTimeout
+          : 60;
       } else {
         // No user-set value: cap the default (60) with TIMEOUT_MAX from server config
         let fallback = 60;
@@ -819,7 +822,17 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
           const configRes = await fetch("/api/graph/config", { method: "GET" });
           if (configRes.ok) {
             const { configs } = await configRes.json();
-            const timeoutMaxEntry = configs.find((c: [string, string | number]) => c[0] === "TIMEOUT_MAX");
+            const typedConfigs: [string, string | number][] = Array.isArray(configs)
+              ? configs.filter((entry: unknown): entry is [string, string | number] => {
+                return (
+                  Array.isArray(entry)
+                  && entry.length >= 2
+                  && typeof entry[0] === "string"
+                  && (typeof entry[1] === "string" || typeof entry[1] === "number")
+                );
+              })
+              : [];
+            const timeoutMaxEntry = typedConfigs.find((c) => c[0] === "TIMEOUT_MAX");
             if (timeoutMaxEntry) {
               const timeoutMaxMs = Number(timeoutMaxEntry[1]);
               if (timeoutMaxMs > 0) {
@@ -830,8 +843,9 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
               }
             }
           }
-        } catch {
+        } catch (error) {
           // If config fetch fails, use the default as-is
+          console.warn("Failed to fetch /api/graph/config for timeout initialization", error);
         }
         timeoutVal = fallback;
       }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -812,7 +812,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
       let timeoutVal: number;
       if (storedTimeout) {
         const parsedStoredTimeout = parseInt(storedTimeout, 10);
-        timeoutVal = Number.isFinite(parsedStoredTimeout) && parsedStoredTimeout > 0
+        timeoutVal = Number.isFinite(parsedStoredTimeout) && parsedStoredTimeout >= 0
           ? parsedStoredTimeout
           : 60;
       } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout initialization to prefer a saved value when valid; otherwise use the server-configured maximum and gracefully fall back to a safe default on errors.
* **Chores**
  * Standardized server config API response to a predictable name/value array and tightened allowed value types.
  * Updated base image used for builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->