### PR TITLE
[codex] docs: align Helm chart install instructions

### DIFF
--- a/helm/falkordb-browser/README.md
+++ b/helm/falkordb-browser/README.md
@@ -10,18 +10,14 @@ This Helm chart deploys the FalkorDB Browser application to a Kubernetes cluster
 
 ## Installation
 
-### Install from Helm Repository (Recommended)
+### Install from OCI Registry (Recommended)
 
 ```bash
-# Add the FalkorDB Helm repository
-helm repo add falkordb https://falkordb.github.io/helm-charts
-helm repo update
-
 # Install the latest version
-helm install falkordb-browser falkordb/falkordb-browser
+helm install falkordb-browser oci://ghcr.io/falkordb/helm-charts/falkordb-browser
 
 # Or install a specific version
-helm install falkordb-browser falkordb/falkordb-browser --version 1.6.7
+helm install falkordb-browser oci://ghcr.io/falkordb/helm-charts/falkordb-browser --version 1.6.7
 ```
 
 ### Install from local chart
@@ -38,8 +34,8 @@ helm install falkordb-browser ./falkordb-browser
 ### Install with custom values
 
 ```bash
-# From Helm repository
-helm install falkordb-browser falkordb/falkordb-browser \
+# From OCI registry
+helm install falkordb-browser oci://ghcr.io/falkordb/helm-charts/falkordb-browser \
   --set env.nextauthUrl=https://your-domain.com \
   --set env.nextauthSecret=your-secret-here \
   --set ingress.enabled=true \
@@ -338,9 +334,9 @@ After deploying the browser, you'll need to configure it to connect to your Falk
 
 ## Publishing and CI/CD
 
-This chart is automatically published to the FalkorDB Helm charts repository via GitHub Actions.
+This chart is automatically packaged into the FalkorDB Helm charts repository via GitHub Actions.
 
-The workflow publishes charts to the [FalkorDB/helm-charts](https://github.com/FalkorDB/helm-charts) repository, which is served via GitHub Pages at `https://falkordb.github.io/helm-charts`.
+The [FalkorDB/helm-charts](https://github.com/FalkorDB/helm-charts) repository publishes packaged charts to the GitHub Container Registry. The OCI chart path is `oci://ghcr.io/falkordb/helm-charts/falkordb-browser`.
 
 The workflow requires a `GHCR_TOKEN` or `GITHUB_TOKEN` secret with write access to the FalkorDB/helm-charts repository.
 


### PR DESCRIPTION
## Summary
- Align the Helm chart README's recommended install path with the top-level README's OCI install command.
- Update the custom-values example to use the same OCI chart reference.
- Clarify that packaged charts flow through `FalkorDB/helm-charts` and are published to GHCR.

Fixes #1895.

## Source proof
- `README.md` already installs `oci://ghcr.io/falkordb/helm-charts/falkordb-browser`.
- `helm/falkordb-browser/README.md` still recommended `helm repo add falkordb https://falkordb.github.io/helm-charts` and `falkordb/falkordb-browser`.
- FalkorDB/falkordb-browser#1377 changed the top-level README to OCI format.
- `FalkorDB/helm-charts` publishes packaged charts to `oci://ghcr.io/falkordb/helm-charts`, and GHCR lists `falkordb-browser` chart tags including `1.6.7` and `2.0.10`.

## Verification
- `git diff --check HEAD~1 HEAD`
- `TOKEN=$(curl -s 'https://ghcr.io/token?service=ghcr.io&scope=repository:falkordb/helm-charts/falkordb-browser:pull' | jq -r .token); curl -s -H "Authorization: Bearer $TOKEN" https://ghcr.io/v2/falkordb/helm-charts/falkordb-browser/tags/list | jq -e '.tags | index("1.6.7") and index("2.0.10")'`
- `gh api repos/FalkorDB/helm-charts/git/trees/HEAD?recursive=1 --jq '.tree[].path' | rg 'charts/falkordb-browser-1\.6\.7\.tgz|charts/falkordb-browser-2\.0\.10\.tgz'`
- `gh api repos/FalkorDB/helm-charts/contents/.github/workflows/helm-publish.yaml --jq '.content' | base64 -d | rg -n "helm push|oci://ghcr.io/falkordb/helm-charts|packages: write"`
- `if rg -n "helm install .*falkordb/falkordb-browser|helm repo add|Install from Helm Repository" helm/falkordb-browser/README.md; then exit 1; else echo "no stale Helm repository install commands"; fi`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm chart installation instructions to recommend GitHub Container Registry (OCI).
  * Added clearer `helm install` examples, including a version-specific command.
  * Revised publishing details to reflect OCI chart distribution under `ghcr.io/falkordb/helm-charts`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->