### PR TITLE
feat: guided CSV ingestion (preview, typed columns, result summary)

### DIFF
--- a/app/api/graph/[graph]/upload/route.ts
+++ b/app/api/graph/[graph]/upload/route.ts
@@ -105,7 +105,11 @@ export async function POST(
         const result = await executeCsvIngestion(graph, csvText, query ?? "");
 
         return NextResponse.json(
-          { message: `Processed ${result.processedRows} CSV row(s) in ${result.chunks} batch(es).` },
+          {
+            message: `Processed ${result.processedRows} CSV row(s) in ${result.chunks} batch(es).`,
+            processedRows: result.processedRows,
+            chunks: result.chunks,
+          },
           { status: 200, headers: getCorsHeaders(request) }
         );
       }

--- a/app/api/graph/[graph]/upload/route.ts
+++ b/app/api/graph/[graph]/upload/route.ts
@@ -7,12 +7,15 @@ import {
   validateUploadInput,
   executeCsvIngestion,
   executeCypherBatch,
+  coerceRow,
+  type CsvColumnType,
 } from "./upload-utils";
 
 interface UploadBody {
   mode?: string;
   fileId?: string;
   query?: string;
+  columnTypes?: Record<string, CsvColumnType>;
 }
 
 export async function OPTIONS(request: Request) {
@@ -52,7 +55,7 @@ export async function POST(
       );
     }
 
