### PR TITLE
feat: batch CSV ingestion via chunked UNWIND

### DIFF
--- a/app/api/graph/[graph]/upload/route.ts
+++ b/app/api/graph/[graph]/upload/route.ts
@@ -105,7 +105,11 @@ export async function POST(
         const result = await executeCsvIngestion(graph, csvText, query ?? "");
 
         return NextResponse.json(
-          { message: `Processed ${result.processedRows} CSV row(s) in ${result.chunks} batch(es).` },
+          {
+            message: `Processed ${result.processedRows} CSV row(s) in ${result.chunks} batch(es).`,
+            processedRows: result.processedRows,
+            chunks: result.chunks,
+          },
           { status: 200, headers: getCorsHeaders(request) }
         );
       }

--- a/app/api/graph/[graph]/upload/route.ts
+++ b/app/api/graph/[graph]/upload/route.ts
@@ -102,10 +102,10 @@ export async function POST(
 
       if (validation.mode === "csv") {
         const csvText = await fs.promises.readFile(storedUpload.filePath, "utf-8");
-        const count = await executeCsvIngestion(graph, csvText, query ?? "");
+        const result = await executeCsvIngestion(graph, csvText, query ?? "");
 
         return NextResponse.json(
-          { message: `Processed ${count} CSV row(s).` },
+          { message: `Processed ${result.processedRows} CSV row(s) in ${result.chunks} batch(es).` },
           { status: 200, headers: getCorsHeaders(request) }
         );
       }

--- a/app/api/graph/[graph]/upload/upload-utils.test.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.test.ts
@@ -7,6 +7,9 @@ import {
   validateUploadInput,
   executeCsvIngestion,
   executeCypherBatch,
+  buildBatchCsvQuery,
+  chunkCsvItems,
+  type CsvRowItem,
 } from "./upload-utils.ts";
 
 function makeGraph(
@@ -241,48 +244,134 @@ test("validateUploadInput rejects an unknown mode", () => {
 });
 
 // ---------------------------------------------------------------------------
-// executeCsvIngestion
+// buildBatchCsvQuery
 // ---------------------------------------------------------------------------
 
-test("executeCsvIngestion runs the query once per row with row and index params", async () => {
+test("buildBatchCsvQuery wraps the body in an UNWIND exposing row and index", () => {
+  assert.equal(
+    buildBatchCsvQuery("CREATE (:Person {name: row.name})"),
+    "UNWIND $rows AS __r WITH __r.index AS index, __r.data AS row\nCREATE (:Person {name: row.name})"
+  );
+});
+
+test("buildBatchCsvQuery trims and strips a trailing semicolon", () => {
+  assert.match(buildBatchCsvQuery("  CREATE (:A) ;  "), /AS row\nCREATE \(:A\)$/);
+});
+
+// ---------------------------------------------------------------------------
+// chunkCsvItems
+// ---------------------------------------------------------------------------
+
+function makeItems(n: number): CsvRowItem[] {
+  return Array.from({ length: n }, (_, i) => ({ index: i, data: { v: String(i) } }));
+}
+
+test("chunkCsvItems splits by row count", () => {
+  const chunks = chunkCsvItems(makeItems(5), 2, 1_000_000);
+  assert.deepEqual(chunks.map((c) => c.length), [2, 2, 1]);
+  assert.deepEqual(chunks[2][0], { index: 4, data: { v: "4" } });
+});
+
+test("chunkCsvItems returns a single chunk when everything fits", () => {
+  const chunks = chunkCsvItems(makeItems(3), 1000, 1_000_000);
+  assert.equal(chunks.length, 1);
+  assert.equal(chunks[0].length, 3);
+});
+
+test("chunkCsvItems splits by approximate byte size for wide rows", () => {
+  const wide: CsvRowItem[] = Array.from({ length: 4 }, (_, i) => ({
+    index: i,
+    data: { blob: "x".repeat(100) },
+  }));
+  const chunks = chunkCsvItems(wide, 1000, 80);
+  assert.equal(chunks.length, 4);
+});
+
+test("chunkCsvItems returns no chunks for an empty list", () => {
+  assert.deepEqual(chunkCsvItems([], 1000, 1000), []);
+});
+
+// ---------------------------------------------------------------------------
+// executeCsvIngestion (batched)
+// ---------------------------------------------------------------------------
+
+test("executeCsvIngestion runs one batched UNWIND query per chunk with row items", async () => {
   const { graph, querySpy } = makeGraph();
-  const query = "CREATE (:Person {name: $row.name})";
 
-  const count = await executeCsvIngestion(graph, "name,age\nAlice,30\nBob,41", query);
+  const result = await executeCsvIngestion(
+    graph,
+    "name,age\nAlice,30\nBob,41",
+    "CREATE (:Person {name: row.name})"
+  );
 
-  assert.equal(count, 2);
-  assert.equal(querySpy.mock.callCount(), 2);
-  assert.equal(querySpy.mock.calls[0].arguments[0], query);
+  assert.deepEqual(result, { processedRows: 2, chunks: 1 });
+  assert.equal(querySpy.mock.callCount(), 1);
+  assert.match(
+    querySpy.mock.calls[0].arguments[0] as string,
+    /^UNWIND \$rows AS __r WITH __r\.index AS index, __r\.data AS row\n/
+  );
   assert.deepEqual(querySpy.mock.calls[0].arguments[1], {
-    params: { row: { name: "Alice", age: "30" }, index: 0 },
+    params: {
+      rows: [
+        { index: 0, data: { name: "Alice", age: "30" } },
+        { index: 1, data: { name: "Bob", age: "41" } },
+      ],
+    },
   });
-  assert.deepEqual(querySpy.mock.calls[1].arguments[1], {
-    params: { row: { name: "Bob", age: "41" }, index: 1 },
+});
+
+test("executeCsvIngestion splits large inputs into multiple chunk queries", async () => {
+  const { graph, querySpy } = makeGraph();
+  const csv = ["name", "n0", "n1", "n2", "n3", "n4"].join("\n");
+
+  const result = await executeCsvIngestion(graph, csv, "CREATE (:P {n: row.name})", {
+    chunkSize: 2,
+  });
+
+  assert.deepEqual(result, { processedRows: 5, chunks: 3 });
+  assert.equal(querySpy.mock.callCount(), 3);
+});
+
+test("executeCsvIngestion applies the transformRow hook before binding params", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await executeCsvIngestion(graph, "age\n30", "CREATE (:P {age: row.age})", {
+    transformRow: (row) => ({ age: Number(row.age) }),
+  });
+
+  assert.deepEqual(querySpy.mock.calls[0].arguments[1], {
+    params: { rows: [{ index: 0, data: { age: 30 } }] },
   });
 });
 
 test("executeCsvIngestion runs no query and returns 0 for an empty CSV", async () => {
   const { graph, querySpy } = makeGraph();
 
-  const count = await executeCsvIngestion(graph, "", "CREATE (:P)");
+  const result = await executeCsvIngestion(graph, "", "CREATE (:P {n: row.name})");
 
-  assert.equal(count, 0);
+  assert.deepEqual(result, { processedRows: 0, chunks: 0 });
   assert.equal(querySpy.mock.callCount(), 0);
 });
 
-test("executeCsvIngestion annotates failures with the row number and stops", async () => {
-  let calls = 0;
-  const { graph, querySpy } = makeGraph(async () => {
-    calls += 1;
-    if (calls === 2) throw new Error("boom");
-    return { data: [] };
+test("executeCsvIngestion rejects a multi-statement body before running anything", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await assert.rejects(
+    () => executeCsvIngestion(graph, "n\n1", "CREATE (:A); CREATE (:B)"),
+    /must be a single Cypher statement/
+  );
+  assert.equal(querySpy.mock.callCount(), 0);
+});
+
+test("executeCsvIngestion annotates failures with the failing chunk's row range", async () => {
+  const { graph } = makeGraph(async () => {
+    throw new Error("boom");
   });
 
   await assert.rejects(
-    () => executeCsvIngestion(graph, "name\nA\nB\nC", "CREATE (:P {n: $row.name})"),
-    /Failed to process CSV row 2: boom/
+    () => executeCsvIngestion(graph, "n\nA\nB\nC", "CREATE (:P {n: row.name})", { chunkSize: 2 }),
+    /Failed to process CSV rows 1-2: boom/
   );
-  assert.equal(querySpy.mock.callCount(), 2);
 });
 
 // ---------------------------------------------------------------------------

--- a/app/api/graph/[graph]/upload/upload-utils.test.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.test.ts
@@ -363,6 +363,27 @@ test("executeCsvIngestion rejects a multi-statement body before running anything
   assert.equal(querySpy.mock.callCount(), 0);
 });
 
+test("executeCsvIngestion uses the normalized statement (drops a trailing comment/semicolon)", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await executeCsvIngestion(graph, "n\n1", "CREATE (:A {n: row.n}); // trailing");
+
+  assert.match(
+    querySpy.mock.calls[0].arguments[0] as string,
+    /AS row\nCREATE \(:A \{n: row\.n\}\)$/
+  );
+});
+
+test("executeCsvIngestion rejects an empty/comment-only body", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await assert.rejects(
+    () => executeCsvIngestion(graph, "n\n1", "// just a comment"),
+    /CSV query is empty/
+  );
+  assert.equal(querySpy.mock.callCount(), 0);
+});
+
 test("executeCsvIngestion annotates failures with the failing chunk's row range", async () => {
   const { graph } = makeGraph(async () => {
     throw new Error("boom");

--- a/app/api/graph/[graph]/upload/upload-utils.test.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.test.ts
@@ -395,6 +395,32 @@ test("executeCsvIngestion annotates failures with the failing chunk's row range"
   );
 });
 
+test("executeCsvIngestion rejects CSV headers that are not valid identifiers", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await assert.rejects(
+    () => executeCsvIngestion(graph, "first name\nAlice", "CREATE (:P {n: row.name})"),
+    /CSV column "first name" is not a valid identifier/
+  );
+  assert.equal(querySpy.mock.callCount(), 0);
+});
+
+test("executeCsvIngestion annotates transformRow errors with the row number", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await assert.rejects(
+    () =>
+      executeCsvIngestion(graph, "n\nA\nB", "CREATE (:P {n: row.n})", {
+        transformRow: (row) => {
+          if (row.n === "B") throw new Error('Column "n": bad');
+          return row;
+        },
+      }),
+    /Failed to process CSV row 2: Column "n": bad/
+  );
+  assert.equal(querySpy.mock.callCount(), 0);
+});
+
 // ---------------------------------------------------------------------------
 // executeCypherBatch
 // ---------------------------------------------------------------------------

--- a/app/api/graph/[graph]/upload/upload-utils.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.ts
@@ -228,15 +228,23 @@ export function splitCypherStatements(cypherBatch: string): string[] {
 export const DEFAULT_CSV_CHUNK_SIZE = 1000;
 export const DEFAULT_CSV_CHUNK_BYTES = 512 * 1024;
 
+export type CsvParamValue =
+  | null
+  | string
+  | number
+  | boolean
+  | CsvParamValue[]
+  | { [key: string]: CsvParamValue };
+
 export interface CsvRowItem {
   index: number;
-  data: Record<string, unknown>;
+  data: Record<string, CsvParamValue>;
 }
 
 export interface CsvIngestionOptions {
   chunkSize?: number;
   maxChunkBytes?: number;
-  transformRow?: (row: Record<string, string>) => Record<string, unknown>;
+  transformRow?: (row: Record<string, string>) => Record<string, CsvParamValue>;
 }
 
 export interface CsvIngestionResult {
@@ -305,8 +313,13 @@ export async function executeCsvIngestion(
     transformRow,
   } = options;
 
-  if (splitCypherStatements(body).length > 1) {
+  const statements = splitCypherStatements(body);
+  if (statements.length > 1) {
     throw new Error("The CSV query must be a single Cypher statement.");
+  }
+  const [statement] = statements;
+  if (!statement) {
+    throw new Error("The CSV query is empty.");
   }
 
   const rows = parseCsvRows(csvText);
@@ -315,7 +328,7 @@ export async function executeCsvIngestion(
     data: transformRow ? transformRow(row) : row,
   }));
   const chunks = chunkCsvItems(items, chunkSize, maxChunkBytes);
-  const query = buildBatchCsvQuery(body);
+  const query = buildBatchCsvQuery(statement);
 
   for (let c = 0; c < chunks.length; c += 1) {
     const chunk = chunks[c];

--- a/app/api/graph/[graph]/upload/upload-utils.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.ts
@@ -1,4 +1,5 @@
 import type { Graph } from "falkordb";
+import type { QueryOptions } from "falkordb/dist/src/commands";
 
 export type UploadMode = "rdb" | "csv" | "cypher";
 
@@ -224,23 +225,116 @@ export function splitCypherStatements(cypherBatch: string): string[] {
  * Returns the number of rows processed. Failures are annotated with the row
  * number so partial-batch errors are actionable.
  */
+export const DEFAULT_CSV_CHUNK_SIZE = 1000;
+export const DEFAULT_CSV_CHUNK_BYTES = 512 * 1024;
+
+export interface CsvRowItem {
+  index: number;
+  data: Record<string, unknown>;
+}
+
+export interface CsvIngestionOptions {
+  chunkSize?: number;
+  maxChunkBytes?: number;
+  transformRow?: (row: Record<string, string>) => Record<string, unknown>;
+}
+
+export interface CsvIngestionResult {
+  processedRows: number;
+  chunks: number;
+}
+
+/**
+ * Wrap a user-provided per-row Cypher body so it runs over a batch of rows.
+ * Each row is exposed as `row` (a map) and its zero-based position as `index`.
+ * A trailing semicolon is stripped so the result is a single statement.
+ *
+ * Note: cardinality-changing clauses in the body (aggregating `WITH`, `LIMIT`,
+ * a nested `UNWIND`, etc.) operate over the whole chunk, not a single row.
+ */
+export function buildBatchCsvQuery(body: string): string {
+  const normalized = body.replace(/[;\s]+$/, "").trim();
+  return `UNWIND $rows AS __r WITH __r.index AS index, __r.data AS row\n${normalized}`;
+}
+
+/**
+ * Split row items into chunks bounded by both a row count and an approximate
+ * serialized byte size, so wide rows don't produce oversized query params.
+ */
+export function chunkCsvItems(
+  items: CsvRowItem[],
+  maxRows: number,
+  maxBytes: number
+): CsvRowItem[][] {
+  const chunks: CsvRowItem[][] = [];
+  let current: CsvRowItem[] = [];
+  let currentBytes = 0;
+
+  for (const item of items) {
+    const size = JSON.stringify(item).length;
+    if (current.length > 0 && (current.length >= maxRows || currentBytes + size > maxBytes)) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(item);
+    currentBytes += size;
+  }
+
+  if (current.length > 0) chunks.push(current);
+
+  return chunks;
+}
+
+/**
+ * Parse CSV text and execute the user's row body over the rows in batches, each
+ * batch a single `UNWIND $rows` query (atomic per chunk; earlier chunks stay
+ * committed if a later one fails). Returns the number of rows and chunks
+ * processed. The optional `transformRow` hook lets callers coerce raw string
+ * cells before they are bound as query params.
+ */
 export async function executeCsvIngestion(
   graph: Graph,
   csvText: string,
-  query: string
-): Promise<number> {
-  const rows = parseCsvRows(csvText);
+  body: string,
+  options: CsvIngestionOptions = {}
+): Promise<CsvIngestionResult> {
+  const {
+    chunkSize = DEFAULT_CSV_CHUNK_SIZE,
+    maxChunkBytes = DEFAULT_CSV_CHUNK_BYTES,
+    transformRow,
+  } = options;
 
-  for (let index = 0; index < rows.length; index += 1) {
+  if (splitCypherStatements(body).length > 1) {
+    throw new Error("The CSV query must be a single Cypher statement.");
+  }
+
+  const rows = parseCsvRows(csvText);
+  const items: CsvRowItem[] = rows.map((row, index) => ({
+    index,
+    data: transformRow ? transformRow(row) : row,
+  }));
+  const chunks = chunkCsvItems(items, chunkSize, maxChunkBytes);
+  const query = buildBatchCsvQuery(body);
+
+  for (let c = 0; c < chunks.length; c += 1) {
+    const chunk = chunks[c];
     try {
+      // Row items carry coerced (possibly non-string) values; FalkorDB accepts
+      // the list-of-maps shape at runtime, so bind it as query params.
+      const options = { params: { rows: chunk } } as unknown as QueryOptions;
       // eslint-disable-next-line no-await-in-loop
-      await graph.query(query, { params: { row: rows[index], index } });
+      await graph.query(query, options);
     } catch (error) {
-      throw new Error(`Failed to process CSV row ${index + 1}: ${(error as Error).message}`);
+      const first = chunk[0].index + 1;
+      const last = chunk[chunk.length - 1].index + 1;
+      throw new Error(
+        `Failed to process CSV rows ${first}-${last}: ${(error as Error).message}`
+      );
     }
   }
 
-  return rows.length;
+  return { processedRows: rows.length, chunks: chunks.length };
 }
 
 /**

--- a/app/api/graph/[graph]/upload/upload-utils.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.ts
@@ -294,6 +294,25 @@ export function chunkCsvItems(
   return chunks;
 }
 
+const CSV_HEADER_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Reject CSV headers that aren't valid Cypher identifiers. The FalkorDB param
+ * serializer emits map keys verbatim (`{key:value}`), so a header with spaces or
+ * special characters would produce an invalid — and potentially injectable — map
+ * literal when bound as `$rows`.
+ */
+function assertSafeCsvHeaders(rows: Record<string, string>[]): void {
+  if (rows.length === 0) return;
+  for (const key of Object.keys(rows[0])) {
+    if (!CSV_HEADER_IDENTIFIER.test(key)) {
+      throw new Error(
+        `CSV column "${key}" is not a valid identifier; rename it using letters, digits, or underscore.`
+      );
+    }
+  }
+}
+
 /**
  * Parse CSV text and execute the user's row body over the rows in batches, each
  * batch a single `UNWIND $rows` query (atomic per chunk; earlier chunks stay
@@ -323,10 +342,14 @@ export async function executeCsvIngestion(
   }
 
   const rows = parseCsvRows(csvText);
-  const items: CsvRowItem[] = rows.map((row, index) => ({
-    index,
-    data: transformRow ? transformRow(row) : row,
-  }));
+  assertSafeCsvHeaders(rows);
+  const items: CsvRowItem[] = rows.map((row, index) => {
+    try {
+      return { index, data: transformRow ? transformRow(row) : row };
+    } catch (error) {
+      throw new Error(`Failed to process CSV row ${index + 1}: ${(error as Error).message}`);
+    }
+  });
   const chunks = chunkCsvItems(items, chunkSize, maxChunkBytes);
   const query = buildBatchCsvQuery(statement);
 

--- a/app/api/graph/[graph]/upload/upload-utils.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.ts
@@ -219,12 +219,7 @@ export function splitCypherStatements(cypherBatch: string): string[] {
   return queries;
 }
 
-/**
- * Parse CSV text and execute the user-provided query once per row, passing the
- * row object and its zero-based index as `$row` / `$index` query parameters.
- * Returns the number of rows processed. Failures are annotated with the row
- * number so partial-batch errors are actionable.
- */
+/** Default batching bounds for CSV ingestion: rows per chunk and bytes per chunk. */
 export const DEFAULT_CSV_CHUNK_SIZE = 1000;
 export const DEFAULT_CSV_CHUNK_BYTES = 512 * 1024;
 
@@ -265,6 +260,13 @@ export function buildBatchCsvQuery(body: string): string {
   return `UNWIND $rows AS __r WITH __r.index AS index, __r.data AS row\n${normalized}`;
 }
 
+const csvByteEncoder = new TextEncoder();
+
+/** Approximate the serialized UTF-8 byte size of a row item. */
+function approximateItemBytes(item: CsvRowItem): number {
+  return csvByteEncoder.encode(JSON.stringify(item)).length;
+}
+
 /**
  * Split row items into chunks bounded by both a row count and an approximate
  * serialized byte size, so wide rows don't produce oversized query params.
@@ -279,7 +281,7 @@ export function chunkCsvItems(
   let currentBytes = 0;
 
   for (const item of items) {
-    const size = JSON.stringify(item).length;
+    const size = approximateItemBytes(item);
     if (current.length > 0 && (current.length >= maxRows || currentBytes + size > maxBytes)) {
       chunks.push(current);
       current = [];
@@ -358,9 +360,9 @@ export async function executeCsvIngestion(
     try {
       // Row items carry coerced (possibly non-string) values; FalkorDB accepts
       // the list-of-maps shape at runtime, so bind it as query params.
-      const options = { params: { rows: chunk } } as unknown as QueryOptions;
+      const queryOptions = { params: { rows: chunk } } as unknown as QueryOptions;
       // eslint-disable-next-line no-await-in-loop
-      await graph.query(query, options);
+      await graph.query(query, queryOptions);
     } catch (error) {
       const first = chunk[0].index + 1;
       const last = chunk[chunk.length - 1].index + 1;

--- a/app/components/graph/UploadGraph.tsx
+++ b/app/components/graph/UploadGraph.tsx
@@ -158,13 +158,13 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange }:
                     </TabsContent>
                     <TabsContent value="csv" className="mt-2 flex flex-col gap-2">
                         <p className="text-sm text-muted-foreground">
-                            Upload a .csv file and execute the query once per row using params: $row, $index.
+                            Upload a .csv file. Your query runs for each row (available as <code>row</code>, plus <code>index</code>); rows are executed in batches with UNWIND.
                         </p>
                         <textarea
                             className="flex min-h-[90px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                             aria-label="CSV ingestion Cypher query"
                             value={csvQuery}
-                            placeholder="UNWIND [$row] AS row CREATE (:Person {name: row.name, age: toInteger(row.age)})"
+                            placeholder="CREATE (:Person {name: row.name, age: toInteger(row.age)})"
                             onChange={(e) => setCsvQuery(e.target.value)}
                         />
                     </TabsContent>

--- a/e2e/tests/uploadGraph.spec.ts
+++ b/e2e/tests/uploadGraph.spec.ts
@@ -16,7 +16,7 @@ const CYPHER_FIXTURE = path.join(FIXTURES_DIR, "upload-people.cypher");
 // CSV upload: 3 data rows → 3 Person nodes created
 // ---------------------------------------------------------------------------
 const CSV_QUERY =
-  "UNWIND [$row] AS row CREATE (:Person {name: row.name, age: toInteger(row.age), city: row.city})";
+  "CREATE (:Person {name: row.name, age: toInteger(row.age), city: row.city})";
 
 test.describe("Upload Graph – CSV", () => {
   let browser: BrowserWrapper;

--- a/readme-browser.md
+++ b/readme-browser.md
@@ -64,7 +64,7 @@ It allows a developer to interact with graphs loaded to FaklorDB, explore how sp
   - “Upload Data” dialog supports drag-and-drop file selection (Dropzone UI).
   - Supports three ingestion modes:
     - restore graph from a `.dump` export (replace contents),
-    - process `.csv` rows with a user-provided Cypher query,
+    - process `.csv` rows with a user-provided Cypher query (runs per `row` in UNWIND batches),
     - execute Cypher batch files (`.txt` / `.cql` / `.cypher`) statement-by-statement.
 
 ### Graph Info panel


### PR DESCRIPTION
# Batch CSV ingestion via chunked UNWIND

> Follow-up to #1911 (graph data ingestion). Stacked on `copilot/load-data-into-graph`; GitHub will retarget to `staging` after #1911 merges. **This PR is a plan — description first, implementation to follow.**

## Problem
CSV mode runs one `graph.query` per row (`executeCsvIngestion`, `app/api/graph/[graph]/upload/upload-utils.ts`). A 5 MB CSV → thousands of sequential round-trips: slow, timeout-prone, and non-atomic (a failure at row N leaves rows 0..N-1 committed).

## Approach
Execute the user's row-stream body over a **batch** with `UNWIND $rows AS row <body>`, in **chunks**.
- **Contract (refined):** the user provides a single Cypher **row-stream body** that references `row` (and `index`), e.g. `CREATE (:Person {name: row.name, age: toInteger(row.age)})`. The server owns the wrapper and prepends both bindings:
  `UNWIND $rows AS __r WITH __r.index AS index, __r.data AS row` + `<body>`.
- One `graph.query` per chunk (default 1000 rows, tunable constant); rows sent as `[{ index, data }]`.
- **Multi-statement bodies (semicolons) are rejected** — a chunk is a single query.

## Changes
- `upload-utils.ts`: `chunkBySizeAndCount(rows, maxRows, maxBytes)`, `buildBatchCsvQuery(body)`, and a batched `executeCsvIngestion(graph, csvText, body, opts)` that returns a **structured result** `{ processedRows, chunks, failedChunkRange? }` and exposes a per-row **transform hook** (seam for the typed-columns PR).
- `route.ts`: call the batched version; surface the structured result.
- `UploadGraph.tsx` + `readme-browser.md`: update the CSV help/placeholder/example to the new body contract.

## Testing
- Unit (`upload-utils.test.ts`, `node --test` + `mock.fn`): chunk sizing by count **and** approx byte size (wide-row case), remainder/boundary (rows == chunkSize, +1); `buildBatchCsvQuery` composition; ingestion issues `ceil(rows/chunk)` queries with `{ params: { rows } }`; empty CSV → 0 queries; chunk failure annotates the row range.
- **e2e (live FalkorDB):** a 2-row batch through `UNWIND $rows AS row CREATE ...` asserting list-of-map params actually work end-to-end (unit mocks can't prove this).

## Notes / risks
- **Semantics:** cardinality-changing clauses (`WITH` aggregation, `DISTINCT`, `ORDER BY`, `LIMIT`, nested `UNWIND`) operate over the **chunk**, not a single row — documented explicitly.
- **Atomicity:** atomic **per chunk** (single `GRAPH.QUERY`); earlier successful chunks stay committed if a later chunk fails — this is not all-or-nothing file import.
- Unreleased feature ⇒ not a released-API break, but call out the CSV-body contract change in release notes.

<sub>Plan reviewed via rubber-duck; incorporated: single-body (not "per-row") framing, preserved `index`, tightened atomicity wording, list-of-map e2e, byte-size chunking, and a result/transform seam for the typed-columns PR.</sub>
