### PR TITLE
chore(deps): bump all dependabot dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "falkordb-browser",
       "version": "2.1.1",
       "dependencies": {
-        "@falkordb/canvas": "v0.1.0",
-        "@falkordb/text-to-cypher": "^0.2.0",
+        "@falkordb/canvas": "v0.2.0",
+        "@falkordb/text-to-cypher": "^0.2.1",
         "@hookform/resolvers": "^5.4.0",
         "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-alert-dialog": "^1.1.17",
@@ -54,7 +54,7 @@
         "jose": "^6.2.3",
         "lodash": "^4.18.0",
         "lru-cache": "^11.5.1",
-        "lucide-react": "^1.21.0",
+        "lucide-react": "^1.22.0",
         "markdown-it": "^14.2.0",
         "monaco-editor": "^0.55.1",
         "next": "^16.2.9",
@@ -70,7 +70,7 @@
         "react-gtm-module": "^2.0.11",
         "react-hook-form": "^7.80.0",
         "react-json-tree": "^0.20.0",
-        "react-resizable-panels": "^4.11.2",
+        "react-resizable-panels": "^4.12.0",
         "swagger-ui-react": "^5.32.8",
         "swr": "^2.4.2",
         "tailwind-merge": "^3.6.0",
@@ -92,7 +92,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/react-gtm-module": "^2.0.4",
         "@types/swagger-ui-react": "^5.18.0",
-        "eslint": "^10.5.0",
+        "eslint": "^10.6.0",
         "eslint-config-next": "^16.2.9",
         "playwright": "^1.61.0",
         "typescript": "^6.0.3"
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@falkordb/canvas": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@falkordb/canvas/-/canvas-0.1.0.tgz",
-      "integrity": "sha512-M4+lXZGq2XrQ0si1h9jp1DUGvY1Fv8MZ8LO9IJ3P3/XXPxLgSHH9sx1WeByCVCOpgQq8rEP9OOax6hR+MbGK0w==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@falkordb/canvas/-/canvas-0.2.0.tgz",
+      "integrity": "sha512-2R2UWrNFv0/dlkVuPT/9Cu1Ww09ksSp/xKJxSHiJcCig0I09JxaWTdPJbW3NXKRsUas4dopCk6miQRbJvMsMyA==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",
@@ -636,9 +636,9 @@
       }
     },
     "node_modules/@falkordb/text-to-cypher": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@falkordb/text-to-cypher/-/text-to-cypher-0.2.0.tgz",
-      "integrity": "sha512-yOUSzI5JAJjK5nytEQzjbH0QdM+lB8ExB6CVA6zMf/VyiX84lXTTz2nD48cm+VP9M+47WSwNQIqOokxNTTCaHw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@falkordb/text-to-cypher/-/text-to-cypher-0.2.1.tgz",
+      "integrity": "sha512-EF4uAx3sMbg/x5OJlcibdu3jHgASJGqC0ZwA8cqwV/a/ugc3BewlkAVjE1GkkEfV59jAYqT5zCHeN5U3z28MMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -6724,9 +6724,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -9317,9 +9317,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
-      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.22.0.tgz",
+      "integrity": "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -10620,9 +10620,9 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.11.2.tgz",
-      "integrity": "sha512-+kfFbDZ8mygc7g0vxOcDzCVGuwiIUOnILqPoUHo6/uP+Mmyx6HzZU+kj1aOPDlktXuobYbr6BtQekvJwHRX4Eg==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.0.tgz",
+      "integrity": "sha512-t/Gp57qSCxGQ52ckhz+8lM7dnuymeU95TEzl2U203qEbGkSLHrtm7US2/ANzq/zOlja3CwPTAfCDuh1unv9mfw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@falkordb/canvas": "v0.1.0",
-    "@falkordb/text-to-cypher": "^0.2.0",
+    "@falkordb/canvas": "v0.2.0",
+    "@falkordb/text-to-cypher": "^0.2.1",
     "@hookform/resolvers": "^5.4.0",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-alert-dialog": "^1.1.17",
@@ -64,7 +64,7 @@
     "jose": "^6.2.3",
     "lodash": "^4.18.0",
     "lru-cache": "^11.5.1",
-    "lucide-react": "^1.21.0",
+    "lucide-react": "^1.22.0",
     "markdown-it": "^14.2.0",
     "monaco-editor": "^0.55.1",
     "next": "^16.2.9",
@@ -80,7 +80,7 @@
     "react-gtm-module": "^2.0.11",
     "react-hook-form": "^7.80.0",
     "react-json-tree": "^0.20.0",
-    "react-resizable-panels": "^4.11.2",
+    "react-resizable-panels": "^4.12.0",
     "swagger-ui-react": "^5.32.8",
     "swr": "^2.4.2",
     "tailwind-merge": "^3.6.0",
@@ -102,7 +102,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/react-gtm-module": "^2.0.4",
     "@types/swagger-ui-react": "^5.18.0",
-    "eslint": "^10.5.0",
+    "eslint": "^10.6.0",
     "eslint-config-next": "^16.2.9",
     "playwright": "^1.61.0",
     "typescript": "^6.0.3"


### PR DESCRIPTION
## Summary

Combines all open Dependabot PRs into a single dependency bump PR.

## Changes

| Package | From | To | Dependabot PR |
|---------|------|----|---------------|
| `eslint` | 10.5.0 | 10.6.0 | #1883 |
| `react-resizable-panels` | 4.11.2 | 4.12.0 | #1882 |
| `@falkordb/canvas` | 0.1.0 | 0.2.0 | #1881 |
| `lucide-react` | 1.21.0 | 1.22.0 | #1880 |
| `@falkordb/text-to-cypher` | 0.2.0 | 0.2.1 | #1879 |

Closes #1879, #1880, #1881, #1882, #1883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several app dependencies to newer versions for improved compatibility and stability.
  * Locked one package to an exact version to ensure more consistent installs and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->