### PR TITLE
fix: use explicit isNodeCell/isLinkCell predicates with correct polar…

### DIFF
--- a/app/api/graph/model.ts
+++ b/app/api/graph/model.ts
@@ -1229,16 +1229,19 @@ export class Graph {
         }
 
         // NodeCell / NodeCell[] / LinkCell / LinkCell[]
+        // 'id' in cellToCheck narrows from DataCell to NodeCell | LinkCell so the
+        // type guards receive a correctly-typed argument without a pre-cast.
         const cellToCheck = Array.isArray(cell) && cell.length > 0 ? cell[0] : cell;
         if (
           cellToCheck &&
           typeof cellToCheck === "object" &&
+          'id' in cellToCheck &&
           cellContainsElementId(cell, id) &&
-          (type ? isNodeCell(cellToCheck as NodeCell | LinkCell) : isLinkCell(cellToCheck as NodeCell | LinkCell))
+          (type ? isNodeCell(cellToCheck) : isLinkCell(cellToCheck))
         ) {
           if (Array.isArray(cell)) {
             cell.forEach(c => 'id' in c && c.id === id && delete (c as NodeCell | LinkCell).properties[key]);
-          } else delete (cell as NodeCell | LinkCell).properties[key];
+          } else delete cellToCheck.properties[key];
 
           return [k, cell];
         }
@@ -1270,23 +1273,19 @@ export class Graph {
           // NodeCell[] / LinkCell[]: map to avoid mutating the original array.
           // Apply the same type guard used for single cells so a node id that
           // collides with an edge id (or vice versa) in the same row is not updated.
+          // 'id' in c narrows from DataCell to NodeCell | LinkCell before matchFn.
           if (Array.isArray(cell)) {
             const matchFn = (c: NodeCell | LinkCell) =>
               c.id === id && (type ? isNodeCell(c) : isLinkCell(c));
-            if (!cell.some(c => 'id' in c && matchFn(c as NodeCell | LinkCell))) return [k, cell];
-            return [k, cell.map(c => 'id' in c && matchFn(c as NodeCell | LinkCell)
-              ? { ...c, properties: { ...(c as NodeCell | LinkCell).properties, [key]: val } }
+            if (!cell.some(c => 'id' in c && matchFn(c))) return [k, cell];
+            return [k, cell.map(c => 'id' in c && matchFn(c)
+              ? { ...c, properties: { ...c.properties, [key]: val } }
               : c)];
           }
 
-          // Single NodeCell / LinkCell
-          const cellToCheck = cell;
-          if (
-            typeof cellToCheck === "object" &&
-            'id' in cell && (cell as NodeCell | LinkCell).id === id &&
-            (type ? isNodeCell(cell as NodeCell | LinkCell) : isLinkCell(cell as NodeCell | LinkCell))
-          ) {
-            return [k, { ...(cell as NodeCell | LinkCell), properties: { ...(cell as NodeCell | LinkCell).properties, [key]: val } }];
+          // Single NodeCell / LinkCell: 'id' in narrows cell to NodeCell | LinkCell.
+          if ('id' in cell && cell.id === id && (type ? isNodeCell(cell) : isLinkCell(cell))) {
+            return [k, { ...cell, properties: { ...cell.properties, [key]: val } }];
           }
 
           return [k, cell];

--- a/app/api/graph/model.ts
+++ b/app/api/graph/model.ts
@@ -282,6 +282,16 @@ function cellContainsElementId(cell: DataCell, elementId: number): boolean {
   return "id" in cell && (cell as NodeCell | LinkCell).id === elementId;
 }
 
+/** Type guard: a NodeCell always carries a `labels` array. */
+function isNodeCell(cell: NodeCell | LinkCell): cell is NodeCell {
+  return "labels" in cell;
+}
+
+/** Type guard: a LinkCell carries `relationshipType` but no `labels`. */
+function isLinkCell(cell: NodeCell | LinkCell): cell is LinkCell {
+  return !("labels" in cell);
+}
+
 export class Graph {
   private id: string;
 
@@ -1224,7 +1234,7 @@ export class Graph {
           cellToCheck &&
           typeof cellToCheck === "object" &&
           cellContainsElementId(cell, id) &&
-          (type === !("labels" in cellToCheck))
+          (type ? isNodeCell(cellToCheck as NodeCell | LinkCell) : isLinkCell(cellToCheck as NodeCell | LinkCell))
         ) {
           if (Array.isArray(cell)) {
             cell.forEach(c => 'id' in c && c.id === id && delete (c as NodeCell | LinkCell).properties[key]);
@@ -1262,7 +1272,7 @@ export class Graph {
           // collides with an edge id (or vice versa) in the same row is not updated.
           if (Array.isArray(cell)) {
             const matchFn = (c: NodeCell | LinkCell) =>
-              'id' in c && c.id === id && (type === !("labels" in c));
+              c.id === id && (type ? isNodeCell(c) : isLinkCell(c));
             if (!cell.some(c => 'id' in c && matchFn(c as NodeCell | LinkCell))) return [k, cell];
             return [k, cell.map(c => 'id' in c && matchFn(c as NodeCell | LinkCell)
               ? { ...c, properties: { ...(c as NodeCell | LinkCell).properties, [key]: val } }
@@ -1274,7 +1284,7 @@ export class Graph {
           if (
             typeof cellToCheck === "object" &&
             'id' in cell && (cell as NodeCell | LinkCell).id === id &&
-            (type === !("labels" in cellToCheck))
+            (type ? isNodeCell(cell as NodeCell | LinkCell) : isLinkCell(cell as NodeCell | LinkCell))
           ) {
             return [k, { ...(cell as NodeCell | LinkCell), properties: { ...(cell as NodeCell | LinkCell).properties, [key]: val } }];
           }


### PR DESCRIPTION
…ity; remove empty ForgeGraph.tsx

- model.ts: add isNodeCell()/isLinkCell() type-guard helpers so the node/edge discrimination in setProperty and removeProperty is explicit and robust against future shape changes
- model.ts: fix inverted type guard — the original type === !("labels" in c) was backwards (type=true means node in the DataPanel convention, but the negation caused it to match edges instead); replace with type ? isNodeCell(c) : isLinkCell(c) in both the array branch and the single-cell branch of setProperty, and in removeProperty
- app/components/ForgeGraph.tsx: delete empty file that was accidentally committed during the previous fix

Addresses coderabbitai Major and overcut-ai Minor comments on PR #1900.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how graph item properties are updated and removed so changes apply to the correct item type.
  * Fixed cases where property edits could affect the wrong graph element, making graph behavior more consistent and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->