### PR TITLE
fix(e2e): use data-testid for settings section headers to fix flaky test

### DIFF
--- a/app/settings/browserSettings.tsx
+++ b/app/settings/browserSettings.tsx
@@ -353,6 +353,7 @@ export default function BrowserSettings() {
                 {/* Graph Info Section */}
                 <Card className="border-border shadow-sm">
                     <CardHeader
+                        data-testid="graphInfoSectionHeader"
                         className="cursor-pointer hover:bg-muted/50 transition-colors p-2"
                         role="button"
                         tabIndex={0}
@@ -429,6 +430,7 @@ export default function BrowserSettings() {
                 {/* Query Execution Section */}
                 <Card className="border-border shadow-sm">
                     <CardHeader
+                        data-testid="queryExecutionSectionHeader"
                         className="cursor-pointer hover:bg-muted/50 transition-colors p-2"
                         role="button"
                         tabIndex={0}
@@ -568,6 +570,7 @@ export default function BrowserSettings() {
                 {/* User Experience Section */}
                 <Card className="border-border shadow-sm">
                     <CardHeader
+                        data-testid="userExperienceSectionHeader"
                         className="cursor-pointer hover:bg-muted/50 transition-colors p-2"
                         role="button"
                         tabIndex={0}

--- a/e2e/logic/POM/settingsQueryPage.ts
+++ b/e2e/logic/POM/settingsQueryPage.ts
@@ -8,11 +8,11 @@ import GraphPage from "./graphPage";
 
 export default class SettingsQueryPage extends GraphPage {
   private get queryExecutionSectionHeader(): Locator {
-    return this.page.getByRole("heading", { name: "Query Execution" }).locator("xpath=ancestor::div[@class and contains(@class, 'cursor-pointer')]");
+    return this.page.getByTestId("queryExecutionSectionHeader");
   }
 
   private get userExperienceSectionHeader(): Locator {
-    return this.page.getByRole("heading", { name: "User Experience" }).locator("xpath=ancestor::div[@class and contains(@class, 'cursor-pointer')]");
+    return this.page.getByTestId("userExperienceSectionHeader");
   }
 
   private get limitInput(): Locator {


### PR DESCRIPTION
Replace fragile XPath ancestor locators with stable data-testid attributes. The XPath 'ancestor::div[contains(@class, cursor-pointer)]' was unreliable because multiple section headers share the same cursor-pointer class on the same page (Graph Info, Query Execution, User Experience).

Added data-testid to each CardHeader and updated the POM locators to use getByTestId(), matching the pattern already used for chatSectionHeader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for improved test coverage and reliability on the settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->