### PR TITLE
Add configurable CSP connect sources

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -14,5 +14,11 @@ ENCRYPTION_KEY="your-64-character-hex-string-here"
 # Example: ALLOWED_ORIGINS=https://example.com,https://app.example.com
 ALLOWED_ORIGINS=http://localhost:3000
 
+# CSP Configuration
+# Comma-separated list of additional http(s) origins the browser app may
+# connect to from the client. Keep this explicit; do not use wildcards.
+# Example: CSP_CONNECT_SRC=https://graphrag.falkordb.com
+CSP_CONNECT_SRC=
+
 # Max number of active connections to FalkorDB instances (LRU cache size)
 MAX_CONNECTION_CACHE_SIZE=100

--- a/proxy.ts
+++ b/proxy.ts
@@ -14,6 +14,13 @@ const rateLimitStore = new Map<string, RateLimitEntry>();
 // Clean up stale entries every 60 seconds
 const CLEANUP_INTERVAL = 60_000;
 let lastCleanup = Date.now();
+const DEFAULT_CONNECT_SRC = [
+    "'self'",
+    "https://cdn.jsdelivr.net",
+    "https://*.google-analytics.com",
+    "https://*.analytics.google.com",
+    "https://*.googletagmanager.com",
+];
 
 function cleanup(windowMs: number) {
     const now = Date.now();
@@ -92,6 +99,30 @@ function getRateLimitConfig(pathname: string): RateLimitConfig | null {
     return null;
 }
 
+function getExtraConnectSrc(): string[] {
+    const raw = process.env.CSP_CONNECT_SRC;
+    if (!raw) return [];
+
+    return raw
+        .split(",")
+        .map(source => source.trim())
+        .filter(Boolean)
+        .map(source => {
+            try {
+                const url = new URL(source);
+                if (url.protocol !== "https:" && url.protocol !== "http:") {
+                    console.warn(`Ignoring invalid CSP_CONNECT_SRC entry with unsupported protocol: ${source}`);
+                    return null;
+                }
+                return url.origin;
+            } catch {
+                console.warn(`Ignoring invalid CSP_CONNECT_SRC entry: ${source}`);
+                return null;
+            }
+        })
+        .filter((source): source is string => Boolean(source));
+}
+
 export function proxy(request: NextRequest) {
     const { pathname } = request.nextUrl;
 
@@ -125,6 +156,7 @@ export function proxy(request: NextRequest) {
     const scriptSrc = isDev
         ? `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'unsafe-eval'`
         : `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`;
+    const connectSrc = [...new Set([...DEFAULT_CONNECT_SRC, ...getExtraConnectSrc()])].join(" ");
 
     const cspHeader = [
         "default-src 'self'",
@@ -132,7 +164,7 @@ export function proxy(request: NextRequest) {
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
         "img-src 'self' data: blob: https://*.googletagmanager.com",
         "font-src 'self' data: https://cdn.jsdelivr.net",
-        "connect-src 'self' https://cdn.jsdelivr.net https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com",
+        `connect-src ${connectSrc}`,
         "worker-src 'self' blob:",
         "object-src 'none'",
         "base-uri 'self'",


### PR DESCRIPTION
## Summary
- Add CSP_CONNECT_SRC support for extra client connect-src origins
- Validate entries as http/https origins and deduplicate them
- Document the env var in .env.local.template

## Validation
- npx tsc --noEmit --pretty false

Note: npm run lint is currently blocked by an existing eslint-plugin-react compatibility error: react/display-name contextOrFilename.getFilename is not a function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Content Security Policy connect-src allowlist through a new `CSP_CONNECT_SRC` environment variable, enabling specification of additional permitted connection origins. Invalid URLs are validated and logged accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->