### PR TITLE
fix: update base image to use node:24-alpine for consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG CYPHER_VERSION=latest
 
-FROM node:24-alpine AS base
+FROM node:24-alpine3.23@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS base
 
 # Update all Alpine packages to fix security vulnerabilities
 RUN apk upgrade --no-cache --available

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG CYPHER_VERSION=latest
 
-FROM node:24-alpine3.23@sha256:9a2c6269f83d74af45665c0b738b78c7b5f07bf2374c72a4c540065a975b9693 AS base
+FROM node:24-alpine AS base
 
 # Update all Alpine packages to fix security vulnerabilities
 RUN apk upgrade --no-cache --available


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Docker base image reference for the multi-stage container build from a pinned digest to the `node:24-alpine` tag, aligning the image source used during build and runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->