### PR TITLE
feat(graph): implement GraphInfoProvider for isolated state management

### DIFF
--- a/app/api/graph/model.ts
+++ b/app/api/graph/model.ts
@@ -469,13 +469,12 @@ export class Graph {
     graphInfo?: GraphInfo,
   ): Promise<Graph> {
     const graph = Graph.empty(
-      undefined,
+      id,
       showPropertyKeyPrefix,
       currentLimit,
       graphInfo
     );
     await graph.extend(results);
-    graph.id = id;
     return graph;
   }
 

--- a/app/components/ForceGraph.tsx
+++ b/app/components/ForceGraph.tsx
@@ -408,6 +408,12 @@ export default function ForceGraph({
         });
     }, [handleNodeClick, handleLinkClick, handleRightClick, handleHover, handleUnselected, checkIsNodeSelected, checkIsLinkSelected, checkIsNodeDimmed, checkIsLinkDimmed, canvasRef, canvasLoaded, captionsKeys, showPropertyKeyPrefix]);
 
+    // Initialize canvas dimmed state when component mounts or dimmed prop changes
+    useEffect(() => {
+        if (!canvasRef.current || !canvasLoaded) return;
+        canvasRef.current.setDimmed(dimmed);
+    }, [dimmed, canvasRef, canvasLoaded]);
+
     // Update canvas data
     useEffect(() => {
         const canvas = canvasRef.current;

--- a/app/components/GraphInfoProvider.tsx
+++ b/app/components/GraphInfoProvider.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useMemo, useState, type MutableRefObject } from "react";
+import { GraphInfoContext } from "./provider";
+
+export type GraphInfoSync = {
+  /** Increment the version counter so GraphInfoContext consumers re-render and
+   *  pick up the latest data from graph.GraphInfo (mutated in-place by the
+   *  caller before invoking this). */
+  bumpVersion: () => void;
+  setNodesCount: (n: number | undefined) => void;
+  setEdgesCount: (e: number | undefined) => void;
+};
+
+/**
+ * Isolated provider that owns the graphInfo re-render trigger plus
+ * nodesCount / edgesCount state.
+ *
+ * Actual GraphInfo data lives on graph.GraphInfo (mutated in-place by the
+ * poll). This component holds only a version counter as a cheap re-render
+ * signal — no data duplication.
+ *
+ * State lives here — not in the parent providers.tsx — so periodic poll
+ * updates (via syncRef) only re-render this component and GraphInfoContext
+ * consumers (the info panel), never the wider application tree.
+ */
+export default function GraphInfoProvider({
+  children,
+  syncRef,
+}: {
+  children: React.ReactNode;
+  syncRef: MutableRefObject<GraphInfoSync>;
+}) {
+  const [graphInfoVersion, setGraphInfoVersion] = useState(0);
+  const [nodesCount, setNodesCount] = useState<number | undefined>();
+  const [edgesCount, setEdgesCount] = useState<number | undefined>();
+
+  // Expose setters to the parent without the parent subscribing to this state.
+  // Called on every render so the ref always holds the latest stable setters.
+  syncRef.current = {
+    bumpVersion: () => setGraphInfoVersion(v => v + 1),
+    setNodesCount,
+    setEdgesCount,
+  };
+
+  const value = useMemo(
+    () => ({ graphInfoVersion, nodesCount, edgesCount }),
+    [graphInfoVersion, nodesCount, edgesCount],
+  );
+
+  return (
+    <GraphInfoContext.Provider value={value}>
+      {children}
+    </GraphInfoContext.Provider>
+  );
+}

--- a/app/components/provider.ts
+++ b/app/components/provider.ts
@@ -410,13 +410,14 @@ export const GraphContext = createContext<GraphContextType>({
 });
 
 type GraphInfoContextType = {
-  graphInfo: GraphInfo;
+  /** Increments each time graph info is refreshed — subscribe to trigger re-renders. */
+  graphInfoVersion: number;
   nodesCount: number | undefined;
   edgesCount: number | undefined;
 };
 
 export const GraphInfoContext = createContext<GraphInfoContextType>({
-  graphInfo: Graph.empty().GraphInfo,
+  graphInfoVersion: 0,
   nodesCount: undefined,
   edgesCount: undefined,
 });

--- a/app/graph/GraphView.tsx
+++ b/app/graph/GraphView.tsx
@@ -54,7 +54,7 @@ function GraphView({
     const { setData, data, graphData, setGraphData, setViewport, viewport } = useContext(ForceGraphContext);
     const { tutorialOpen } = useContext(BrowserSettingsContext);
 
-    const [dimmed, setDimmed] = useState(false);
+    const [dimmed, setDimmed] = useState(true);
 
     const elementsLength = graph.getElements().length;
 

--- a/app/graph/graphInfo.tsx
+++ b/app/graph/graphInfo.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useCallback, useContext, useEffect, useState } from "react";
 import { Loader2, X, Palette, Play, Plus, Network, Search } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Popover, PopoverContent, PopoverTrigger, PopoverClose } from "@/components/ui/popover";
@@ -23,9 +23,9 @@ function escapeIdentifier(id: string): string {
  * @returns The Graph Info panel React element containing graph name, memory usage, node/edge counts, property keys, and query buttons
  */
 export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizingLabel }: { onClose: () => void, customizingLabel: InfoLabel | null, setCustomizingLabel: Dispatch<SetStateAction<InfoLabel | null>> }) {
-    const { runQuery, graphName, handleSetGraphName, graphNames, setGraphNames, setGraph } = useContext(GraphContext);
-    const { graphInfo, nodesCount, edgesCount } = useContext(GraphInfoContext);
-    const { Labels, Relationships, PropertyKeys, MemoryUsage } = graphInfo;
+    const { graph, runQuery, graphName, handleSetGraphName, graphNames, setGraphNames, setGraph } = useContext(GraphContext);
+    const { nodesCount, edgesCount } = useContext(GraphInfoContext);
+    const { Labels, Relationships, PropertyKeys, MemoryUsage } = graph.GraphInfo;
     const { isQueryLoading } = useContext(QueryLoadingContext);
     const { settings: { graphInfo: { showMemoryUsage, maxItemsForSearch } } } = useContext(BrowserSettingsContext);
     const { isReadOnly } = useContext(ConnectionContext);
@@ -34,9 +34,28 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
     const [edgesSearch, setEdgesSearch] = useState("");
     const [propertyKeysSearch, setPropertyKeysSearch] = useState("");
 
-    useEffect(() => { setNodesSearch(""); }, [Labels, maxItemsForSearch]);
-    useEffect(() => { setEdgesSearch(""); }, [Relationships, maxItemsForSearch]);
-    useEffect(() => { setPropertyKeysSearch(""); }, [PropertyKeys, maxItemsForSearch]);
+    // Reset searches only when the active graph changes or the display limit
+    // changes — not on every periodic poll that refreshes GraphInfoContext.
+    useEffect(() => {
+        setNodesSearch("");
+        setEdgesSearch("");
+        setPropertyKeysSearch("");
+    }, [graphName, maxItemsForSearch]);
+
+    // Stable callbacks so SelectGraph's handleSetRows useCallback is not
+    // invalidated on every GraphInfoContext poll update, which would trigger
+    // its useEffect([options, handleSetRows]) and reset checked rows.
+    const handleSetOptions = useCallback((opts: string[]) => {
+        setGraphNames(opts as unknown as string[]);
+    }, [setGraphNames]);
+
+    const handleSetSelectedValue = useCallback((name: string) => {
+        handleSetGraphName(formatName(name));
+    }, [handleSetGraphName]);
+
+    const handleSetGraphFromSelect = useCallback((g: Graph) => {
+        setGraph(g);
+    }, [setGraph]);
 
     return (
         <div data-testid="graphInfoPanel" className={cn("relative h-full w-full p-3 grid gap-3", showMemoryUsage ? "grid-rows-[max-content_max-content_max-content_1fr_1fr_1fr]" : "grid-rows-[max-content_max-content_1fr_1fr_1fr]")}>
@@ -57,13 +76,10 @@ export default function GraphInfoPanel({ onClose, customizingLabel, setCustomizi
                         <div className="w-full flex gap-2 items-center overflow-hidden">
                             <SelectGraph
                                 options={graphNames}
-                                setOptions={(opts) => setGraphNames(opts as unknown as string[])}
+                                setOptions={handleSetOptions}
                                 selectedValue={graphName}
-                                setSelectedValue={(name) => {
-                                    handleSetGraphName(formatName(name));
-
-                                }}
-                                setGraph={(g) => setGraph(g as Graph)}
+                                setSelectedValue={handleSetSelectedValue}
+                                setGraph={handleSetGraphFromSelect}
                             />
                             {
                                 !isReadOnly &&

--- a/app/graph/page.tsx
+++ b/app/graph/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
-import { cn, convertToCanvasData, getMemoryUsage, getMetaStats, isTwoNodes, Link, MemoryValue, Node, prepareArg, securedFetch, Value } from "@/lib/utils";
+import { cn, convertToCanvasData, getMemoryUsage, getMetaStats, getSSEGraphResult, isTwoNodes, Link, MemoryValue, Node, prepareArg, securedFetch, Value } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import dynamicImport from "next/dynamic";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
@@ -168,16 +168,50 @@ export default function Page() {
     const fetchInfo = useCallback(async (type: string) => {
         if (!graphName) return [];
 
+        if (type === "(property key)") {
+            const readOnlyParam = isReadOnlyRef.current ? '&readOnly=true' : '';
+            const query = "CALL db.propertyKeys() YIELD propertyKey as info";
+            const sse = await getSSEGraphResult(
+                `/api/graph/${prepareArg(graphName)}?query=${prepareArg(query)}${readOnlyParam}`,
+                toast,
+                setIndicator,
+            ) as { data?: Array<{ info?: unknown }> };
+
+            if (!sse || !Array.isArray(sse.data)) return [];
+
+            return sse.data
+                .map((entry) => (typeof entry?.info === "string" ? entry.info : undefined))
+                .filter((value): value is string => typeof value === "string");
+        }
+
         const readOnlyParam = isReadOnlyRef.current ? '&readOnly=true' : '';
-        const result = await securedFetch(`/api/graph/${graphName}/info?type=${type}${readOnlyParam}`, {
+        const result = await securedFetch(`/api/graph/${prepareArg(graphName)}/info?type=${prepareArg(type)}${readOnlyParam}`, {
             method: "GET",
         }, toast, setIndicator);
 
         if (!result.ok) return [];
 
-        const json = await result.json();
+        const bodyText = await result.text();
+        let json: unknown;
 
-        return json.result.data.map(({ info }: { info: string }) => info);
+        try {
+            json = JSON.parse(bodyText);
+        } catch (error) {
+            console.error("Failed to parse graph info response", {
+                error,
+                responseUrl: result.url,
+                contentType: result.headers.get("content-type"),
+                preview: bodyText.slice(0, 200),
+            });
+            return [];
+        }
+
+        const data = (json as { result?: { data?: Array<{ info?: unknown }> } })?.result?.data;
+        if (!Array.isArray(data)) return [];
+
+        return data
+            .map((entry) => (typeof entry?.info === "string" ? entry.info : undefined))
+            .filter((value): value is string => typeof value === "string");
     }, [graphName, setIndicator, toast]);
 
     const fetchMetaStats = useCallback((name: string) => getMetaStats(name, toast, setIndicator, isReadOnlyRef.current), [setIndicator, toast]);

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -20,7 +20,8 @@ import type { Data as CanvasData, HierarchyDirection, LayoutMode, RadialDirectio
 import LoginVerification from "./loginVerification";
 import AiFixDialogs from "./components/AiFixDialogs";
 import { Graph, GraphInfo } from "./api/graph/model";
-import { GraphContext, GraphInfoContext, HistoryQueryContext, IndicatorContext, QueryLoadingContext, BrowserSettingsContext, ForceGraphContext, TableViewContext, ConnectionContext, UDFContext, DiagnosticsContext, AiFixContext, type AiFixResult, SessionConnection, type ChatApiKey, type ChatModelSource, type LocalLlmProvider } from "./components/provider";
+import { GraphContext, HistoryQueryContext, IndicatorContext, QueryLoadingContext, BrowserSettingsContext, ForceGraphContext, TableViewContext, ConnectionContext, UDFContext, DiagnosticsContext, AiFixContext, type AiFixResult, SessionConnection, type ChatApiKey, type ChatModelSource, type LocalLlmProvider } from "./components/provider";
+import GraphInfoProvider, { type GraphInfoSync } from "./components/GraphInfoProvider";
 import { MEMORY_USAGE_VERSION_THRESHOLD } from "./utils";
 import ProviderLayout from "./components/ProviderLayout";
 
@@ -215,15 +216,22 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   // graph.GraphInfo in-place without triggering a graph state change.
   const graphRef = useRef<Graph>(graph);
   graphRef.current = graph;
-  // graphInfo and nodesCount/edgesCount are owned by GraphInfoContext so that
-  // only GraphInfoPanel re-renders on periodic info polls, not the whole tree.
-  const [graphInfo, setGraphInfoState] = useState<GraphInfo>(graph.GraphInfo);
+  // graphInfo / nodesCount / edgesCount state is owned by GraphInfoProvider so
+  // that periodic info polls only re-render that isolated subtree, not the
+  // whole providers tree.  We communicate with it via a stable ref of setters.
+  const graphInfoSyncRef = useRef<GraphInfoSync>({
+    bumpVersion: () => {},
+    setNodesCount: () => {},
+    setEdgesCount: () => {},
+  });
+
   const setGraphInfo = useCallback((gi: GraphInfo) => {
     // Mutate graph.GraphInfo in-place — no graph state change, so GraphContext
     // consumers (canvas, toolbar, …) are not disturbed.
     graphRef.current.GraphInfo = gi;
-    // Update GraphInfoContext so only its consumers re-render.
-    setGraphInfoState(gi);
+    // Bump the version counter in GraphInfoProvider so its consumers
+    // re-render and read the fresh data from graph.GraphInfo.
+    graphInfoSyncRef.current.bumpVersion();
   }, []);
   const [data, setData] = useState<GraphData>({ ...graph.Elements });
   const [graphData, setGraphData] = useState<CanvasData>();
@@ -250,8 +258,6 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   const [newSecretKey, setNewSecretKey] = useState("");
   const [secretKey, setSecretKey] = useState("");
   const [hasChanges, setHasChanges] = useState(false);
-  const [nodesCount, setNodesCount] = useState<number>();
-  const [edgesCount, setEdgesCount] = useState<number>();
   const [newMaxSavedMessages, setNewMaxSavedMessages] = useState(0);
   const [maxSavedMessages, setMaxSavedMessages] = useState(0);
   const [chatApiKeys, setChatApiKeys] = useState<ChatApiKey[]>([]);
@@ -613,8 +619,8 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
 
       const { nodes, edges } = result;
 
-      setEdgesCount(edges);
-      setNodesCount(nodes);
+      graphInfoSyncRef.current.setEdgesCount(edges);
+      graphInfoSyncRef.current.setNodesCount(nodes);
     } catch (error) {
       console.error(error);
     }
@@ -784,8 +790,8 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     setGraphName(name);
     setSelectedParam("");
     setGraphInfo(GraphInfo.empty(toast, setIndicator));
-    setNodesCount(undefined);
-    setEdgesCount(undefined);
+    graphInfoSyncRef.current.setNodesCount(undefined);
+    graphInfoSyncRef.current.setEdgesCount(undefined);
     setData({ nodes: [], links: [] });
     setGraphData(undefined);
     setViewport(undefined);
@@ -822,12 +828,6 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     setSelectedParam,
     initialQuery: initialQueryRef.current,
   }), [graph, graphName, handleSetGraphName, graphNames, labels, relationships, currentTab, runQuery, fetchCount, handleCooldown, cooldownTicks, isLoading, expandFilter, selectedParam]);
-
-  const graphInfoContextValue = useMemo(() => ({
-    graphInfo,
-    nodesCount,
-    edgesCount,
-  }), [graphInfo, nodesCount, edgesCount]);
 
   useEffect(() => {
     setRelationships([...graph.Relationships]);
@@ -1365,8 +1365,8 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     setSelectedParam("");
     setGraphNamesLoaded(false);
     setGraphNames([]);
-    setNodesCount(undefined);
-    setEdgesCount(undefined);
+    graphInfoSyncRef.current.setNodesCount(undefined);
+    graphInfoSyncRef.current.setEdgesCount(undefined);
     setHistoryQuery(h => ({ ...h, query: "", currentQuery: defaultQueryHistory.currentQuery }));
     setLabels([]);
     setRelationships([]);
@@ -1517,7 +1517,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
       <LoginVerification>
         <BrowserSettingsContext.Provider value={browserSettingsContext}>
           <GraphContext.Provider value={graphContext}>
-            <GraphInfoContext.Provider value={graphInfoContextValue}>
+            <GraphInfoProvider syncRef={graphInfoSyncRef}>
               <HistoryQueryContext.Provider value={historyQueryContext}>
               <IndicatorContext.Provider value={indicatorContext}>
                 <QueryLoadingContext.Provider value={queryLoadingContext}>
@@ -1547,7 +1547,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
                 </QueryLoadingContext.Provider>
               </IndicatorContext.Provider>
             </HistoryQueryContext.Provider>
-            </GraphInfoContext.Provider>
+            </GraphInfoProvider>
           </GraphContext.Provider>
         </BrowserSettingsContext.Provider>
       </LoginVerification>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -656,19 +656,53 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   }, []);
 
   const fetchInfo = useCallback(async (type: string, name: string) => {
-    if (!graphName) return [];
+    if (!name) return [];
+
+    if (type === "(property key)") {
+      const readOnlyParam = isReadOnlyRef.current ? '&readOnly=true' : '';
+      const query = "CALL db.propertyKeys() YIELD propertyKey as info";
+      const sse = await getSSEGraphResult(
+        `/api/graph/${prepareArg(name)}?query=${prepareArg(query)}${readOnlyParam}`,
+        toast,
+        setIndicator,
+      ) as { data?: Array<{ info?: unknown }> };
+
+      if (!sse || !Array.isArray(sse.data)) return [];
+
+      return sse.data
+        .map((entry) => (typeof entry?.info === "string" ? entry.info : undefined))
+        .filter((value): value is string => typeof value === "string");
+    }
 
     const readOnlyParam = isReadOnlyRef.current ? '&readOnly=true' : '';
-    const result = await securedFetch(`/api/graph/${name}/info?type=${type}${readOnlyParam}`, {
+    const result = await securedFetch(`/api/graph/${prepareArg(name)}/info?type=${prepareArg(type)}${readOnlyParam}`, {
       method: "GET",
     }, toast, setIndicator);
 
     if (!result.ok) return [];
 
-    const json = await result.json();
+    const bodyText = await result.text();
+    let json: unknown;
 
-    return json.result.data.map(({ info }: { info: string }) => info);
-  }, [graphName, toast, setIndicator]);
+    try {
+      json = JSON.parse(bodyText);
+    } catch (error) {
+      console.error("Failed to parse graph info response", {
+        error,
+        responseUrl: result.url,
+        contentType: result.headers.get("content-type"),
+        preview: bodyText.slice(0, 200),
+      });
+      return [];
+    }
+
+    const data = (json as { result?: { data?: Array<{ info?: unknown }> } })?.result?.data;
+    if (!Array.isArray(data)) return [];
+
+    return data
+      .map((entry) => (typeof entry?.info === "string" ? entry.info : undefined))
+      .filter((value): value is string => typeof value === "string");
+  }, [toast, setIndicator]);
 
   const fetchMetaStats = useCallback((name: string) => getMetaStats(name, toast, setIndicator, isReadOnlyRef.current), [toast, setIndicator]);
 

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getSSEGraphResult, securedFetch, setActiveConnectionIdGlobal } from "./utils.ts";
+
+const noopToast = () => {};
+const noopIndicator = () => {};
+
+afterEach(() => {
+  setActiveConnectionIdGlobal(null);
+});
+
+describe("API URL normalization", () => {
+  it("normalizes relative securedFetch URLs to root-relative paths", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ input, init });
+      return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+    }) as typeof fetch;
+
+    try {
+      setActiveConnectionIdGlobal("conn-123");
+
+      const response = await securedFetch("api/graph/demo", {}, noopToast, noopIndicator);
+
+      assert.equal(response.status, 200);
+      assert.equal(calls.length, 1);
+      assert.equal(String(calls[0].input), "/api/graph/demo");
+      assert.equal(calls[0].init?.headers instanceof Headers, true);
+      assert.equal((calls[0].init?.headers as Headers).get("X-Connection-Id"), "conn-123");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("normalizes relative EventSource URLs to root-relative paths", async () => {
+    const OriginalEventSource = globalThis.EventSource;
+    let lastInstance: {
+      url: string;
+      listeners: Record<string, (event: MessageEvent) => void>;
+      close: () => void;
+    } | undefined;
+
+    class MockEventSource {
+      url: string;
+
+      listeners: Record<string, (event: MessageEvent) => void>;
+
+      constructor(url: string) {
+        this.url = url;
+        this.listeners = {};
+        lastInstance = this;
+      }
+
+      addEventListener(name: string, listener: (event: MessageEvent) => void) {
+        this.listeners[name] = listener;
+      }
+
+      close() {}
+    }
+
+    globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+
+    try {
+      setActiveConnectionIdGlobal("conn-456");
+      const promise = getSSEGraphResult("api/graph/demo?query=RETURN 1", noopToast, noopIndicator);
+
+      assert.ok(lastInstance);
+      assert.equal(lastInstance?.url, "/api/graph/demo?query=RETURN 1&connectionId=conn-456");
+
+      lastInstance?.listeners.result({ data: JSON.stringify({ ok: true }) } as MessageEvent);
+
+      await assert.doesNotReject(async () => {
+        assert.deepEqual(await promise, { ok: true });
+      });
+    } finally {
+      globalThis.EventSource = OriginalEventSource;
+      setActiveConnectionIdGlobal(null);
+    }
+  });
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -265,7 +265,7 @@ export async function getSSEGraphResult(
     let handled = false;
 
     // EventSource doesn't support headers — inject connectionId as a query param.
-    let effectiveUrl = url;
+    let effectiveUrl = normalizeApiUrl(url);
     if (_activeConnectionId) {
       const sep = effectiveUrl.includes("?") ? "&" : "?";
       effectiveUrl += `${sep}connectionId=${encodeURIComponent(_activeConnectionId)}`;
@@ -273,29 +273,48 @@ export async function getSSEGraphResult(
 
     const evtSource = new EventSource(effectiveUrl);
     evtSource.addEventListener("result", (event: MessageEvent) => {
-      const result = JSON.parse(event.data);
-      evtSource.close();
-      setIndicator("online");
-      resolve(result);
+      const payloadText = typeof event.data === "string" ? event.data : "";
+
+      try {
+        const result = JSON.parse(payloadText);
+        evtSource.close();
+        setIndicator("online");
+        resolve(result);
+      } catch (error) {
+        console.error("Failed to parse SSE result event:", error);
+        evtSource.close();
+        setIndicator("offline");
+        reject(new Error("Invalid server response"));
+      }
     });
 
     evtSource.addEventListener("error", (event: MessageEvent) => {
       handled = true;
-      let rawMessage: unknown = "Request failed";
+      let rawMessage: unknown = "";
       let rawStatus: unknown = 0;
       let code: string | undefined;
+      const eventData = typeof (event as { data?: unknown }).data === "string"
+        ? (event as { data?: string }).data
+        : "";
 
-      try {
-        const payload = JSON.parse(event.data) as {
-          message?: unknown;
-          status?: unknown;
-          code?: string;
-        };
-        rawMessage = payload.message;
-        rawStatus = payload.status;
-        code = payload.code;
-      } catch (error) {
-        console.error("Failed to parse SSE error event:", error);
+      if (eventData) {
+        try {
+          const payload = JSON.parse(eventData) as {
+            message?: unknown;
+            status?: unknown;
+            code?: string;
+          };
+          rawMessage = payload.message;
+          rawStatus = payload.status;
+          code = payload.code;
+        } catch (error) {
+          rawMessage = extractResponseErrorMessage(eventData);
+          console.error("Failed to parse SSE error event:", error);
+        }
+      }
+
+      if (!rawMessage) {
+        rawMessage = (event as { message?: unknown }).message;
       }
 
       const message = normalizeErrorMessage(rawMessage) || "Request failed";
@@ -557,6 +576,14 @@ export function getActiveConnectionIdGlobal(): string | null {
   return _activeConnectionId;
 }
 
+function normalizeApiUrl(input: string): string {
+  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(input) || input.startsWith("//") || input.startsWith("/")) {
+    return input;
+  }
+
+  return `/${input}`;
+}
+
 export async function securedFetch(
   input: string,
   init: RequestInit,
@@ -571,7 +598,7 @@ export async function securedFetch(
   }
   effectiveInit.headers = existingHeaders;
 
-  const response = await fetch(input, effectiveInit);
+  const response = await fetch(normalizeApiUrl(input), effectiveInit);
   const { status } = response;
 
   // Sign out only on an explicit X-Session-Invalid signal, not on all 401s.
@@ -616,6 +643,8 @@ export const getDefaultQuery = (q?: string) =>
   q || "MATCH (n) OPTIONAL MATCH (n)-[e]-(m) RETURN * LIMIT 100";
 
 export const getMetaStats = async (name: string, toast: ToastFn, setIndicator: (indicator: "online" | "offline") => void, isReadOnly?: boolean) => {
+  if (!name) return undefined;
+
   const q = "CALL db.meta.stats() YIELD labels, relTypes RETURN labels, relTypes as relationships";
   const readOnlyParam = isReadOnly ? '&readOnly=true' : '';
 
@@ -625,11 +654,13 @@ export const getMetaStats = async (name: string, toast: ToastFn, setIndicator: (
     if (!result) return undefined;
 
     const row = result.data?.[0];
+    if (!row || typeof row !== "object") return undefined;
 
-    if (!row) return undefined;
+    const labels = row.labels && typeof row.labels === "object" ? row.labels : {};
+    const relationships = row.relationships && typeof row.relationships === "object" ? row.relationships : {};
 
-    const l = Object.entries(row.labels);
-    const r = Object.entries(row.relationships);
+    const l = Object.entries(labels);
+    const r = Object.entries(relationships);
 
     return [l, r];
   } catch (error) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,11 +6,11 @@
 
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
-import React, { RefObject } from "react";
+import React, { type RefObject } from "react";
 import type { FalkorDBCanvas, Data as CanvasData } from "@falkordb/canvas";
 import { signOut } from "next-auth/react";
-import { getCypherErrorHint, SYNTAX_ERROR_HINT, parseSyntaxError, enrichSyntaxMessage, type SyntaxErrorInfo, type HintLink } from "./cypherErrors";
-import { suggestForError, findFuncArgTypo } from "./cypherSuggestions";
+import { getCypherErrorHint, SYNTAX_ERROR_HINT, parseSyntaxError, enrichSyntaxMessage, type SyntaxErrorInfo, type HintLink } from "./cypherErrors.ts";
+import { suggestForError, findFuncArgTypo } from "./cypherSuggestions.ts";
 
 export { parseSyntaxError };
 export type { SyntaxErrorInfo };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "falkordb-browser",
       "version": "2.2.0",
       "dependencies": {
-        "@falkordb/canvas": "^0.2.2",
+        "@falkordb/canvas": "^0.2.5",
         "@falkordb/text-to-cypher": "^0.2.2",
         "@hookform/resolvers": "^5.4.0",
         "@monaco-editor/react": "^4.6.0",
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@falkordb/canvas": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@falkordb/canvas/-/canvas-0.2.2.tgz",
-      "integrity": "sha512-oGo4/tXrLqUzzf39wjpcZ2lfoSo0InTsHqORGBpLVyQtgyNRSLgNdgKUrAbO3vjVnjbfNFzKIwHrUJFf2R6mHA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@falkordb/canvas/-/canvas-0.2.5.tgz",
+      "integrity": "sha512-BSVDHYC9WeuGF9iPUkGmh11KgyV3whVAjmLWDaai29GKXyJrG49LPiwxRAaKY2bA9ha7bU8ZWMJ77EqfUPXhmA==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "falkordb-browser",
       "version": "2.2.0",
       "dependencies": {
-        "@falkordb/canvas": "^0.2.1",
+        "@falkordb/canvas": "^0.2.2",
         "@falkordb/text-to-cypher": "^0.2.2",
         "@hookform/resolvers": "^5.4.0",
         "@monaco-editor/react": "^4.6.0",
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@falkordb/canvas": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@falkordb/canvas/-/canvas-0.2.1.tgz",
-      "integrity": "sha512-CZQqQzqDy3mQJYsbpwn83emAqnIgIt1qXkMbEh5n4zj+oVS/DoLUmzIdHT31aAnm1gL0POA1p3g5N9jFz9W+HQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@falkordb/canvas/-/canvas-0.2.2.tgz",
+      "integrity": "sha512-oGo4/tXrLqUzzf39wjpcZ2lfoSo0InTsHqORGBpLVyQtgyNRSLgNdgKUrAbO3vjVnjbfNFzKIwHrUJFf2R6mHA==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",
@@ -1367,9 +1367,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1385,9 +1382,6 @@
       "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1405,9 +1399,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1423,9 +1414,6 @@
       "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@falkordb/canvas": "^0.2.2",
+    "@falkordb/canvas": "^0.2.5",
     "@falkordb/text-to-cypher": "^0.2.2",
     "@hookform/resolvers": "^5.4.0",
     "@monaco-editor/react": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@falkordb/canvas": "^0.2.1",
+    "@falkordb/canvas": "^0.2.2",
     "@falkordb/text-to-cypher": "^0.2.2",
     "@hookform/resolvers": "^5.4.0",
     "@monaco-editor/react": "^4.6.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved graph info syncing to update node/edge counts smoothly with less UI churn.

* **Bug Fixes**
  * Search filters reset only when changing the active graph or search limit.
  * Reduced re-render flicker during graph selection by stabilizing graph option handlers.
  * Canvas dim mode now initializes correctly and stays in sync when toggled.
  * Hardened graph-info fetching, SSE parsing, and response handling for malformed data.

* **Tests**
  * Updated dim-mode Playwright expectations; expanded URL/SSE utility test coverage.

* **Chores**
  * Bumped the canvas dependency patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->