### PR TITLE
fix: address PR #1892 review comments

### DIFF
--- a/app/api/graph/model.ts
+++ b/app/api/graph/model.ts
@@ -1047,12 +1047,13 @@ export class Graph {
               cellContainsElementId(cell, selectedElement.id) &&
               "labels" in cellToCheck
             ) {
-              const newCell = Array.isArray(cell) ? cell.map(c => ({ ...c }) as NodeCell) : { ...cell } as NodeCell;
-              if (Array.isArray(newCell)) {
-                newCell.forEach((c) => { c.labels = c.labels.filter((l) => l !== label); });
-              } else {
-                newCell.labels = newCell.labels.filter((l) => l !== label);
-              }
+              // Use map + spread so only the matching node is updated immutably;
+              // a plain forEach on a shallow copy would mutate all nodes' labels.
+              const newCell = Array.isArray(cell)
+                ? (cell as NodeCell[]).map(c => c.id === selectedElement.id
+                    ? { ...c, labels: c.labels.filter((l: string) => l !== label) }
+                    : { ...c })
+                : { ...cell as NodeCell, labels: (cell as NodeCell).labels.filter((l: string) => l !== label) };
               return [key, newCell];
             }
 
@@ -1138,12 +1139,13 @@ export class Graph {
               cellContainsElementId(cell, selectedElement.id) &&
               "labels" in cellToCheck
             ) {
-              const newCell = Array.isArray(cell) ? cell.map(c => ({ ...c }) as NodeCell) : { ...cell } as NodeCell;
-              if (Array.isArray(newCell)) {
-                newCell.forEach((c) => { c.labels.push(label); });
-              } else {
-                newCell.labels.push(label);
-              }
+              // Spread labels to avoid mutating the original array (shallow copy
+              // of NodeCell keeps the reference); only apply to the matching node.
+              const newCell = Array.isArray(cell)
+                ? (cell as NodeCell[]).map(c => c.id === selectedElement.id
+                    ? { ...c, labels: [...c.labels, label] }
+                    : { ...c })
+                : { ...cell as NodeCell, labels: [...(cell as NodeCell).labels, label] };
               return [key, newCell];
             }
 

--- a/app/api/graph/model.ts
+++ b/app/api/graph/model.ts
@@ -2,7 +2,7 @@
 /* eslint-disable one-var */
 /* eslint-disable no-param-reassign */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Data, getMetaStats, GraphData, InfoLabel, InfoRelationship, Label, Link, LinkCell, MemoryValue, Node, NodeCell, PathCell, Relationship, ToastFn, Value } from "@/lib/utils";
+import { Data, DataCell, getMetaStats, GraphData, InfoLabel, InfoRelationship, Label, Link, LinkCell, MemoryValue, Node, NodeCell, PathCell, Relationship, ToastFn, Value } from "@/lib/utils";
 import { getConnectionItem } from "@/lib/connection-storage";
 
 // Color palette for node customization
@@ -264,6 +264,22 @@ export class GraphInfo {
 
     return newColor;
   }