-    const { mode, fileId, query } = body;
+    const { mode, fileId, query, columnTypes } = body;
 
     if (!mode || !fileId) {
       return NextResponse.json(
@@ -102,7 +105,12 @@ export async function POST(
 
       if (validation.mode === "csv") {
         const csvText = await fs.promises.readFile(storedUpload.filePath, "utf-8");
-        const result = await executeCsvIngestion(graph, csvText, query ?? "");
+        const result = await executeCsvIngestion(graph, csvText, query ?? "", {
+          transformRow:
+            columnTypes && Object.keys(columnTypes).length > 0
+              ? (row) => coerceRow(row, columnTypes)
+              : undefined,
+        });
 
         return NextResponse.json(
           {

--- a/app/api/graph/[graph]/upload/route.ts
+++ b/app/api/graph/[graph]/upload/route.ts
@@ -102,10 +102,10 @@ export async function POST(
 
       if (validation.mode === "csv") {
         const csvText = await fs.promises.readFile(storedUpload.filePath, "utf-8");
-        const count = await executeCsvIngestion(graph, csvText, query ?? "");
+        const result = await executeCsvIngestion(graph, csvText, query ?? "");
 
         return NextResponse.json(
-          { message: `Processed ${count} CSV row(s).` },
+          { message: `Processed ${result.processedRows} CSV row(s) in ${result.chunks} batch(es).` },
           { status: 200, headers: getCorsHeaders(request) }
         );
       }

--- a/app/api/graph/[graph]/upload/upload-utils.test.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.test.ts
@@ -7,6 +7,9 @@ import {
   validateUploadInput,
   executeCsvIngestion,
   executeCypherBatch,
+  buildBatchCsvQuery,
+  chunkCsvItems,
+  type CsvRowItem,
 } from "./upload-utils.ts";
 
 function makeGraph(
@@ -241,48 +244,134 @@ test("validateUploadInput rejects an unknown mode", () => {
 });
 
 // ---------------------------------------------------------------------------
-// executeCsvIngestion
+// buildBatchCsvQuery
 // ---------------------------------------------------------------------------
 
-test("executeCsvIngestion runs the query once per row with row and index params", async () => {
+test("buildBatchCsvQuery wraps the body in an UNWIND exposing row and index", () => {
+  assert.equal(
+    buildBatchCsvQuery("CREATE (:Person {name: row.name})"),
+    "UNWIND $rows AS __r WITH __r.index AS index, __r.data AS row\nCREATE (:Person {name: row.name})"
+  );
+});
+
+test("buildBatchCsvQuery trims and strips a trailing semicolon", () => {
+  assert.match(buildBatchCsvQuery("  CREATE (:A) ;  "), /AS row\nCREATE \(:A\)$/);
+});
+
+// ---------------------------------------------------------------------------
+// chunkCsvItems
+// ---------------------------------------------------------------------------
+
+function makeItems(n: number): CsvRowItem[] {
+  return Array.from({ length: n }, (_, i) => ({ index: i, data: { v: String(i) } }));
+}
+
+test("chunkCsvItems splits by row count", () => {
+  const chunks = chunkCsvItems(makeItems(5), 2, 1_000_000);
+  assert.deepEqual(chunks.map((c) => c.length), [2, 2, 1]);
+  assert.deepEqual(chunks[2][0], { index: 4, data: { v: "4" } });
+});
+
+test("chunkCsvItems returns a single chunk when everything fits", () => {
+  const chunks = chunkCsvItems(makeItems(3), 1000, 1_000_000);
+  assert.equal(chunks.length, 1);
+  assert.equal(chunks[0].length, 3);
+});
+
+test("chunkCsvItems splits by approximate byte size for wide rows", () => {
+  const wide: CsvRowItem[] = Array.from({ length: 4 }, (_, i) => ({
+    index: i,
+    data: { blob: "x".repeat(100) },
+  }));
+  const chunks = chunkCsvItems(wide, 1000, 80);
+  assert.equal(chunks.length, 4);
+});
+
+test("chunkCsvItems returns no chunks for an empty list", () => {
+  assert.deepEqual(chunkCsvItems([], 1000, 1000), []);
+});
+
+// ---------------------------------------------------------------------------
+// executeCsvIngestion (batched)
+// ---------------------------------------------------------------------------
+
+test("executeCsvIngestion runs one batched UNWIND query per chunk with row items", async () => {
   const { graph, querySpy } = makeGraph();
-  const query = "CREATE (:Person {name: $row.name})";
 
-  const count = await executeCsvIngestion(graph, "name,age\nAlice,30\nBob,41", query);
+  const result = await executeCsvIngestion(
+    graph,
+    "name,age\nAlice,30\nBob,41",
+    "CREATE (:Person {name: row.name})"
+  );
 
-  assert.equal(count, 2);
-  assert.equal(querySpy.mock.callCount(), 2);
-  assert.equal(querySpy.mock.calls[0].arguments[0], query);
+  assert.deepEqual(result, { processedRows: 2, chunks: 1 });
+  assert.equal(querySpy.mock.callCount(), 1);
+  assert.match(
+    querySpy.mock.calls[0].arguments[0] as string,
+    /^UNWIND \$rows AS __r WITH __r\.index AS index, __r\.data AS row\n/
+  );
   assert.deepEqual(querySpy.mock.calls[0].arguments[1], {
-    params: { row: { name: "Alice", age: "30" }, index: 0 },
+    params: {
+      rows: [
+        { index: 0, data: { name: "Alice", age: "30" } },
+        { index: 1, data: { name: "Bob", age: "41" } },
+      ],
+    },
   });
-  assert.deepEqual(querySpy.mock.calls[1].arguments[1], {
-    params: { row: { name: "Bob", age: "41" }, index: 1 },
+});
+
+test("executeCsvIngestion splits large inputs into multiple chunk queries", async () => {
+  const { graph, querySpy } = makeGraph();
+  const csv = ["name", "n0", "n1", "n2", "n3", "n4"].join("\n");
+
+  const result = await executeCsvIngestion(graph, csv, "CREATE (:P {n: row.name})", {
+    chunkSize: 2,
+  });
+
+  assert.deepEqual(result, { processedRows: 5, chunks: 3 });
+  assert.equal(querySpy.mock.callCount(), 3);
+});
+
+test("executeCsvIngestion applies the transformRow hook before binding params", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await executeCsvIngestion(graph, "age\n30", "CREATE (:P {age: row.age})", {
+    transformRow: (row) => ({ age: Number(row.age) }),
+  });
+
+  assert.deepEqual(querySpy.mock.calls[0].arguments[1], {
+    params: { rows: [{ index: 0, data: { age: 30 } }] },
   });
 });
 
 test("executeCsvIngestion runs no query and returns 0 for an empty CSV", async () => {
   const { graph, querySpy } = makeGraph();
 
-  const count = await executeCsvIngestion(graph, "", "CREATE (:P)");
+  const result = await executeCsvIngestion(graph, "", "CREATE (:P {n: row.name})");
 
-  assert.equal(count, 0);
+  assert.deepEqual(result, { processedRows: 0, chunks: 0 });
   assert.equal(querySpy.mock.callCount(), 0);
 });
 
-test("executeCsvIngestion annotates failures with the row number and stops", async () => {
-  let calls = 0;
-  const { graph, querySpy } = makeGraph(async () => {
-    calls += 1;
-    if (calls === 2) throw new Error("boom");
-    return { data: [] };
+test("executeCsvIngestion rejects a multi-statement body before running anything", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await assert.rejects(
+    () => executeCsvIngestion(graph, "n\n1", "CREATE (:A); CREATE (:B)"),
+    /must be a single Cypher statement/
+  );
+  assert.equal(querySpy.mock.callCount(), 0);
+});
+
+test("executeCsvIngestion annotates failures with the failing chunk's row range", async () => {
+  const { graph } = makeGraph(async () => {
+    throw new Error("boom");
   });
 
   await assert.rejects(
-    () => executeCsvIngestion(graph, "name\nA\nB\nC", "CREATE (:P {n: $row.name})"),
-    /Failed to process CSV row 2: boom/
+    () => executeCsvIngestion(graph, "n\nA\nB\nC", "CREATE (:P {n: row.name})", { chunkSize: 2 }),
+    /Failed to process CSV rows 1-2: boom/
   );
-  assert.equal(querySpy.mock.callCount(), 2);
 });
 
 // ---------------------------------------------------------------------------

--- a/app/api/graph/[graph]/upload/upload-utils.test.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.test.ts
@@ -363,6 +363,27 @@ test("executeCsvIngestion rejects a multi-statement body before running anything
   assert.equal(querySpy.mock.callCount(), 0);
 });
 
+test("executeCsvIngestion uses the normalized statement (drops a trailing comment/semicolon)", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await executeCsvIngestion(graph, "n\n1", "CREATE (:A {n: row.n}); // trailing");
+
+  assert.match(
+    querySpy.mock.calls[0].arguments[0] as string,
+    /AS row\nCREATE \(:A \{n: row\.n\}\)$/
+  );
+});
+
+test("executeCsvIngestion rejects an empty/comment-only body", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await assert.rejects(
+    () => executeCsvIngestion(graph, "n\n1", "// just a comment"),
+    /CSV query is empty/
+  );
+  assert.equal(querySpy.mock.callCount(), 0);
+});
+
 test("executeCsvIngestion annotates failures with the failing chunk's row range", async () => {
   const { graph } = makeGraph(async () => {
     throw new Error("boom");

--- a/app/api/graph/[graph]/upload/upload-utils.test.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.test.ts
@@ -395,6 +395,32 @@ test("executeCsvIngestion annotates failures with the failing chunk's row range"
   );
 });
 
+test("executeCsvIngestion rejects CSV headers that are not valid identifiers", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await assert.rejects(
+    () => executeCsvIngestion(graph, "first name\nAlice", "CREATE (:P {n: row.name})"),
+    /CSV column "first name" is not a valid identifier/
+  );
+  assert.equal(querySpy.mock.callCount(), 0);
+});
+
+test("executeCsvIngestion annotates transformRow errors with the row number", async () => {
+  const { graph, querySpy } = makeGraph();
+
+  await assert.rejects(
+    () =>
+      executeCsvIngestion(graph, "n\nA\nB", "CREATE (:P {n: row.n})", {
+        transformRow: (row) => {
+          if (row.n === "B") throw new Error('Column "n": bad');
+          return row;
+        },
+      }),
+    /Failed to process CSV row 2: Column "n": bad/
+  );
+  assert.equal(querySpy.mock.callCount(), 0);
+});
+
 // ---------------------------------------------------------------------------
 // executeCypherBatch
 // ---------------------------------------------------------------------------

--- a/app/api/graph/[graph]/upload/upload-utils.test.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.test.ts
@@ -496,6 +496,10 @@ test("coerceValue rejects non-integers", () => {
   assert.throws(() => coerceValue("abc", "integer"), /not an integer/);
 });
 
+test("coerceValue rejects integers outside the safe range", () => {
+  assert.throws(() => coerceValue("9007199254740993", "integer"), /safe integer range/);
+});
+
 test("coerceValue parses floats and rejects invalid", () => {
   assert.equal(coerceValue("3.14", "float"), 3.14);
   assert.equal(coerceValue("", "float"), null);

--- a/app/api/graph/[graph]/upload/upload-utils.test.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.test.ts
@@ -9,6 +9,10 @@ import {
   executeCypherBatch,
   buildBatchCsvQuery,
   chunkCsvItems,
+  coerceValue,
+  coerceRow,
+  escapeCypherIdentifier,
+  generateCsvQuery,
   type CsvRowItem,
 } from "./upload-utils.ts";
 
@@ -470,4 +474,84 @@ test("splitCypherStatements replaces block comments with a boundary (no token me
 
 test("splitCypherStatements retains an unterminated block comment so it surfaces downstream", () => {
   assert.deepEqual(splitCypherStatements("CREATE (:A); /* oops"), ["CREATE (:A)", "/* oops"]);
+});
+
+// ---------------------------------------------------------------------------
+// coerceValue / coerceRow
+// ---------------------------------------------------------------------------
+
+test("coerceValue returns strings unchanged", () => {
+  assert.equal(coerceValue("hello", "string"), "hello");
+  assert.equal(coerceValue("", "string"), "");
+});
+
+test("coerceValue parses integers and maps empty to null", () => {
+  assert.equal(coerceValue("42", "integer"), 42);
+  assert.equal(coerceValue("-7", "integer"), -7);
+  assert.equal(coerceValue("  ", "integer"), null);
+});
+
+test("coerceValue rejects non-integers", () => {
+  assert.throws(() => coerceValue("4.5", "integer"), /not an integer/);
+  assert.throws(() => coerceValue("abc", "integer"), /not an integer/);
+});
+
+test("coerceValue parses floats and rejects invalid", () => {
+  assert.equal(coerceValue("3.14", "float"), 3.14);
+  assert.equal(coerceValue("", "float"), null);
+  assert.throws(() => coerceValue("x", "float"), /not a number/);
+});
+
+test("coerceValue parses booleans (true/false/1/0, case-insensitive)", () => {
+  assert.equal(coerceValue("true", "boolean"), true);
+  assert.equal(coerceValue("FALSE", "boolean"), false);
+  assert.equal(coerceValue("1", "boolean"), true);
+  assert.equal(coerceValue("0", "boolean"), false);
+  assert.equal(coerceValue("", "boolean"), null);
+  assert.throws(() => coerceValue("maybe", "boolean"), /not a boolean/);
+});
+
+test("coerceRow applies per-column types and defaults unlisted columns to string", () => {
+  assert.deepEqual(
+    coerceRow({ name: "Alice", age: "30", vip: "true" }, { age: "integer", vip: "boolean" }),
+    { name: "Alice", age: 30, vip: true }
+  );
+});
+
+test("coerceRow annotates conversion errors with the column name", () => {
+  assert.throws(() => coerceRow({ age: "old" }, { age: "integer" }), /Column "age": .*not an integer/);
+});
+
+// ---------------------------------------------------------------------------
+// escapeCypherIdentifier / generateCsvQuery
+// ---------------------------------------------------------------------------
+
+test("escapeCypherIdentifier leaves valid identifiers bare", () => {
+  assert.equal(escapeCypherIdentifier("name"), "name");
+  assert.equal(escapeCypherIdentifier("_x1"), "_x1");
+});
+
+test("escapeCypherIdentifier backtick-quotes and doubles embedded backticks", () => {
+  assert.equal(escapeCypherIdentifier("first name"), "`first name`");
+  assert.equal(escapeCypherIdentifier("a`b"), "`a``b`");
+  assert.equal(escapeCypherIdentifier("1col"), "`1col`");
+});
+
+test("generateCsvQuery builds a CREATE with escaped label and props", () => {
+  assert.equal(
+    generateCsvQuery("Person", ["name", "age"]),
+    "CREATE (:Person {name: row.name, age: row.age})"
+  );
+});
+
+test("generateCsvQuery escapes unsafe headers/label so they cannot inject Cypher", () => {
+  const q = generateCsvQuery("La bel", ["first name", "x`) DETACH DELETE n //"]);
+  assert.match(q, /^CREATE \(:`La bel` \{/);
+  assert.ok(q.includes("`first name`: row.`first name`"));
+  assert.ok(q.includes("`x``) DETACH DELETE n //`: row.`x``) DETACH DELETE n //`"));
+});
+
+test("generateCsvQuery defaults the label and handles no columns", () => {
+  assert.equal(generateCsvQuery("", []), "CREATE (:Row)");
+  assert.equal(generateCsvQuery("  ", ["a"]), "CREATE (:Row {a: row.a})");
 });

--- a/app/api/graph/[graph]/upload/upload-utils.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.ts
@@ -247,6 +247,86 @@ export interface CsvIngestionResult {
   chunks: number;
 }
 
+export type CsvColumnType = "string" | "integer" | "float" | "boolean";
+
+/**
+ * Coerce a raw CSV cell (always a string) to the target column type.
+ * Empty values become null for non-string types. Invalid values throw so the
+ * caller can surface an actionable error. Unknown types fall back to string.
+ */
+export function coerceValue(value: string, type: CsvColumnType): CsvParamValue {
+  if (type === "integer" || type === "float" || type === "boolean") {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+
+    if (type === "integer") {
+      if (!/^[+-]?\d+$/.test(trimmed)) {
+        throw new Error(`"${value}" is not an integer`);
+      }
+      return Number.parseInt(trimmed, 10);
+    }
+
+    if (type === "float") {
+      const parsed = Number(trimmed);
+      if (!Number.isFinite(parsed)) {
+        throw new Error(`"${value}" is not a number`);
+      }
+      return parsed;
+    }
+
+    const lower = trimmed.toLowerCase();
+    if (lower === "true" || lower === "1") return true;
+    if (lower === "false" || lower === "0") return false;
+    throw new Error(`"${value}" is not a boolean`);
+  }
+
+  return value;
+}
+
+/**
+ * Coerce every cell of a row using a per-column type map (default string).
+ * Errors are annotated with the column name.
+ */
+export function coerceRow(
+  row: Record<string, string>,
+  columnTypes: Record<string, CsvColumnType>
+): Record<string, CsvParamValue> {
+  const result: Record<string, CsvParamValue> = {};
+  for (const [key, raw] of Object.entries(row)) {
+    try {
+      result[key] = coerceValue(raw, columnTypes[key] ?? "string");
+    } catch (error) {
+      throw new Error(`Column "${key}": ${(error as Error).message}`);
+    }
+  }
+  return result;
+}
+
+const CYPHER_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Return a name usable as a Cypher label/property key: bare when it is a valid
+ * identifier, otherwise backtick-quoted with embedded backticks doubled.
+ */
+export function escapeCypherIdentifier(name: string): string {
+  if (CYPHER_IDENTIFIER.test(name)) return name;
+  return `\`${name.replace(/`/g, "``")}\``;
+}
+
+/**
+ * Build a safe starter `CREATE` statement from a node label and CSV headers.
+ * Labels and property keys are escaped so arbitrary header text cannot inject
+ * Cypher.
+ */
+export function generateCsvQuery(label: string, columns: string[]): string {
+  const safeLabel = escapeCypherIdentifier(label.trim() || "Row");
+  const props = columns
+    .filter((col) => col.trim() !== "")
+    .map((col) => `${escapeCypherIdentifier(col)}: row.${escapeCypherIdentifier(col)}`)
+    .join(", ");
+  return props ? `CREATE (:${safeLabel} {${props}})` : `CREATE (:${safeLabel})`;
+}
+
 /**
  * Wrap a user-provided per-row Cypher body so it runs over a batch of rows.
  * Each row is exposed as `row` (a map) and its zero-based position as `index`.

--- a/app/api/graph/[graph]/upload/upload-utils.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.ts
@@ -263,7 +263,11 @@ export function coerceValue(value: string, type: CsvColumnType): CsvParamValue {
       if (!/^[+-]?\d+$/.test(trimmed)) {
         throw new Error(`"${value}" is not an integer`);
       }
-      return Number.parseInt(trimmed, 10);
+      const parsed = Number.parseInt(trimmed, 10);
+      if (!Number.isSafeInteger(parsed)) {
+        throw new Error(`"${value}" is out of the safe integer range`);
+      }
+      return parsed;
     }
 
     if (type === "float") {

--- a/app/api/graph/[graph]/upload/upload-utils.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.ts
@@ -228,15 +228,23 @@ export function splitCypherStatements(cypherBatch: string): string[] {
 export const DEFAULT_CSV_CHUNK_SIZE = 1000;
 export const DEFAULT_CSV_CHUNK_BYTES = 512 * 1024;
 
+export type CsvParamValue =
+  | null
+  | string
+  | number
+  | boolean
+  | CsvParamValue[]
+  | { [key: string]: CsvParamValue };
+
 export interface CsvRowItem {
   index: number;
-  data: Record<string, unknown>;
+  data: Record<string, CsvParamValue>;
 }
 
 export interface CsvIngestionOptions {
   chunkSize?: number;
   maxChunkBytes?: number;
-  transformRow?: (row: Record<string, string>) => Record<string, unknown>;
+  transformRow?: (row: Record<string, string>) => Record<string, CsvParamValue>;
 }
 
 export interface CsvIngestionResult {
@@ -305,8 +313,13 @@ export async function executeCsvIngestion(
     transformRow,
   } = options;
 
-  if (splitCypherStatements(body).length > 1) {
+  const statements = splitCypherStatements(body);
+  if (statements.length > 1) {
     throw new Error("The CSV query must be a single Cypher statement.");
+  }
+  const [statement] = statements;
+  if (!statement) {
+    throw new Error("The CSV query is empty.");
   }
 
   const rows = parseCsvRows(csvText);
@@ -315,7 +328,7 @@ export async function executeCsvIngestion(
     data: transformRow ? transformRow(row) : row,
   }));
   const chunks = chunkCsvItems(items, chunkSize, maxChunkBytes);
-  const query = buildBatchCsvQuery(body);
+  const query = buildBatchCsvQuery(statement);
 
   for (let c = 0; c < chunks.length; c += 1) {
     const chunk = chunks[c];

--- a/app/api/graph/[graph]/upload/upload-utils.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.ts
@@ -1,4 +1,5 @@
 import type { Graph } from "falkordb";
+import type { QueryOptions } from "falkordb/dist/src/commands";
 
 export type UploadMode = "rdb" | "csv" | "cypher";
 
@@ -224,23 +225,116 @@ export function splitCypherStatements(cypherBatch: string): string[] {
  * Returns the number of rows processed. Failures are annotated with the row
  * number so partial-batch errors are actionable.
  */
+export const DEFAULT_CSV_CHUNK_SIZE = 1000;
+export const DEFAULT_CSV_CHUNK_BYTES = 512 * 1024;
+
+export interface CsvRowItem {
+  index: number;
+  data: Record<string, unknown>;
+}
+
+export interface CsvIngestionOptions {
+  chunkSize?: number;
+  maxChunkBytes?: number;
+  transformRow?: (row: Record<string, string>) => Record<string, unknown>;
+}
+
+export interface CsvIngestionResult {
+  processedRows: number;
+  chunks: number;
+}
+
+/**
+ * Wrap a user-provided per-row Cypher body so it runs over a batch of rows.
+ * Each row is exposed as `row` (a map) and its zero-based position as `index`.
+ * A trailing semicolon is stripped so the result is a single statement.
+ *
+ * Note: cardinality-changing clauses in the body (aggregating `WITH`, `LIMIT`,
+ * a nested `UNWIND`, etc.) operate over the whole chunk, not a single row.
+ */
+export function buildBatchCsvQuery(body: string): string {
+  const normalized = body.replace(/[;\s]+$/, "").trim();
+  return `UNWIND $rows AS __r WITH __r.index AS index, __r.data AS row\n${normalized}`;
+}
+
+/**
+ * Split row items into chunks bounded by both a row count and an approximate
+ * serialized byte size, so wide rows don't produce oversized query params.
+ */
+export function chunkCsvItems(
+  items: CsvRowItem[],
+  maxRows: number,
+  maxBytes: number
+): CsvRowItem[][] {
+  const chunks: CsvRowItem[][] = [];
+  let current: CsvRowItem[] = [];
+  let currentBytes = 0;
+
+  for (const item of items) {
+    const size = JSON.stringify(item).length;
+    if (current.length > 0 && (current.length >= maxRows || currentBytes + size > maxBytes)) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(item);
+    currentBytes += size;
+  }
+
+  if (current.length > 0) chunks.push(current);
+
+  return chunks;
+}
+
+/**
+ * Parse CSV text and execute the user's row body over the rows in batches, each
+ * batch a single `UNWIND $rows` query (atomic per chunk; earlier chunks stay
+ * committed if a later one fails). Returns the number of rows and chunks
+ * processed. The optional `transformRow` hook lets callers coerce raw string
+ * cells before they are bound as query params.
+ */
 export async function executeCsvIngestion(
   graph: Graph,
   csvText: string,
-  query: string
-): Promise<number> {
-  const rows = parseCsvRows(csvText);
+  body: string,
+  options: CsvIngestionOptions = {}
+): Promise<CsvIngestionResult> {
+  const {
+    chunkSize = DEFAULT_CSV_CHUNK_SIZE,
+    maxChunkBytes = DEFAULT_CSV_CHUNK_BYTES,
+    transformRow,
+  } = options;
 
-  for (let index = 0; index < rows.length; index += 1) {
+  if (splitCypherStatements(body).length > 1) {
+    throw new Error("The CSV query must be a single Cypher statement.");
+  }
+
+  const rows = parseCsvRows(csvText);
+  const items: CsvRowItem[] = rows.map((row, index) => ({
+    index,
+    data: transformRow ? transformRow(row) : row,
+  }));
+  const chunks = chunkCsvItems(items, chunkSize, maxChunkBytes);
+  const query = buildBatchCsvQuery(body);
+
+  for (let c = 0; c < chunks.length; c += 1) {
+    const chunk = chunks[c];
     try {
+      // Row items carry coerced (possibly non-string) values; FalkorDB accepts
+      // the list-of-maps shape at runtime, so bind it as query params.
+      const options = { params: { rows: chunk } } as unknown as QueryOptions;
       // eslint-disable-next-line no-await-in-loop
-      await graph.query(query, { params: { row: rows[index], index } });
+      await graph.query(query, options);
     } catch (error) {
-      throw new Error(`Failed to process CSV row ${index + 1}: ${(error as Error).message}`);
+      const first = chunk[0].index + 1;
+      const last = chunk[chunk.length - 1].index + 1;
+      throw new Error(
+        `Failed to process CSV rows ${first}-${last}: ${(error as Error).message}`
+      );
     }
   }
 
-  return rows.length;
+  return { processedRows: rows.length, chunks: chunks.length };
 }
 
 /**

--- a/app/api/graph/[graph]/upload/upload-utils.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.ts
@@ -294,6 +294,25 @@ export function chunkCsvItems(
   return chunks;
 }
 
+const CSV_HEADER_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Reject CSV headers that aren't valid Cypher identifiers. The FalkorDB param
+ * serializer emits map keys verbatim (`{key:value}`), so a header with spaces or
+ * special characters would produce an invalid — and potentially injectable — map
+ * literal when bound as `$rows`.
+ */
+function assertSafeCsvHeaders(rows: Record<string, string>[]): void {
+  if (rows.length === 0) return;
+  for (const key of Object.keys(rows[0])) {
+    if (!CSV_HEADER_IDENTIFIER.test(key)) {
+      throw new Error(
+        `CSV column "${key}" is not a valid identifier; rename it using letters, digits, or underscore.`
+      );
+    }
+  }
+}
+
 /**
  * Parse CSV text and execute the user's row body over the rows in batches, each
  * batch a single `UNWIND $rows` query (atomic per chunk; earlier chunks stay
@@ -323,10 +342,14 @@ export async function executeCsvIngestion(
   }
 
   const rows = parseCsvRows(csvText);
-  const items: CsvRowItem[] = rows.map((row, index) => ({
-    index,
-    data: transformRow ? transformRow(row) : row,
-  }));
+  assertSafeCsvHeaders(rows);
+  const items: CsvRowItem[] = rows.map((row, index) => {
+    try {
+      return { index, data: transformRow ? transformRow(row) : row };
+    } catch (error) {
+      throw new Error(`Failed to process CSV row ${index + 1}: ${(error as Error).message}`);
+    }
+  });
   const chunks = chunkCsvItems(items, chunkSize, maxChunkBytes);
   const query = buildBatchCsvQuery(statement);
 

--- a/app/api/graph/[graph]/upload/upload-utils.ts
+++ b/app/api/graph/[graph]/upload/upload-utils.ts
@@ -219,12 +219,7 @@ export function splitCypherStatements(cypherBatch: string): string[] {
   return queries;
 }
 
-/**
- * Parse CSV text and execute the user-provided query once per row, passing the
- * row object and its zero-based index as `$row` / `$index` query parameters.
- * Returns the number of rows processed. Failures are annotated with the row
- * number so partial-batch errors are actionable.
- */
+/** Default batching bounds for CSV ingestion: rows per chunk and bytes per chunk. */
 export const DEFAULT_CSV_CHUNK_SIZE = 1000;
 export const DEFAULT_CSV_CHUNK_BYTES = 512 * 1024;
 
@@ -265,6 +260,13 @@ export function buildBatchCsvQuery(body: string): string {
   return `UNWIND $rows AS __r WITH __r.index AS index, __r.data AS row\n${normalized}`;
 }
 
+const csvByteEncoder = new TextEncoder();
+
+/** Approximate the serialized UTF-8 byte size of a row item. */
+function approximateItemBytes(item: CsvRowItem): number {
+  return csvByteEncoder.encode(JSON.stringify(item)).length;
+}
+
 /**
  * Split row items into chunks bounded by both a row count and an approximate
  * serialized byte size, so wide rows don't produce oversized query params.
@@ -279,7 +281,7 @@ export function chunkCsvItems(
   let currentBytes = 0;
 
   for (const item of items) {
-    const size = JSON.stringify(item).length;
+    const size = approximateItemBytes(item);
     if (current.length > 0 && (current.length >= maxRows || currentBytes + size > maxBytes)) {
       chunks.push(current);
       current = [];
@@ -358,9 +360,9 @@ export async function executeCsvIngestion(
     try {
       // Row items carry coerced (possibly non-string) values; FalkorDB accepts
       // the list-of-maps shape at runtime, so bind it as query params.
-      const options = { params: { rows: chunk } } as unknown as QueryOptions;
+      const queryOptions = { params: { rows: chunk } } as unknown as QueryOptions;
       // eslint-disable-next-line no-await-in-loop
-      await graph.query(query, options);
+      await graph.query(query, queryOptions);
     } catch (error) {
       const first = chunk[0].index + 1;
       const last = chunk[chunk.length - 1].index + 1;

--- a/app/components/graph/UploadGraph.tsx
+++ b/app/components/graph/UploadGraph.tsx
@@ -7,6 +7,7 @@ import CloseDialog from "../CloseDialog";
 import { IndicatorContext } from "../provider";
 import DialogComponent from "../DialogComponent";
 import { prepareArg, securedFetch } from "@/lib/utils";
+import { parseCsvRows, generateCsvQuery, type CsvColumnType } from "@/app/api/graph/[graph]/upload/upload-utils";
 
 type UploadMode = "rdb" | "csv" | "cypher";
 
@@ -21,6 +22,10 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange }:
     const [files, setFiles] = useState<File[]>([]);
     const [mode, setMode] = useState<UploadMode>("rdb");
     const [csvQuery, setCsvQuery] = useState("");
+    const [csvColumns, setCsvColumns] = useState<string[]>([]);
+    const [csvPreview, setCsvPreview] = useState<Record<string, string>[]>([]);
+    const [columnTypes, setColumnTypes] = useState<Record<string, CsvColumnType>>({});
+    const [nodeLabel, setNodeLabel] = useState("Row");
     const [isLoading, setIsLoading] = useState(false);
     const uploadInFlightRef = useRef(false);
     const isControlled = typeof open === "boolean" && typeof onOpenChange === "function";
@@ -47,9 +52,41 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange }:
             setCsvQuery("");
             setMode("rdb");
             setIsLoading(false);
+            setNodeLabel("Row");
             uploadInFlightRef.current = false;
         }
     }, [dialogOpen]);
+
+    useEffect(() => {
+        if (mode !== "csv" || files.length !== 1) {
+            setCsvColumns([]);
+            setCsvPreview([]);
+            setColumnTypes({});
+            return undefined;
+        }
+
+        let cancelled = false;
+        files[0].text()
+            .then((text) => {
+                if (cancelled) return;
+                const rows = parseCsvRows(text);
+                const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
+                setCsvColumns(columns);
+                setCsvPreview(rows.slice(0, 5));
+                setColumnTypes((prev) => {
+                    const next: Record<string, CsvColumnType> = {};
+                    columns.forEach((col) => { next[col] = prev[col] ?? "string"; });
+                    return next;
+                });
+            })
+            .catch(() => {
+                if (cancelled) return;
+                setCsvColumns([]);
+                setCsvPreview([]);
+            });
+
+        return () => { cancelled = true; };
+    }, [files, mode]);
 
     const onUploadData = async (e: FormEvent) => {
         e.preventDefault();
@@ -101,7 +138,8 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange }:
                     body: JSON.stringify({
                         mode,
                         fileId: id,
-                        query: mode === "csv" ? csvQuery : undefined
+                        query: mode === "csv" ? csvQuery : undefined,
+                        columnTypes: mode === "csv" ? columnTypes : undefined
                     })
                 },
                 toast,
@@ -167,6 +205,65 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange }:
                             placeholder="CREATE (:Person {name: row.name, age: toInteger(row.age)})"
                             onChange={(e) => setCsvQuery(e.target.value)}
                         />
+                        {csvColumns.length > 0 && (
+                            <div className="flex flex-col gap-2">
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    <label className="text-sm text-muted-foreground" htmlFor="csvNodeLabel">Node label</label>
+                                    <input
+                                        id="csvNodeLabel"
+                                        className="rounded-md border border-input bg-background px-2 py-1 text-sm"
+                                        value={nodeLabel}
+                                        onChange={(e) => setNodeLabel(e.target.value)}
+                                        aria-label="Generated node label"
+                                    />
+                                    <button
+                                        type="button"
+                                        className="rounded-md border border-input bg-background px-2 py-1 text-sm hover:bg-accent"
+                                        onClick={() => setCsvQuery(generateCsvQuery(nodeLabel, csvColumns))}
+                                        data-testid="uploadGenerateQuery"
+                                    >
+                                        Generate query
+                                    </button>
+                                </div>
+                                <p className="text-xs text-muted-foreground">
+                                    Preview & column types (values are coerced server-side before binding):
+                                </p>
+                                <div className="overflow-auto max-h-[30dvh] border border-input rounded-md">
+                                    <table className="w-full text-sm">
+                                        <thead>
+                                            <tr>
+                                                {csvColumns.map((col) => (
+                                                    <th key={col} className="px-2 py-1 text-left align-top">
+                                                        <div className="font-medium">{col}</div>
+                                                        <select
+                                                            className="mt-1 rounded-md border border-input bg-background px-1 py-0.5 text-xs"
+                                                            aria-label={`Type for column ${col}`}
+                                                            value={columnTypes[col] ?? "string"}
+                                                            onChange={(e) => setColumnTypes((prev) => ({ ...prev, [col]: e.target.value as CsvColumnType }))}
+                                                        >
+                                                            <option value="string">string</option>
+                                                            <option value="integer">integer</option>
+                                                            <option value="float">float</option>
+                                                            <option value="boolean">boolean</option>
+                                                        </select>
+                                                    </th>
+                                                ))}
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {csvPreview.map((previewRow, rowIndex) => (
+                                                // eslint-disable-next-line react/no-array-index-key
+                                                <tr key={rowIndex} className="border-t border-input">
+                                                    {csvColumns.map((col) => (
+                                                        <td key={col} className="px-2 py-1 align-top">{previewRow[col]}</td>
+                                                    ))}
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        )}
                     </TabsContent>
                     <TabsContent value="cypher" className="mt-2">
                         <p className="text-sm text-muted-foreground">

--- a/app/components/graph/UploadGraph.tsx
+++ b/app/components/graph/UploadGraph.tsx
@@ -66,7 +66,9 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange }:
         }
 
         let cancelled = false;
-        files[0].text()
+        // Read only a bounded prefix — enough for headers + preview rows —
+        // rather than the whole (up to 5 MB) file into browser memory.
+        files[0].slice(0, 64 * 1024).text()
             .then((text) => {
                 if (cancelled) return;
                 const rows = parseCsvRows(text);
@@ -228,6 +230,11 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange }:
                                 <p className="text-xs text-muted-foreground">
                                     Preview & column types (values are coerced server-side before binding):
                                 </p>
+                                {csvColumns.some((col) => !/^[A-Za-z_][A-Za-z0-9_]*$/.test(col)) && (
+                                    <p className="text-xs text-red-500">
+                                        Some column names aren&apos;t valid identifiers (letters, digits, underscore; not starting with a digit). Rename them in your CSV before uploading.
+                                    </p>
+                                )}
                                 <div className="overflow-auto max-h-[30dvh] border border-input rounded-md">
                                     <table className="w-full text-sm">
                                         <thead>

--- a/app/components/graph/UploadGraph.tsx
+++ b/app/components/graph/UploadGraph.tsx
@@ -158,13 +158,13 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange }:
                     </TabsContent>
                     <TabsContent value="csv" className="mt-2 flex flex-col gap-2">
                         <p className="text-sm text-muted-foreground">
-                            Upload a .csv file and execute the query once per row using params: $row, $index.
+                            Upload a .csv file. Your query runs for each row (available as <code>row</code>, plus <code>index</code>); rows are executed in batches with UNWIND.
                         </p>
                         <textarea
                             className="flex min-h-[90px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                             aria-label="CSV ingestion Cypher query"
                             value={csvQuery}
-                            placeholder="UNWIND [$row] AS row CREATE (:Person {name: row.name, age: toInteger(row.age)})"
+                            placeholder="CREATE (:Person {name: row.name, age: toInteger(row.age)})"
                             onChange={(e) => setCsvQuery(e.target.value)}
                         />
                     </TabsContent>

--- a/e2e/logic/POM/graphPage.ts
+++ b/e2e/logic/POM/graphPage.ts
@@ -1362,6 +1362,17 @@ export default class GraphPage extends BasePage {
     );
   }
 
+  /** Set the coercion type for a CSV column in the preview table. */
+  async setUploadColumnType(column: string, type: "string" | "integer" | "float" | "boolean"): Promise<void> {
+    await this.page.getByLabel(`Type for column ${column}`).selectOption(type);
+  }
+
+  /** Fill the generated-node label and click "Generate query". */
+  async generateCsvQuery(nodeLabel: string): Promise<void> {
+    await this.page.getByLabel("Generated node label").fill(nodeLabel);
+    await this.page.getByTestId("uploadGenerateQuery").click();
+  }
+
   /** Submit the upload form and wait for the dialog to close. */
   async clickUploadConfirm(): Promise<void> {
     await interactWhenVisible(

--- a/e2e/tests/uploadGraph.spec.ts
+++ b/e2e/tests/uploadGraph.spec.ts
@@ -16,7 +16,7 @@ const CYPHER_FIXTURE = path.join(FIXTURES_DIR, "upload-people.cypher");
 // CSV upload: 3 data rows → 3 Person nodes created
 // ---------------------------------------------------------------------------
 const CSV_QUERY =
-  "UNWIND [$row] AS row CREATE (:Person {name: row.name, age: toInteger(row.age), city: row.city})";
+  "CREATE (:Person {name: row.name, age: toInteger(row.age), city: row.city})";
 
 test.describe("Upload Graph – CSV", () => {
   let browser: BrowserWrapper;

--- a/e2e/tests/uploadGraph.spec.ts
+++ b/e2e/tests/uploadGraph.spec.ts
@@ -67,6 +67,33 @@ test.describe("Upload Graph – CSV", () => {
 
     await apiCall.removeGraph(graphName);
   });
+
+  test(`@admin CSV upload with a typed column + generated query coerces values`, async () => {
+    const graphName = getRandomString("uploadCsvTyped");
+    await apiCall.addGraph(graphName);
+
+    const graph = await browser.createNewPage(GraphPage, urls.graphUrl);
+    await graph.openUploadDialog(graphName);
+    await graph.selectUploadTab("csv");
+    await graph.setUploadFile(CSV_FIXTURE);
+    // Mark age as an integer and let the dialog generate the query (no toInteger)
+    await graph.setUploadColumnType("age", "integer");
+    await graph.generateCsvQuery("Person");
+    await graph.clickUploadConfirm();
+    await graph.toast.waitFor();
+
+    expect(await graph.toast.textContent()).toContain("Upload completed");
+
+    // age was coerced to an integer server-side, so an integer match works
+    const result = await apiCall.runQuery(
+      graphName,
+      "MATCH (n:Person) WHERE n.age = 30 RETURN count(n) AS cnt"
+    );
+    const cnt = result.data[0]?.cnt ?? result.data[0]?.["count(n)"];
+    expect(Number(cnt)).toBe(1);
+
+    await apiCall.removeGraph(graphName);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/readme-browser.md
+++ b/readme-browser.md
@@ -64,7 +64,7 @@ It allows a developer to interact with graphs loaded to FaklorDB, explore how sp
   - “Upload Data” dialog supports drag-and-drop file selection (Dropzone UI).
   - Supports three ingestion modes:
     - restore graph from a `.dump` export (replace contents),
-    - process `.csv` rows with a user-provided Cypher query (runs per `row` in UNWIND batches),
+    - process `.csv` rows with a user-provided Cypher query (runs per `row` in UNWIND batches, with a preview, per-column type coercion, and a generated starter query),
     - execute Cypher batch files (`.txt` / `.cql` / `.cypher`) statement-by-statement.
 
 ### Graph Info panel

--- a/readme-browser.md
+++ b/readme-browser.md
@@ -64,7 +64,7 @@ It allows a developer to interact with graphs loaded to FaklorDB, explore how sp
   - “Upload Data” dialog supports drag-and-drop file selection (Dropzone UI).
   - Supports three ingestion modes:
     - restore graph from a `.dump` export (replace contents),
-    - process `.csv` rows with a user-provided Cypher query,
+    - process `.csv` rows with a user-provided Cypher query (runs per `row` in UNWIND batches),
     - execute Cypher batch files (`.txt` / `.cql` / `.cypher`) statement-by-statement.
 
 ### Graph Info panel


### PR DESCRIPTION
# Guided CSV ingestion — preview, typed columns, result summary

> Follow-up to #1911. **Depends on the batching PR** (shares CSV ingestion) — land after it. Stacked accordingly. **Plan — implementation to follow.**

## Problem
`parseCsvRows` yields all-strings, so users must hand-write `toInteger(...)`, get no preview, and only a single end toast (or a 422 on failure). High barrier for non-experts.

## Approach (additive, non-breaking)
1. **Preview:** on CSV selection, parse client-side and show the first N rows + detected headers in a table.
2. **Typed column mapping:** per-column type selector; server coerces values before binding so `row.age` is already typed. Generate a starter query from the mapping.
3. **Result summary:** show created/failed counts; on partial failure show the failing chunk range (see risk below).

## Changes
- `upload-utils.ts`: `coerceValue(value, type)` + `coerceRows(rows, columnTypes)`, wired via the **transform hook** the batching PR exposes (no rewrite of batching).
- `route.ts`: accept optional `columnTypes`; return the structured summary.
- `UploadGraph.tsx`: preview table, per-column type selectors, generated-query button, result-summary panel.
- `readme-browser.md`: document preview + typing.

## Testing
- Unit: `coerceValue` for int/float/bool/null + invalid/empty (rules documented below); `coerceRows` only touches listed columns; **generated-query identifier safety** (malicious/non-identifier headers); result-summary shape; preview parsing reuses `parseCsvRows`.
- e2e: typed mapping (age→int) so `toInteger` is unnecessary; assert summary counts.

## Notes / risks
- **Partial-failure granularity:** with chunked `UNWIND`, a failed chunk does **not** reveal which row failed. Start with `processedRows` + `failedChunkRange`; optional per-row retry (binary search within the failed chunk after rollback) is a **stretch**. This seam is designed in the batching PR.
- **Injection/identifier safety:** generated property/label names from headers must be validated against a safe identifier regex **and** backtick-escaped (escaping embedded backticks). Values stay parameterized.
- **Coercion rules (server-side):** `int`/`float` via strict parse; `bool` ∈ {true,false,1,0}; empty → `null`. **`date` deferred** — FalkorDB may not accept JS `Date` params; store ISO strings until verified against live FalkorDB.
- Streaming/progress for very large files and a dry-run (`EXPLAIN`) validation are **follow-ups**, not in this PR.

<sub>Plan reviewed via rubber-duck; incorporated: downgraded exact failed-row → failed-chunk-range, added generated-identifier injection hardening, deferred `date` coercion pending live verification, and reused the batching PR's transform seam.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV uploads now support per-column type selection and automatic data coercion.
  * Added a preview of detected CSV columns and sample rows before upload.
  * Users can generate a starter query from a chosen node label.

* **Bug Fixes**
  * CSV uploads now run in batches and return clearer completion details.
  * Improved handling of malformed or empty upload queries, with better error reporting.

* **Documentation**
  * Updated upload guidance to reflect the new CSV preview, typing, and batch processing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->