+}
+
+/** Returns true when a DataCell contains an element with the given id.
+ *  Handles NodeCell, LinkCell, PathCell, and homogeneous arrays of each.
+ *  PathCell members live inside `.nodes[]` / `.edges[]` and have no top-level `id`. */
+function cellContainsElementId(cell: DataCell, elementId: number): boolean {
+  if (!cell || typeof cell !== "object") return false;
+  if (Array.isArray(cell)) return cell.some((c) => cellContainsElementId(c as DataCell, elementId));
+  if ("nodes" in cell && Array.isArray((cell as PathCell).nodes)) {
+    const path = cell as PathCell;
+    return (
+      path.nodes.some((n) => n.id === elementId) ||
+      (path.edges?.some((e) => e.id === elementId) ?? false)
+    );
+  }
+  return "id" in cell && (cell as NodeCell | LinkCell).id === elementId;
 }
 
 export class Graph {
@@ -986,7 +1002,7 @@ export class Graph {
           if (
             cell &&
             typeof cell === "object" &&
-            elements.some((element) => Array.isArray(cell) ? cell.some(c => 'id' in c && c.id === element.id) : 'id' in cell && element.id === cell.id)
+            elements.some((element) => cellContainsElementId(cell, element.id))
           ) {
             return [key, undefined];
           }
@@ -1007,25 +1023,36 @@ export class Graph {
       this.Data = this.Data.map((row) =>
         Object.fromEntries(
           Object.entries(row).map(([key, cell]) => {
+            if (!cell || typeof cell !== "object") return [key, cell];
+
+            // PathCell: update labels on the matching node within the path.
+            if (!Array.isArray(cell) && "nodes" in cell && Array.isArray((cell as PathCell).nodes)) {
+              const path = cell as PathCell;
+              if (!path.nodes.some((n) => n.id === selectedElement.id)) return [key, cell];
+              return [key, {
+                ...path,
+                nodes: path.nodes.map((n) =>
+                  n.id === selectedElement.id
+                    ? { ...n, labels: n.labels.filter((l) => l !== label) }
+                    : n
+                ),
+              }];
+            }
+
+            // NodeCell / NodeCell[] (label edits never apply to LinkCell)
             const cellToCheck = Array.isArray(cell) && cell.length > 0 ? cell[0] : cell;
             if (
-              cell &&
               cellToCheck &&
-              typeof cell === "object" &&
               typeof cellToCheck === "object" &&
-              (Array.isArray(cell) ? cell.some(c => 'id' in c && c.id === selectedElement.id) : 'id' in cell && cell.id === selectedElement.id) &&
+              cellContainsElementId(cell, selectedElement.id) &&
               "labels" in cellToCheck
             ) {
               const newCell = Array.isArray(cell) ? cell.map(c => ({ ...c }) as NodeCell) : { ...cell } as NodeCell;
-
               if (Array.isArray(newCell)) {
-                newCell.forEach((c) => {
-                  c.labels = c.labels.filter((l) => l !== label);
-                });
+                newCell.forEach((c) => { c.labels = c.labels.filter((l) => l !== label); });
               } else {
                 newCell.labels = newCell.labels.filter((l) => l !== label);
               }
-
               return [key, newCell];
             }
 
@@ -1087,25 +1114,36 @@ export class Graph {
       this.Data = this.Data.map((row) =>
         Object.fromEntries(
           Object.entries(row).map(([key, cell]) => {
+            if (!cell || typeof cell !== "object") return [key, cell];
+
+            // PathCell: push the new label onto the matching node within the path.
+            if (!Array.isArray(cell) && "nodes" in cell && Array.isArray((cell as PathCell).nodes)) {
+              const path = cell as PathCell;
+              if (!path.nodes.some((n) => n.id === selectedElement.id)) return [key, cell];
+              return [key, {
+                ...path,
+                nodes: path.nodes.map((n) =>
+                  n.id === selectedElement.id
+                    ? { ...n, labels: [...n.labels, label] }
+                    : n
+                ),
+              }];
+            }
+
+            // NodeCell / NodeCell[]
             const cellToCheck = Array.isArray(cell) && cell.length > 0 ? cell[0] : cell;
             if (
-              cell &&
               cellToCheck &&
-              typeof cell === "object" &&
               typeof cellToCheck === "object" &&
-              (Array.isArray(cell) ? cell.some(c => 'id' in c && c.id === selectedElement.id) : 'id' in cell && cell.id === selectedElement.id) &&
+              cellContainsElementId(cell, selectedElement.id) &&
               "labels" in cellToCheck
             ) {
               const newCell = Array.isArray(cell) ? cell.map(c => ({ ...c }) as NodeCell) : { ...cell } as NodeCell;
-
               if (Array.isArray(newCell)) {
-                newCell.forEach((c) => {
-                  c.labels.push(label);
-                });
+                newCell.forEach((c) => { c.labels.push(label); });
               } else {
                 newCell.labels.push(label);
               }
-
               return [key, newCell];
             }
 
@@ -1158,13 +1196,32 @@ export class Graph {
   public removeProperty(key: string, id: number, type: boolean) {
     this.Data = this.Data.map((row) => {
       const newRow = Object.entries(row).map(([k, cell]) => {
+        if (!cell || typeof cell !== "object") return [k, cell];
+
+        // PathCell: delete the property from the matching node or edge inside the path.
+        if (!Array.isArray(cell) && "nodes" in cell && Array.isArray((cell as PathCell).nodes)) {
+          const path = cell as PathCell;
+          const nodeIdx = path.nodes.findIndex((n) => n.id === id);
+          if (nodeIdx !== -1) {
+            const updatedProps = { ...path.nodes[nodeIdx].properties };
+            delete updatedProps[key];
+            return [k, { ...path, nodes: path.nodes.map((n, i) => i === nodeIdx ? { ...n, properties: updatedProps } : n) }];
+          }
+          const edgeIdx = (path.edges ?? []).findIndex((e) => e.id === id);
+          if (edgeIdx !== -1) {
+            const updatedProps = { ...path.edges![edgeIdx].properties };
+            delete updatedProps[key];
+            return [k, { ...path, edges: path.edges!.map((e, i) => i === edgeIdx ? { ...e, properties: updatedProps } : e) }];
+          }
+          return [k, cell];
+        }
+
+        // NodeCell / NodeCell[] / LinkCell / LinkCell[]
         const cellToCheck = Array.isArray(cell) && cell.length > 0 ? cell[0] : cell;
         if (
-          cell &&
           cellToCheck &&
-          typeof cell === "object" &&
           typeof cellToCheck === "object" &&
-          (Array.isArray(cell) ? cell.some(c => 'id' in c && c.id === id) : 'id' in cell && cell.id === id) &&
+          cellContainsElementId(cell, id) &&
           (type === !("labels" in cellToCheck))
         ) {
           if (Array.isArray(cell)) {
@@ -1184,20 +1241,36 @@ export class Graph {
     this.Data = this.Data.map((row) =>
       Object.fromEntries(
         Object.entries(row).map(([k, cell]) => {
-          const cellToCheck = Array.isArray(cell) && cell.length > 0 ? cell[0] : cell;
+          if (!cell || typeof cell !== "object") return [k, cell];
+
+          // PathCell: update the matching node or edge inside the path.
+          if (!Array.isArray(cell) && "nodes" in cell && Array.isArray((cell as PathCell).nodes)) {
+            const path = cell as PathCell;
+            if (path.nodes.some((n) => n.id === id)) {
+              return [k, { ...path, nodes: path.nodes.map((n) => n.id === id ? { ...n, properties: { ...n.properties, [key]: val } } : n) }];
+            }
+            if (path.edges?.some((e) => e.id === id)) {
+              return [k, { ...path, edges: path.edges!.map((e) => e.id === id ? { ...e, properties: { ...e.properties, [key]: val } } : e) }];
+            }
+            return [k, cell];
+          }
+
+          // NodeCell[] / LinkCell[]: map to avoid mutating the original array.
+          if (Array.isArray(cell)) {
+            if (!cell.some(c => 'id' in c && c.id === id)) return [k, cell];
+            return [k, cell.map(c => 'id' in c && c.id === id ? { ...c, properties: { ...(c as NodeCell | LinkCell).properties, [key]: val } } : c)];
+          }
+
+          // Single NodeCell / LinkCell
+          const cellToCheck = cell;
           if (
-            cell &&
-            cellToCheck &&
-            typeof cell === "object" &&
             typeof cellToCheck === "object" &&
-            (Array.isArray(cell) ? cell.some(c => 'id' in c && c.id === id) : 'id' in cell && cell.id === id) &&
+            'id' in cell && (cell as NodeCell | LinkCell).id === id &&
             (type === !("labels" in cellToCheck))
           ) {
-            return [
-              k,
-              { ...cell, properties: { ...((Array.isArray(cell) ? cell.find(c => 'id' in c && c.id === id) : cell) as NodeCell | LinkCell | undefined)?.properties, [key]: val } },
-            ];
+            return [k, { ...(cell as NodeCell | LinkCell), properties: { ...(cell as NodeCell | LinkCell).properties, [key]: val } }];
           }
+
           return [k, cell];
         })
       )

--- a/app/components/AiFixDialogs.tsx
+++ b/app/components/AiFixDialogs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { Check, Copy, Sparkles, X } from "lucide-react";
 import { AiFixContext } from "./provider";
 import DialogComponent from "./DialogComponent";
@@ -12,6 +12,7 @@ export default function AiFixDialogs() {
     const { result, pendingConsentProvider, confirmConsent, cancelConsent, dismissResult, insertCorrectedQuery } = useContext(AiFixContext);
     const [dontAskAgain, setDontAskAgain] = useState(false);
     const [copied, setCopied] = useState(false);
+    const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const { size: panelSize, onResize: onPanelResize } = useResizableSize("ai-fix-panel-size", 480, 400, 300, 250);
 
     const handleCopy = async (text: string) => {
@@ -20,7 +21,10 @@ export default function AiFixDialogs() {
         try {
             await writer(text);
             setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
+            // Cancel any in-flight reset timer (e.g. rapid double-click) before
+            // scheduling a new one so the icon never flips back prematurely.
+            if (copyTimeoutRef.current !== null) clearTimeout(copyTimeoutRef.current);
+            copyTimeoutRef.current = setTimeout(() => { setCopied(false); copyTimeoutRef.current = null; }, 2000);
         } catch {
             setCopied(false);
         }

--- a/app/components/CypherEditor.tsx
+++ b/app/components/CypherEditor.tsx
@@ -263,7 +263,12 @@ export default function CypherEditor({ graph, graphName, historyQuery, maximize,
             { method: 'GET' },
             toast,
             setIndicator
-        ).then(result => result?.ok ? result.json() : null).then(json => {
+        ).then(result => {
+            // Treat non-OK responses as errors so the catch block can apply
+            // FALLBACK_PROCEDURE_NAMES; a null-to-then chain would silently store [].
+            if (!result?.ok) throw new Error("Procedure info fetch failed");
+            return result.json();
+        }).then(json => {
             // Ignore the response if the component unmounted or the graph changed
             // while the request was in flight (prevents stale overwrites).
             if (cancelled || graphIdRef.current !== requestGraphId) return;

--- a/app/components/ForceGraph.tsx
+++ b/app/components/ForceGraph.tsx
@@ -52,6 +52,10 @@ export default function ForceGraph({
     const { background, foreground } = getTheme(theme);
 
     const lastClick = useRef<{ date: number, id: number }>({ date: 0, id: -1 });
+    // Tracks which `data` snapshot was present when the last saved viewport was
+    // restored. Lets the effect skip overwriting the canvas on the re-run that
+    // is triggered by setGraphData(undefined) clearing the consumed restore.
+    const restoredAtDataRef = useRef<typeof data | null>(null);
 
     const [hoverElement, setHoverElement] = useState<Node | Link | undefined>();
     const [canvasLoaded, setCanvasLoaded] = useState(false);
@@ -411,14 +415,29 @@ export default function ForceGraph({
 
         let nodeCount: number;
         if (graphData) {
-            nodeCount = graphData.nodes.length;
+            // Restore a saved canvas layout (e.g. after switching back to a graph the
+            // user was already exploring). Record which `data` snapshot was current so
+            // that the cleanup re-run triggered by setGraphData(undefined) below can
+            // skip the data branch, preventing the restored viewport from being
+            // immediately overwritten by stale query data.
+            restoredAtDataRef.current = data;
             canvas.setData(graphData);
             setGraphData(undefined);
-        } else {
-            const canvasData = convertToCanvasData(data);
-            nodeCount = canvasData.nodes.length;
-            canvas.setData(canvasData);
+            return undefined; // zoom correction not needed for a restored viewport
         }
+
+        // If this run was triggered solely by setGraphData(undefined) clearing the
+        // consumed restore (graphData dep changed to null), skip re-rendering so
+        // the restored layout is preserved.
+        if (restoredAtDataRef.current === data) {
+            restoredAtDataRef.current = null;
+            return undefined;
+        }
+        restoredAtDataRef.current = null;
+
+        const canvasData = convertToCanvasData(data);
+        nodeCount = canvasData.nodes.length;
+        canvas.setData(canvasData);
 
         // With the npm @falkordb/canvas package the canvas's zoomToFit fires asynchronously
         // via a requestAnimationFrame, so the min-zoom enforcement inside the canvas runs
@@ -444,9 +463,7 @@ export default function ForceGraph({
         }
 
         return undefined;
-
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [canvasRef, data, setGraphData, canvasLoaded]);
+    }, [canvasRef, data, graphData, setGraphData, canvasLoaded]);
 
     return (
         <div

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -557,8 +557,8 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   }), [scrollPosition, search, expand, dataHash]);
 
   const isReadOnly = useMemo(() =>
-    sessionData?.user?.role === "Read-Only" || connectionInfo.sentinelRole === "replica",
-    [sessionData?.user?.role, connectionInfo.sentinelRole]
+    sessionData?.user?.role === "Read-Only" || (connectionType === "Sentinel" && connectionInfo.sentinelRole === "replica"),
+    [sessionData?.user?.role, connectionInfo.sentinelRole, connectionType]
   );
   // Ref that always holds the latest isReadOnly value.
   // Callbacks read from the ref so they don't need isReadOnly in their

--- a/e2e/logic/POM/tableView.ts
+++ b/e2e/logic/POM/tableView.ts
@@ -59,11 +59,11 @@ export default class TableView extends GraphPage {
     }
 
     /**
-     * Returns the text content of the first data cell in the first table row.
-     * For PATH results the JSONTree renders nodes/edges keys, so this text will
-     * include strings like "nodes" or "edges" when the cell holds a PATH value.
+     * Returns true if the first data cell in the first table row contains `text`.
+     * For PATH results the JSONTree renders nodes/edges keys, so checking for
+     * `'nodes'` or `'edges'` confirms the cell holds a PATH value.
      */
-    public async getFirstCellContainsText(text: string): Promise<boolean> {
+    public async firstCellContains(text: string): Promise<boolean> {
         await this.tableViewTabPanel.waitFor({ state: 'visible', timeout: 10000 });
         const firstCell = this.tableViewTableRows.first().locator('td').first();
         await firstCell.waitFor({ state: 'visible', timeout: 5000 });

--- a/e2e/tests/canvas.spec.ts
+++ b/e2e/tests/canvas.spec.ts
@@ -475,31 +475,37 @@ test.describe('Canvas Tests', () => {
     test(`@admin PATH query result visualizes nodes and edges on the canvas`, async () => {
         const graphName = getRandomString('path-canvas');
         await apicalls.addGraph(graphName);
-        await apicalls.runQuery(graphName, "CREATE (:City {name:'A'})-[:ROAD]->(:City {name:'B'})");
-        const graph = await browser.createNewPage(GraphPage, urls.graphUrl);
-        await graph.selectGraphByName(graphName);
-        await graph.insertQuery("MATCH p=(a:City)-[:ROAD]->(b:City) RETURN p");
-        await graph.clickRunQuery();
-        const nodes = await graph.getNodesScreenPositions();
-        expect(nodes.length).toBeGreaterThanOrEqual(2);
-        const links = await graph.getLinksScreenPositions();
-        expect(links.length).toBeGreaterThanOrEqual(1);
-        await apicalls.removeGraph(graphName);
+        try {
+            await apicalls.runQuery(graphName, "CREATE (:City {name:'A'})-[:ROAD]->(:City {name:'B'})");
+            const graph = await browser.createNewPage(GraphPage, urls.graphUrl);
+            await graph.selectGraphByName(graphName);
+            await graph.insertQuery("MATCH p=(a:City)-[:ROAD]->(b:City) RETURN p");
+            await graph.clickRunQuery();
+            const nodes = await graph.getNodesScreenPositions();
+            expect(nodes.filter(n => n.visible).length).toBe(2);
+            const links = await graph.getLinksScreenPositions();
+            expect(links.filter(l => l.visible).length).toBe(1);
+        } finally {
+            await apicalls.removeGraph(graphName);
+        }
     });
 
     test(`@admin algo.SPpaths query result visualizes nodes and edges on the canvas`, async () => {
         const graphName = getRandomString('path-algo');
         await apicalls.addGraph(graphName);
-        await apicalls.runQuery(graphName, "CREATE (:Station {name:'A'})-[:LINE]->(:Station {name:'B'})-[:LINE]->(:Station {name:'C'})");
-        const graph = await browser.createNewPage(GraphPage, urls.graphUrl);
-        await graph.selectGraphByName(graphName);
-        await graph.insertQuery("MATCH (src:Station {name:'A'}), (dest:Station {name:'C'}) CALL algo.SPpaths({sourceNode: src, targetNode: dest, pathCount: 1, weightProp: '', defaultWeight: 1}) YIELD path RETURN path");
-        await graph.clickRunQuery();
-        const nodes = await graph.getNodesScreenPositions();
-        expect(nodes.length).toBeGreaterThanOrEqual(2);
-        const links = await graph.getLinksScreenPositions();
-        expect(links.length).toBeGreaterThanOrEqual(1);
-        await apicalls.removeGraph(graphName);
+        try {
+            await apicalls.runQuery(graphName, "CREATE (:Station {name:'A'})-[:LINE]->(:Station {name:'B'})-[:LINE]->(:Station {name:'C'})");
+            const graph = await browser.createNewPage(GraphPage, urls.graphUrl);
+            await graph.selectGraphByName(graphName);
+            await graph.insertQuery("MATCH (src:Station {name:'A'}), (dest:Station {name:'C'}) CALL algo.SPpaths({sourceNode: src, targetNode: dest, pathCount: 1, weightProp: '', defaultWeight: 1}) YIELD path RETURN path");
+            await graph.clickRunQuery();
+            const nodes = await graph.getNodesScreenPositions();
+            expect(nodes.filter(n => n.visible).length).toBe(3);
+            const links = await graph.getLinksScreenPositions();
+            expect(links.filter(l => l.visible).length).toBe(2);
+        } finally {
+            await apicalls.removeGraph(graphName);
+        }
     });
 
 });

--- a/e2e/tests/table.spec.ts
+++ b/e2e/tests/table.spec.ts
@@ -64,28 +64,36 @@ test.describe('Table View Tests', () => {
     test('@admin PATH query result appears as a single row in table view', async () => {
         const graphName = getRandomString('path-table');
         await apiCalls.addGraph(graphName);
-        await apiCalls.runQuery(graphName, "CREATE (:City {name:'start'})-[:ROAD]->(:City {name:'end'})");
-        const tableView = await browser.createNewPage(TableView, urls.graphUrl);
-        await tableView.selectGraphByName(graphName);
-        await tableView.insertQuery("MATCH p=(a:City {name:'start'})-[:ROAD]->(b:City {name:'end'}) RETURN p");
-        await tableView.clickRunQuery(false);
-        await tableView.clickTableTab();
-        const rowCount = await tableView.getRowsCount();
-        expect(rowCount).toBe(1);
-        await apiCalls.removeGraph(graphName);
+        try {
+            await apiCalls.runQuery(graphName, "CREATE (:City {name:'start'})-[:ROAD]->(:City {name:'end'})");
+            const tableView = await browser.createNewPage(TableView, urls.graphUrl);
+            await tableView.selectGraphByName(graphName);
+            await tableView.insertQuery("MATCH p=(a:City {name:'start'})-[:ROAD]->(b:City {name:'end'}) RETURN p");
+            await tableView.clickRunQuery(false);
+            await tableView.clickTableTab();
+            const rowCount = await tableView.getRowsCount();
+            expect(rowCount).toBe(1);
+        } finally {
+            await apiCalls.removeGraph(graphName);
+        }
     });
 
-    test('@admin PATH cell renders path data (nodes key) in table view', async () => {
+    test('@admin PATH cell renders path data (nodes and edges keys) in table view', async () => {
         const graphName = getRandomString('path-cell');
         await apiCalls.addGraph(graphName);
-        await apiCalls.runQuery(graphName, "CREATE (:City {name:'start'})-[:ROAD]->(:City {name:'end'})");
-        const tableView = await browser.createNewPage(TableView, urls.graphUrl);
-        await tableView.selectGraphByName(graphName);
-        await tableView.insertQuery("MATCH p=(a:City {name:'start'})-[:ROAD]->(b:City {name:'end'}) RETURN p");
-        await tableView.clickRunQuery(false);
-        await tableView.clickTableTab();
-        const cellContainsPathData = await tableView.getFirstCellContainsText('nodes');
-        expect(cellContainsPathData).toBe(true);
-        await apiCalls.removeGraph(graphName);
+        try {
+            await apiCalls.runQuery(graphName, "CREATE (:City {name:'start'})-[:ROAD]->(:City {name:'end'})");
+            const tableView = await browser.createNewPage(TableView, urls.graphUrl);
+            await tableView.selectGraphByName(graphName);
+            await tableView.insertQuery("MATCH p=(a:City {name:'start'})-[:ROAD]->(b:City {name:'end'}) RETURN p");
+            await tableView.clickRunQuery(false);
+            await tableView.clickTableTab();
+            // Verify exactly one result row belongs to this query before inspecting content.
+            expect(await tableView.getRowsCount()).toBe(1);
+            expect(await tableView.firstCellContains('nodes')).toBe(true);
+            expect(await tableView.firstCellContains('edges')).toBe(true);
+        } finally {
+            await apiCalls.removeGraph(graphName);
+        }
     });
 });


### PR DESCRIPTION
- model.ts: add DataCell import and cellContainsElementId helper so PathCell rows (which have no top-level 'id') are matched in removeElements, removeLabel, addLabel, removeProperty, and setProperty; fix setProperty array-spread bug that produced an object-with-numeric-keys instead of an updated array
- CypherEditor.tsx: throw on non-OK fetch so 4xx/5xx errors reach the .catch block and FALLBACK_PROCEDURE_NAMES is applied instead of silently storing []
- providers.tsx: gate Sentinel replica check on connectionType === 'Sentinel' to prevent stale sentinel data marking non-Sentinel connections read-only
- ForceGraph.tsx: add restoredAtDataRef to prevent restored canvas viewport from being overwritten on the setGraphData(undefined) re-run; add graphData to useEffect deps and remove eslint-disable-next-line comment
- AiFixDialogs.tsx: use a ref to track the copy timer and cancel it before scheduling a new one (rapid double-click guard)
- e2e/logic/POM/tableView.ts: rename getFirstCellContainsText → firstCellContains
- e2e/tests/canvas.spec.ts: wrap PATH tests in try/finally for graph cleanup; use exact visible-element counts instead of >= assertions
- e2e/tests/table.spec.ts: wrap PATH tests in try/finally; assert row count before cell content in second test; check both 'nodes' and 'edges' keys; use renamed firstCellContains helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graph labels and properties now update more reliably across nodes, links, and path results.
  * Path query results are better handled in both the canvas and table views.
* **Bug Fixes**
  * Fixed copy status feedback so repeated copy actions behave consistently.
  * Improved procedure autocomplete fallback when procedure data can’t be loaded.
  * Restoring a saved canvas now preserves the restored view correctly.
  * Read-only mode now updates properly when connection type changes.
* **Tests**
  * Strengthened end-to-end coverage for path results and improved graph cleanup using `try/finally`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->