### PR TITLE
Chat: confidence badge on 0-100 scale with text-to-cypher 0.2.3

### DIFF
--- a/app/api/chat/route.tsx
+++ b/app/api/chat/route.tsx
@@ -210,7 +210,7 @@ export async function POST(request: NextRequest) {
             cypherQuery: result.cypherQuery || null,
             cypherResult: result.cypherResult || null,
             answer: result.answer || null,
-            confidence: (result as { confidence?: number }).confidence ?? null,
+            confidence: result.confidence ?? null,
             tokenUsage: result.tokenUsage || null,
         }, { headers: getCorsHeaders(request) });
 

--- a/app/graph/Chat.tsx
+++ b/app/graph/Chat.tsx
@@ -486,10 +486,10 @@ export default function Chat({ onClose }: Props) {
                                         style.wrap
                                     )}
                                     title={`${style.label}: how confident the model is that this answer is correct given the graph data`}
-                                    aria-label={`${style.label}, ${confidence}%`}
                                 >
                                     <span className={cn("h-1.5 w-1.5 rounded-full", style.dot)} aria-hidden />
-                                    <span className="text-muted-foreground">Confidence</span>
+                                    <span className="sr-only">{style.label}: </span>
+                                    <span className="text-muted-foreground" aria-hidden>Confidence</span>
                                     <span className="tabular-nums">{confidence}%</span>
                                 </span>
                             );

--- a/app/graph/Chat.tsx
+++ b/app/graph/Chat.tsx
@@ -16,7 +16,8 @@ import { detectProviderFromApiKey, detectProviderFromModel, getProviderDisplayNa
 import ToastButton from "../components/ToastButton";
 import { ShineBorder } from "@/components/ui/shine-border";
 import { getConnectionItem, setConnectionItem, getConnectionPrefix } from "@/lib/connection-storage";
-import { getConfidenceStyle, normalizeConfidence, migrateLegacyConfidence } from "./confidence";
+import { getConfidenceStyle, normalizeConfidence } from "./confidence";
+import { parseStoredMessages, serializeChatHistory } from "./chatHistory";
 
 const mdInstance = new MarkdownIt({
     html: false,
@@ -63,39 +64,7 @@ const getErrorStatus = (error: unknown) => {
 };
 
 // Confidence badge tiers moved to ./confidence for unit testing.
-
-// Bump when the persisted chat payload shape or value scales change.
-// v1 (legacy) was a bare Message[] whose `confidence` used the old 0-1 scale;
-// v2 wraps the array and stores confidence on the current 0-100 scale.
-const CHAT_HISTORY_VERSION = 2;
-
-// Restore persisted chat history, migrating pre-0-100 confidence values so a
-// cached 0-1 fraction (e.g. 0.9) no longer renders as a red "1%" badge.
-const parseStoredMessages = (raw: string | null): Message[] => {
-    if (!raw) return [];
-
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(raw);
-    } catch {
-        return [];
-    }
-
-    if (Array.isArray(parsed)) {
-        // Legacy (unversioned): confidence was persisted on the 0-1 scale.
-        return (parsed as Message[]).map(message =>
-            message.confidence != null
-                ? { ...message, confidence: migrateLegacyConfidence(message.confidence) }
-                : message
-        );
-    }
-
-    if (parsed && typeof parsed === "object" && Array.isArray((parsed as { messages?: unknown }).messages)) {
-        return (parsed as { messages: Message[] }).messages;
-    }
-
-    return [];
-};
+// Chat history persistence/migration moved to ./chatHistory for unit testing.
 
 export default function Chat({ onClose }: Props) {
     const { resolvedTheme } = useTheme();
@@ -193,10 +162,7 @@ export default function Chat({ onClose }: Props) {
         let statusGroup: Message[];
 
         if (messages.length > 0) {
-            setConnectionItem(`chat-${graphName}`, JSON.stringify({
-                version: CHAT_HISTORY_VERSION,
-                messages: getLastUserMessagesWithContext(messages, maxSavedMessages),
-            }));
+            setConnectionItem(`chat-${graphName}`, serializeChatHistory(getLastUserMessagesWithContext(messages, maxSavedMessages)));
         }
 
         const newMessagesList = messages.map((message, i): Message | [Message[], boolean] | undefined => {

--- a/app/graph/Chat.tsx
+++ b/app/graph/Chat.tsx
@@ -16,6 +16,7 @@ import { detectProviderFromApiKey, detectProviderFromModel, getProviderDisplayNa
 import ToastButton from "../components/ToastButton";
 import { ShineBorder } from "@/components/ui/shine-border";
 import { getConnectionItem, setConnectionItem, getConnectionPrefix } from "@/lib/connection-storage";
+import { getConfidenceStyle, normalizeConfidence, migrateLegacyConfidence } from "./confidence";
 
 const mdInstance = new MarkdownIt({
     html: false,
@@ -61,27 +62,39 @@ const getErrorStatus = (error: unknown) => {
     return 0;
 };
 
-// Confidence badge tiers: calm, low-saturation tints that stay readable in light and dark themes.
-const getConfidenceStyle = (value: number) => {
-    if (value >= 90) {
-        return {
-            label: "High confidence",
-            wrap: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 ring-emerald-500/20",
-            dot: "bg-emerald-500",
-        };
+// Confidence badge tiers moved to ./confidence for unit testing.
+
+// Bump when the persisted chat payload shape or value scales change.
+// v1 (legacy) was a bare Message[] whose `confidence` used the old 0-1 scale;
+// v2 wraps the array and stores confidence on the current 0-100 scale.
+const CHAT_HISTORY_VERSION = 2;
+
+// Restore persisted chat history, migrating pre-0-100 confidence values so a
+// cached 0-1 fraction (e.g. 0.9) no longer renders as a red "1%" badge.
+const parseStoredMessages = (raw: string | null): Message[] => {
+    if (!raw) return [];
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return [];
     }
-    if (value >= 70) {
-        return {
-            label: "Medium confidence",
-            wrap: "bg-amber-500/10 text-amber-700 dark:text-amber-300 ring-amber-500/25",
-            dot: "bg-amber-500",
-        };
+
+    if (Array.isArray(parsed)) {
+        // Legacy (unversioned): confidence was persisted on the 0-1 scale.
+        return (parsed as Message[]).map(message =>
+            message.confidence != null
+                ? { ...message, confidence: migrateLegacyConfidence(message.confidence) }
+                : message
+        );
     }
-    return {
-        label: "Low confidence",
-        wrap: "bg-rose-500/10 text-rose-700 dark:text-rose-300 ring-rose-500/25",
-        dot: "bg-rose-500",
-    };
+
+    if (parsed && typeof parsed === "object" && Array.isArray((parsed as { messages?: unknown }).messages)) {
+        return (parsed as { messages: Message[] }).messages;
+    }
+
+    return [];
 };
 
 export default function Chat({ onClose }: Props) {
@@ -170,8 +183,7 @@ export default function Chat({ onClose }: Props) {
     useEffect(() => {
         if (!getConnectionPrefix()) return;
         const savedMessages = getConnectionItem(`chat-${graphName}`);
-        const currentMessages = JSON.parse(savedMessages || "[]");
-        setMessages(currentMessages);
+        setMessages(parseStoredMessages(savedMessages));
 
         const savedCypherOnly = getConnectionItem(`cypherOnly-${graphName}`);
         setCypherOnly(savedCypherOnly === "true");
@@ -181,7 +193,10 @@ export default function Chat({ onClose }: Props) {
         let statusGroup: Message[];
 
         if (messages.length > 0) {
-            setConnectionItem(`chat-${graphName}`, JSON.stringify(getLastUserMessagesWithContext(messages, maxSavedMessages)));
+            setConnectionItem(`chat-${graphName}`, JSON.stringify({
+                version: CHAT_HISTORY_VERSION,
+                messages: getLastUserMessagesWithContext(messages, maxSavedMessages),
+            }));
         }
 
         const newMessagesList = messages.map((message, i): Message | [Message[], boolean] | undefined => {
@@ -492,20 +507,24 @@ export default function Chat({ onClose }: Props) {
                 return (
                     <div className="flex flex-col gap-1">
                         <MarkdownMessage content={message.content} />
-                        {message.type === "Result" && message.confidence != null && (() => {
-                            const style = getConfidenceStyle(message.confidence);
+                        {message.type === "Result" && (() => {
+                            const confidence = normalizeConfidence(message.confidence);
+                            if (confidence == null) return null;
+                            const style = getConfidenceStyle(confidence);
                             return (
                                 <span
+                                    data-testid="chatConfidenceBadge"
                                     className={cn(
                                         "mt-1 inline-flex w-fit items-center gap-1.5 rounded-full px-2 py-0.5",
                                         "text-[11px] font-medium leading-none ring-1 ring-inset",
                                         style.wrap
                                     )}
-                                    title={`${style.label}: the model's self-reported certainty in this answer`}
+                                    title={`${style.label}: how confident the model is that this answer is correct given the graph data`}
+                                    aria-label={`${style.label}, ${confidence}%`}
                                 >
                                     <span className={cn("h-1.5 w-1.5 rounded-full", style.dot)} aria-hidden />
                                     <span className="text-muted-foreground">Confidence</span>
-                                    <span className="tabular-nums">{Math.round(message.confidence)}%</span>
+                                    <span className="tabular-nums">{confidence}%</span>
                                 </span>
                             );
                         })()}

--- a/app/graph/Chat.tsx
+++ b/app/graph/Chat.tsx
@@ -61,6 +61,29 @@ const getErrorStatus = (error: unknown) => {
     return 0;
 };
 
+// Confidence badge tiers: calm, low-saturation tints that stay readable in light and dark themes.
+const getConfidenceStyle = (value: number) => {
+    if (value >= 90) {
+        return {
+            label: "High confidence",
+            wrap: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 ring-emerald-500/20",
+            dot: "bg-emerald-500",
+        };
+    }
+    if (value >= 70) {
+        return {
+            label: "Medium confidence",
+            wrap: "bg-amber-500/10 text-amber-700 dark:text-amber-300 ring-amber-500/25",
+            dot: "bg-amber-500",
+        };
+    }
+    return {
+        label: "Low confidence",
+        wrap: "bg-rose-500/10 text-rose-700 dark:text-rose-300 ring-rose-500/25",
+        dot: "bg-rose-500",
+    };
+};
+
 export default function Chat({ onClose }: Props) {
     const { resolvedTheme } = useTheme();
     const { currentTheme } = getTheme(resolvedTheme);
@@ -469,16 +492,23 @@ export default function Chat({ onClose }: Props) {
                 return (
                     <div className="flex flex-col gap-1">
                         <MarkdownMessage content={message.content} />
-                        {message.type === "Result" && message.confidence != null && (
-                            <span className={cn(
-                                "text-xs px-1.5 py-0.5 rounded w-fit",
-                                message.confidence >= 0.9 ? "bg-green-500/20 text-green-400" :
-                                    message.confidence >= 0.7 ? "bg-yellow-500/20 text-yellow-400" :
-                                        "bg-red-500/20 text-red-400"
-                            )}>
-                                Confidence: {Math.round(message.confidence * 100)}%
-                            </span>
-                        )}
+                        {message.type === "Result" && message.confidence != null && (() => {
+                            const style = getConfidenceStyle(message.confidence);
+                            return (
+                                <span
+                                    className={cn(
+                                        "mt-1 inline-flex w-fit items-center gap-1.5 rounded-full px-2 py-0.5",
+                                        "text-[11px] font-medium leading-none ring-1 ring-inset",
+                                        style.wrap
+                                    )}
+                                    title={`${style.label}: the model's self-reported certainty in this answer`}
+                                >
+                                    <span className={cn("h-1.5 w-1.5 rounded-full", style.dot)} aria-hidden />
+                                    <span className="text-muted-foreground">Confidence</span>
+                                    <span className="tabular-nums">{Math.round(message.confidence)}%</span>
+                                </span>
+                            );
+                        })()}
                     </div>
                 );
         }

--- a/app/graph/chatHistory.test.ts
+++ b/app/graph/chatHistory.test.ts
@@ -43,11 +43,34 @@ describe("parseStoredMessages", () => {
         assert.equal(parsed[0].confidence, undefined);
     });
 
-    it("filters out non-object entries so a stray null cannot crash rendering", () => {
-        const raw = JSON.stringify([null, result("a", 0.8), "oops", [1, 2]]);
+    it("filters out malformed entries so corrupt storage cannot crash rendering", () => {
+        const raw = JSON.stringify([
+            null,
+            "oops",
+            [1, 2],
+            { role: "assistant", type: "Status", content: {} }, // non-string content
+            { role: "bogus", type: "Result", content: "x" }, // invalid role
+            { role: "assistant", type: "Nope", content: "x" }, // invalid type
+            { role: "assistant", type: "Result", content: "x", confidence: "90" }, // non-numeric confidence
+            { role: "assistant", type: "Result", content: "x", tokenUsage: "5" }, // non-numeric tokenUsage
+            result("a", 0.8),
+        ]);
         const parsed = parseStoredMessages(raw);
         assert.equal(parsed.length, 1);
         assert.equal(parsed[0].confidence, 80);
+    });
+
+    it("keeps valid messages with null/absent optional numeric fields", () => {
+        const raw = JSON.stringify([
+            { role: "user", content: "hi", type: "Text" },
+            { role: "assistant", content: "a", type: "Result", confidence: null, tokenUsage: null },
+            { role: "assistant", content: "b", type: "Result", confidence: 90, tokenUsage: 5 },
+        ]);
+        const parsed = parseStoredMessages(raw);
+        assert.equal(parsed.length, 3);
+        assert.equal(parsed[0].confidence, undefined);
+        assert.equal(parsed[1].confidence, null);
+        assert.equal(parsed[2].confidence, 90);
     });
 
     it("uses versioned payloads as-is without rescaling", () => {

--- a/app/graph/chatHistory.test.ts
+++ b/app/graph/chatHistory.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseStoredMessages, serializeChatHistory, CHAT_HISTORY_VERSION } from "./chatHistory.ts";
+import type { Message } from "@/lib/utils";
+
+const result = (content: string, confidence?: number): Message => ({
+    role: "assistant",
+    content,
+    type: "Result",
+    ...(confidence != null ? { confidence } : {}),
+});
+
+describe("parseStoredMessages", () => {
+    it("returns [] for empty or missing input", () => {
+        assert.deepEqual(parseStoredMessages(null), []);
+        assert.deepEqual(parseStoredMessages(""), []);
+    });
+
+    it("returns [] for malformed JSON", () => {
+        assert.deepEqual(parseStoredMessages("{not json"), []);
+    });
+
+    it("reconciles a mixed legacy bare array across both scales", () => {
+        // 0.9 (fraction) -> 90, 10 (already 0-100) -> 10, 90 -> 90, 1 (ambiguous) -> omitted
+        const raw = JSON.stringify([
+            result("a", 0.9),
+            result("b", 10),
+            result("c", 90),
+            result("d", 1),
+        ]);
+        const parsed = parseStoredMessages(raw);
+        assert.equal(parsed.length, 4);
+        assert.equal(parsed[0].confidence, 90);
+        assert.equal(parsed[1].confidence, 10);
+        assert.equal(parsed[2].confidence, 90);
+        assert.equal(parsed[3].confidence, undefined);
+    });
+
+    it("leaves messages without confidence untouched in legacy arrays", () => {
+        const raw = JSON.stringify([{ role: "user", content: "hi", type: "Text" }]);
+        const parsed = parseStoredMessages(raw);
+        assert.equal(parsed.length, 1);
+        assert.equal(parsed[0].confidence, undefined);
+    });
+
+    it("filters out non-object entries so a stray null cannot crash rendering", () => {
+        const raw = JSON.stringify([null, result("a", 0.8), "oops", [1, 2]]);
+        const parsed = parseStoredMessages(raw);
+        assert.equal(parsed.length, 1);
+        assert.equal(parsed[0].confidence, 80);
+    });
+
+    it("uses versioned payloads as-is without rescaling", () => {
+        const raw = serializeChatHistory([result("a", 90), result("b", 10)]);
+        const parsed = parseStoredMessages(raw);
+        assert.equal(parsed.length, 2);
+        assert.equal(parsed[0].confidence, 90);
+        assert.equal(parsed[1].confidence, 10);
+    });
+
+    it("discards payloads with an unknown version", () => {
+        const raw = JSON.stringify({ version: 999, messages: [result("a", 90)] });
+        assert.deepEqual(parseStoredMessages(raw), []);
+    });
+
+    it("filters null entries inside a versioned payload", () => {
+        const raw = JSON.stringify({
+            version: CHAT_HISTORY_VERSION,
+            messages: [null, result("a", 90)],
+        });
+        const parsed = parseStoredMessages(raw);
+        assert.equal(parsed.length, 1);
+        assert.equal(parsed[0].confidence, 90);
+    });
+
+    it("returns [] for an object without a messages array", () => {
+        assert.deepEqual(parseStoredMessages(JSON.stringify({ version: CHAT_HISTORY_VERSION })), []);
+        assert.deepEqual(parseStoredMessages(JSON.stringify({ foo: "bar" })), []);
+    });
+
+    it("round-trips serialized history (idempotent, no re-rescale)", () => {
+        const messages = [result("a", 90), result("b", 1)];
+        const first = parseStoredMessages(serializeChatHistory(messages));
+        const second = parseStoredMessages(serializeChatHistory(first));
+        assert.deepEqual(second, first);
+    });
+});
+
+describe("serializeChatHistory", () => {
+    it("wraps messages with the current version marker", () => {
+        const raw = serializeChatHistory([result("a", 90)]);
+        const obj = JSON.parse(raw);
+        assert.equal(obj.version, CHAT_HISTORY_VERSION);
+        assert.equal(obj.messages.length, 1);
+        assert.equal(obj.messages[0].confidence, 90);
+    });
+});

--- a/app/graph/chatHistory.ts
+++ b/app/graph/chatHistory.ts
@@ -19,8 +19,23 @@ interface VersionedChatHistory {
     messages: Message[];
 }
 
+const CHAT_ROLES = new Set(["user", "assistant"]);
+const CHAT_TYPES = new Set(["Text", "Result", "Error", "Status", "CypherQuery", "CypherResult"]);
+
+function isOptionalNumber(value: unknown): boolean {
+    return value == null || typeof value === "number";
+}
+
 function isMessageLike(value: unknown): value is Message {
-    return value != null && typeof value === "object" && !Array.isArray(value) && "role" in value;
+    if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+    const message = value as Record<string, unknown>;
+    return (
+        CHAT_ROLES.has(message.role as string) &&
+        typeof message.content === "string" &&
+        CHAT_TYPES.has(message.type as string) &&
+        isOptionalNumber(message.confidence) &&
+        isOptionalNumber(message.tokenUsage)
+    );
 }
 
 /**
@@ -33,7 +48,9 @@ function isMessageLike(value: unknown): value is Message {
  * - A `{ version, messages }` object is used as-is only when the version
  *   matches the current one; unknown versions are discarded rather than
  *   guessed at.
- * Non-object entries are filtered out so a stray `null` can't crash rendering.
+ * Non-conforming entries (wrong shape, non-string content, invalid role/type,
+ * or non-numeric confidence/tokenUsage) are filtered out so corrupt storage
+ * can't crash rendering.
  */
 export function parseStoredMessages(raw: string | null): Message[] {
     if (!raw) return [];

--- a/app/graph/chatHistory.ts
+++ b/app/graph/chatHistory.ts
@@ -1,0 +1,71 @@
+// Persistence helpers for the Chat panel's per-graph history.
+//
+// History is stored in connection-scoped localStorage. Older builds persisted a
+// bare `Message[]`; that shape carries no version marker and its `confidence`
+// values may be on either the legacy 0-1 scale or the current 0-100 scale
+// (depending on which build last wrote them). Current builds wrap the array
+// with a version so future reads are unambiguous.
+
+import type { Message } from "@/lib/utils";
+import { migrateLegacyConfidence } from "./confidence.ts";
+
+// Bump when the persisted payload shape or value scales change.
+// v1 (legacy) was a bare Message[]; v2 wraps the array and stores confidence on
+// the current 0-100 scale.
+export const CHAT_HISTORY_VERSION = 2;
+
+interface VersionedChatHistory {
+    version: number;
+    messages: Message[];
+}
+
+function isMessageLike(value: unknown): value is Message {
+    return value != null && typeof value === "object" && !Array.isArray(value) && "role" in value;
+}
+
+/**
+ * Restore persisted chat history.
+ *
+ * - Malformed JSON, or anything that isn't a recognized shape, yields `[]`.
+ * - A bare array is legacy (v1): each `confidence` is reconciled onto the
+ *   0-100 scale via {@link migrateLegacyConfidence} so a cached `0.9` renders
+ *   as `90%` while an already-0-100 `90` is left untouched.
+ * - A `{ version, messages }` object is used as-is only when the version
+ *   matches the current one; unknown versions are discarded rather than
+ *   guessed at.
+ * Non-object entries are filtered out so a stray `null` can't crash rendering.
+ */
+export function parseStoredMessages(raw: string | null): Message[] {
+    if (!raw) return [];
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return [];
+    }
+
+    if (Array.isArray(parsed)) {
+        return parsed.filter(isMessageLike).map(message =>
+            message.confidence != null
+                ? { ...message, confidence: migrateLegacyConfidence(message.confidence) }
+                : message
+        );
+    }
+
+    if (
+        parsed != null &&
+        typeof parsed === "object" &&
+        (parsed as VersionedChatHistory).version === CHAT_HISTORY_VERSION &&
+        Array.isArray((parsed as VersionedChatHistory).messages)
+    ) {
+        return (parsed as VersionedChatHistory).messages.filter(isMessageLike);
+    }
+
+    return [];
+}
+
+/** Serialize chat history with the current version marker. */
+export function serializeChatHistory(messages: Message[]): string {
+    return JSON.stringify({ version: CHAT_HISTORY_VERSION, messages } satisfies VersionedChatHistory);
+}

--- a/app/graph/confidence.test.ts
+++ b/app/graph/confidence.test.ts
@@ -35,12 +35,24 @@ describe("migrateLegacyConfidence", () => {
         assert.equal(migrateLegacyConfidence(0.856), 86);
     });
 
-    it("treats a stored 1 as 100% (legacy payloads are wholly 0-1)", () => {
-        assert.equal(migrateLegacyConfidence(1), 100);
+    it("leaves already-0-100 values untouched (they cannot be fractions)", () => {
+        assert.equal(migrateLegacyConfidence(10), 10);
+        assert.equal(migrateLegacyConfidence(90), 90);
+        assert.equal(migrateLegacyConfidence(100), 100);
+    });
+
+    it("clamps out-of-range legacy values", () => {
+        assert.equal(migrateLegacyConfidence(150), 100);
+        assert.equal(migrateLegacyConfidence(-5), 0);
+    });
+
+    it("omits the ambiguous value 1 (1% vs 100%)", () => {
+        assert.equal(migrateLegacyConfidence(1), undefined);
     });
 
     it("returns undefined for non-finite or non-numeric input", () => {
         assert.equal(migrateLegacyConfidence(NaN), undefined);
+        assert.equal(migrateLegacyConfidence(Infinity), undefined);
         assert.equal(migrateLegacyConfidence(undefined), undefined);
         assert.equal(migrateLegacyConfidence(null), undefined);
     });

--- a/app/graph/confidence.test.ts
+++ b/app/graph/confidence.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeConfidence, migrateLegacyConfidence, getConfidenceStyle } from "./confidence.ts";
+
+describe("normalizeConfidence", () => {
+    it("rounds and passes through valid 0-100 values", () => {
+        assert.equal(normalizeConfidence(0), 0);
+        assert.equal(normalizeConfidence(70), 70);
+        assert.equal(normalizeConfidence(90), 90);
+        assert.equal(normalizeConfidence(100), 100);
+        assert.equal(normalizeConfidence(89.6), 90);
+        assert.equal(normalizeConfidence(70.4), 70);
+    });
+
+    it("clamps out-of-range values into [0, 100]", () => {
+        assert.equal(normalizeConfidence(150), 100);
+        assert.equal(normalizeConfidence(-10), 0);
+    });
+
+    it("returns undefined for non-finite or non-numeric input", () => {
+        assert.equal(normalizeConfidence(NaN), undefined);
+        assert.equal(normalizeConfidence(Infinity), undefined);
+        assert.equal(normalizeConfidence(-Infinity), undefined);
+        assert.equal(normalizeConfidence(undefined), undefined);
+        assert.equal(normalizeConfidence(null), undefined);
+        assert.equal(normalizeConfidence("90"), undefined);
+    });
+});
+
+describe("migrateLegacyConfidence", () => {
+    it("rescales 0-1 fractions onto the 0-100 scale", () => {
+        assert.equal(migrateLegacyConfidence(0.9), 90);
+        assert.equal(migrateLegacyConfidence(0.7), 70);
+        assert.equal(migrateLegacyConfidence(0), 0);
+        assert.equal(migrateLegacyConfidence(0.856), 86);
+    });
+
+    it("treats a stored 1 as 100% (legacy payloads are wholly 0-1)", () => {
+        assert.equal(migrateLegacyConfidence(1), 100);
+    });
+
+    it("returns undefined for non-finite or non-numeric input", () => {
+        assert.equal(migrateLegacyConfidence(NaN), undefined);
+        assert.equal(migrateLegacyConfidence(undefined), undefined);
+        assert.equal(migrateLegacyConfidence(null), undefined);
+    });
+});
+
+describe("getConfidenceStyle", () => {
+    it("returns the high tier at 90 and above", () => {
+        assert.equal(getConfidenceStyle(90).label, "High confidence");
+        assert.equal(getConfidenceStyle(100).label, "High confidence");
+    });
+
+    it("returns the medium tier in [70, 90)", () => {
+        assert.equal(getConfidenceStyle(70).label, "Medium confidence");
+        assert.equal(getConfidenceStyle(89).label, "Medium confidence");
+    });
+
+    it("returns the low tier below 70", () => {
+        assert.equal(getConfidenceStyle(69).label, "Low confidence");
+        assert.equal(getConfidenceStyle(0).label, "Low confidence");
+    });
+});

--- a/app/graph/confidence.ts
+++ b/app/graph/confidence.ts
@@ -1,0 +1,61 @@
+// Confidence badge helpers for the Chat panel.
+//
+// The @falkordb/text-to-cypher library reports confidence on a 0-100 scale
+// ("Model self-reported confidence (0-100) that the answer is correct given
+// the data"). These helpers keep the rendered percentage and the styling tier
+// derived from a single, sanitized value so they never disagree, and rescale
+// legacy chat history that was persisted on the old 0-1 fraction scale.
+
+export interface ConfidenceStyle {
+    label: string;
+    wrap: string;
+    dot: string;
+}
+
+/**
+ * Sanitize a live confidence value onto the 0-100 scale.
+ *
+ * Returns `undefined` for non-numeric or non-finite input (so no badge is
+ * shown), otherwise clamps to [0, 100] and rounds so that tier selection and
+ * the displayed percentage are always computed from the same integer.
+ */
+export function normalizeConfidence(value: unknown): number | undefined {
+    if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+    return Math.round(Math.min(100, Math.max(0, value)));
+}
+
+/**
+ * Rescale a confidence value read from legacy (unversioned) chat history.
+ *
+ * Older history stored confidence as a 0-1 fraction, so the whole payload is
+ * known to be on that scale — a stored `1` unambiguously means 100%, not 1%.
+ * Multiply into the 0-100 range and reuse {@link normalizeConfidence} for the
+ * clamp/round/finite handling.
+ */
+export function migrateLegacyConfidence(value: unknown): number | undefined {
+    if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+    return normalizeConfidence(value * 100);
+}
+
+// Confidence badge tiers: calm, low-saturation tints that stay readable in light and dark themes.
+export function getConfidenceStyle(value: number): ConfidenceStyle {
+    if (value >= 90) {
+        return {
+            label: "High confidence",
+            wrap: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 ring-emerald-500/20",
+            dot: "bg-emerald-500",
+        };
+    }
+    if (value >= 70) {
+        return {
+            label: "Medium confidence",
+            wrap: "bg-amber-500/10 text-amber-700 dark:text-amber-300 ring-amber-500/25",
+            dot: "bg-amber-500",
+        };
+    }
+    return {
+        label: "Low confidence",
+        wrap: "bg-rose-500/10 text-rose-700 dark:text-rose-300 ring-rose-500/25",
+        dot: "bg-rose-500",
+    };
+}

--- a/app/graph/confidence.ts
+++ b/app/graph/confidence.ts
@@ -25,16 +25,24 @@ export function normalizeConfidence(value: unknown): number | undefined {
 }
 
 /**
- * Rescale a confidence value read from legacy (unversioned) chat history.
+ * Reconcile a confidence value read from legacy (unversioned) chat history,
+ * whose scale is not recorded per value.
  *
- * Older history stored confidence as a 0-1 fraction, so the whole payload is
- * known to be on that scale — a stored `1` unambiguously means 100%, not 1%.
- * Multiply into the 0-100 range and reuse {@link normalizeConfidence} for the
- * clamp/round/finite handling.
+ * Bare-array histories can contain values from two eras: older builds stored a
+ * 0-1 fraction, while newer builds (still writing bare arrays) already stored a
+ * 0-100 value. Disambiguate by magnitude since a 0-1 fraction can never exceed
+ * 1:
+ *   - `value > 1`     -> already on the 0-100 scale, normalize as-is
+ *   - `0 < value < 1` -> a 0-1 fraction, rescaled to 0-100
+ *   - `value <= 0`    -> 0 on either scale
+ *   - `value === 1`   -> ambiguous (1% vs 100%); omitted so it is never
+ *                        mislabelled in either direction
  */
 export function migrateLegacyConfidence(value: unknown): number | undefined {
     if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
-    return normalizeConfidence(value * 100);
+    if (value === 1) return undefined;
+    if (value > 0 && value < 1) return normalizeConfidence(value * 100);
+    return normalizeConfidence(value);
 }
 
 // Confidence badge tiers: calm, low-saturation tints that stay readable in light and dark themes.

--- a/e2e/logic/POM/chatComponent.ts
+++ b/e2e/logic/POM/chatComponent.ts
@@ -420,14 +420,6 @@ export default class ChatComponent extends GraphPage {
     );
   }
 
-  async getChatConfidenceBadgeLabel(): Promise<string | null> {
-    return interactWhenVisible(
-      this.chatConfidenceBadge.last(),
-      (el) => el.getAttribute("aria-label"),
-      "Chat Confidence Badge Label"
-    );
-  }
-
   async getChatConfidenceBadgeCount(): Promise<number> {
     return this.chatConfidenceBadge.count();
   }

--- a/e2e/logic/POM/chatComponent.ts
+++ b/e2e/logic/POM/chatComponent.ts
@@ -35,6 +35,10 @@ export default class ChatComponent extends GraphPage {
     return this.page.getByTestId(`chatAssistantMessage-${type}`);
   }
 
+  private get chatConfidenceBadge(): Locator {
+    return this.page.getByTestId("chatConfidenceBadge");
+  }
+
   // Input and Send
   private get chatForm(): Locator {
     return this.page.getByTestId("chatForm");
@@ -396,6 +400,31 @@ export default class ChatComponent extends GraphPage {
       this.chatFooterModel,
       (el) => el.textContent(),
       "Chat Footer Model"
+    );
+  }
+
+  async waitForChatConfidenceBadge(): Promise<boolean> {
+    try {
+      await this.chatConfidenceBadge.first().waitFor({ state: "visible", timeout: 10000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getChatConfidenceBadgeText(): Promise<string | null> {
+    return interactWhenVisible(
+      this.chatConfidenceBadge.first(),
+      (el) => el.textContent(),
+      "Chat Confidence Badge"
+    );
+  }
+
+  async getChatConfidenceBadgeLabel(): Promise<string | null> {
+    return interactWhenVisible(
+      this.chatConfidenceBadge.first(),
+      (el) => el.getAttribute("aria-label"),
+      "Chat Confidence Badge Label"
     );
   }
 }

--- a/e2e/logic/POM/chatComponent.ts
+++ b/e2e/logic/POM/chatComponent.ts
@@ -405,7 +405,7 @@ export default class ChatComponent extends GraphPage {
 
   async waitForChatConfidenceBadge(): Promise<boolean> {
     try {
-      await this.chatConfidenceBadge.first().waitFor({ state: "visible", timeout: 10000 });
+      await this.chatConfidenceBadge.last().waitFor({ state: "visible", timeout: 10000 });
       return true;
     } catch {
       return false;
@@ -414,7 +414,7 @@ export default class ChatComponent extends GraphPage {
 
   async getChatConfidenceBadgeText(): Promise<string | null> {
     return interactWhenVisible(
-      this.chatConfidenceBadge.first(),
+      this.chatConfidenceBadge.last(),
       (el) => el.textContent(),
       "Chat Confidence Badge"
     );
@@ -422,9 +422,13 @@ export default class ChatComponent extends GraphPage {
 
   async getChatConfidenceBadgeLabel(): Promise<string | null> {
     return interactWhenVisible(
-      this.chatConfidenceBadge.first(),
+      this.chatConfidenceBadge.last(),
       (el) => el.getAttribute("aria-label"),
       "Chat Confidence Badge Label"
     );
+  }
+
+  async getChatConfidenceBadgeCount(): Promise<number> {
+    return this.chatConfidenceBadge.count();
   }
 }

--- a/e2e/tests/chat.spec.ts
+++ b/e2e/tests/chat.spec.ts
@@ -697,6 +697,18 @@ test.describe("Chat Feature Tests", () => {
     await chat.clickChatSendButton();
     await chat.waitForAssistantResponse("Result");
 
+    // Confidence badge should render the 0-100 value directly (not as a 0-1 fraction)
+    const hasConfidenceBadge = await chat.waitForChatConfidenceBadge();
+    expect(hasConfidenceBadge).toBe(true);
+
+    const confidenceText = await chat.getChatConfidenceBadgeText();
+    expect(confidenceText).toContain("90%");
+
+    // 90 falls in the high-confidence tier
+    const confidenceLabel = await chat.getChatConfidenceBadgeLabel();
+    expect(confidenceLabel).toContain("High confidence");
+    expect(confidenceLabel).toContain("90%");
+
     // Footer should now display token data
     const hasTokens = await chat.waitForChatFooterTokens();
     expect(hasTokens).toBe(true);

--- a/e2e/tests/chat.spec.ts
+++ b/e2e/tests/chat.spec.ts
@@ -683,7 +683,7 @@ test.describe("Chat Feature Tests", () => {
           cypherQuery: "MATCH (a:Person)-[:KNOWS]->(b) RETURN b.name",
           cypherResult: null,
           answer: "Bob is Alice's friend.",
-          confidence: 0.9,
+          confidence: 90,
           tokenUsage: { totalTokens: 150 },
         }),
       });

--- a/e2e/tests/chat.spec.ts
+++ b/e2e/tests/chat.spec.ts
@@ -544,6 +544,9 @@ test.describe("Chat Feature Tests", () => {
     const hasCodeBlock = await markdownDiv.locator("pre code").count();
     expect(hasCodeBlock).toBeGreaterThanOrEqual(1);
 
+    // A null confidence must not render a badge
+    expect(await chat.getChatConfidenceBadgeCount()).toBe(0);
+
     // Cleanup mock
     await page.unroute("**/api/chat");
     await apiCall.removeGraph(graphName);
@@ -785,6 +788,87 @@ test.describe("Chat Feature Tests", () => {
 
     expect(await chat.getChatFooterLastTokens()).toContain("50");
     expect(await chat.getChatFooterTotalTokens()).toContain("150");
+
+    await page.unroute("**/api/chat");
+    await apiCall.removeGraph(graphName);
+  });
+
+  test(`@readwrite Verify confidence badge renders the correct tier and percentage per message`, async () => {
+    const graphName = getRandomString("chat");
+    await apiCall.addGraph(graphName);
+    await apiCall.runQuery(graphName, 'CREATE (a:Person {name: "Alice"})-[:KNOWS]->(b:Person {name: "Bob"})');
+
+    const chat = await browser.createNewPage(ChatComponent);
+    await browser.setPageToFullScreen();
+    const page = await browser.getPage();
+
+    await page.addInitScript(({ selectedModel }) => {
+      localStorage.setItem("model", selectedModel);
+      localStorage.setItem("secretKey", "fake-key-confidence-tiers");
+    }, { selectedModel: DEFAULT_CHAT_MODEL });
+    await page.goto(urls.graphUrl);
+    await page.waitForLoadState("networkidle");
+
+    // Each call returns the next confidence on the 0-100 scale so we exercise
+    // every tier boundary: 90 (high), 70 (medium), 69 (low).
+    const confidences = [90, 70, 69];
+    let callCount = 0;
+    await page.route("**/api/chat", (route) => {
+      const confidence = confidences[Math.min(callCount, confidences.length - 1)];
+      callCount += 1;
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cypherQuery: "MATCH (n) RETURN n",
+          cypherResult: null,
+          answer: `Answer with confidence ${confidence}.`,
+          confidence,
+          tokenUsage: { totalTokens: 10 },
+        }),
+      });
+    });
+
+    await chat.selectGraphByName(graphName);
+    await chat.openChat();
+    await chat.waitForChatPanel();
+
+    // 90 → High confidence (inclusive lower boundary)
+    await chat.fillChatInput("First question");
+    await chat.clickChatSendButton();
+    await chat.waitForAssistantResponse("Result");
+    expect(await chat.getChatConfidenceBadgeText()).toContain("90%");
+    expect(await chat.getChatConfidenceBadgeLabel()).toContain("High confidence");
+
+    // 70 → Medium confidence (inclusive lower boundary)
+    await chat.fillChatInput("Second question");
+    await chat.waitForChatSendButtonEnabled();
+    await chat.clickChatSendButton();
+    await chat.waitForAssistantResponse("Result");
+    await page.waitForFunction(
+      () => {
+        const badge = document.querySelectorAll('[data-testid="chatConfidenceBadge"]');
+        return badge[badge.length - 1]?.getAttribute("aria-label")?.includes("Medium confidence");
+      },
+      { timeout: 5000 }
+    );
+    expect(await chat.getChatConfidenceBadgeText()).toContain("70%");
+    expect(await chat.getChatConfidenceBadgeLabel()).toContain("Medium confidence");
+
+    // 69 → Low confidence (just below the medium boundary)
+    await chat.fillChatInput("Third question");
+    await chat.waitForChatSendButtonEnabled();
+    await chat.clickChatSendButton();
+    await chat.waitForAssistantResponse("Result");
+    await page.waitForFunction(
+      () => {
+        const badge = document.querySelectorAll('[data-testid="chatConfidenceBadge"]');
+        return badge[badge.length - 1]?.getAttribute("aria-label")?.includes("Low confidence");
+      },
+      { timeout: 5000 }
+    );
+    expect(await chat.getChatConfidenceBadgeText()).toContain("69%");
+    expect(await chat.getChatConfidenceBadgeLabel()).toContain("Low confidence");
 
     await page.unroute("**/api/chat");
     await apiCall.removeGraph(graphName);

--- a/e2e/tests/chat.spec.ts
+++ b/e2e/tests/chat.spec.ts
@@ -704,13 +704,11 @@ test.describe("Chat Feature Tests", () => {
     const hasConfidenceBadge = await chat.waitForChatConfidenceBadge();
     expect(hasConfidenceBadge).toBe(true);
 
+    // The badge text carries the visible percentage plus the screen-reader tier label
     const confidenceText = await chat.getChatConfidenceBadgeText();
     expect(confidenceText).toContain("90%");
-
     // 90 falls in the high-confidence tier
-    const confidenceLabel = await chat.getChatConfidenceBadgeLabel();
-    expect(confidenceLabel).toContain("High confidence");
-    expect(confidenceLabel).toContain("90%");
+    expect(confidenceText).toContain("High confidence");
 
     // Footer should now display token data
     const hasTokens = await chat.waitForChatFooterTokens();
@@ -838,7 +836,7 @@ test.describe("Chat Feature Tests", () => {
     await chat.clickChatSendButton();
     await chat.waitForAssistantResponse("Result");
     expect(await chat.getChatConfidenceBadgeText()).toContain("90%");
-    expect(await chat.getChatConfidenceBadgeLabel()).toContain("High confidence");
+    expect(await chat.getChatConfidenceBadgeText()).toContain("High confidence");
 
     // 70 → Medium confidence (inclusive lower boundary)
     await chat.fillChatInput("Second question");
@@ -848,12 +846,12 @@ test.describe("Chat Feature Tests", () => {
     await page.waitForFunction(
       () => {
         const badge = document.querySelectorAll('[data-testid="chatConfidenceBadge"]');
-        return badge[badge.length - 1]?.getAttribute("aria-label")?.includes("Medium confidence");
+        return badge[badge.length - 1]?.textContent?.includes("Medium confidence");
       },
       { timeout: 5000 }
     );
     expect(await chat.getChatConfidenceBadgeText()).toContain("70%");
-    expect(await chat.getChatConfidenceBadgeLabel()).toContain("Medium confidence");
+    expect(await chat.getChatConfidenceBadgeText()).toContain("Medium confidence");
 
     // 69 → Low confidence (just below the medium boundary)
     await chat.fillChatInput("Third question");
@@ -863,12 +861,12 @@ test.describe("Chat Feature Tests", () => {
     await page.waitForFunction(
       () => {
         const badge = document.querySelectorAll('[data-testid="chatConfidenceBadge"]');
-        return badge[badge.length - 1]?.getAttribute("aria-label")?.includes("Low confidence");
+        return badge[badge.length - 1]?.textContent?.includes("Low confidence");
       },
       { timeout: 5000 }
     );
     expect(await chat.getChatConfidenceBadgeText()).toContain("69%");
-    expect(await chat.getChatConfidenceBadgeLabel()).toContain("Low confidence");
+    expect(await chat.getChatConfidenceBadgeText()).toContain("Low confidence");
 
     await page.unroute("**/api/chat");
     await apiCall.removeGraph(graphName);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "node --test \"app/**/*.test.ts\" \"lib/**/*.test.ts\"",
-    "test:coverage": "node --test --experimental-test-coverage --test-coverage-include=\"lib/cypherSuggestions.ts\" --test-coverage-include=\"lib/cypherDiagnostics.ts\" --test-coverage-include=\"lib/aiFix.ts\" --test-coverage-include=\"lib/cypherErrors.ts\" --test-coverage-include=\"lib/clipboard.ts\" --test-coverage-lines=100 --test-coverage-functions=100 --test-coverage-branches=100 \"app/**/*.test.ts\" \"lib/**/*.test.ts\"",
+    "test:coverage": "node --test --experimental-test-coverage --test-coverage-include=\"lib/cypherSuggestions.ts\" --test-coverage-include=\"lib/cypherDiagnostics.ts\" --test-coverage-include=\"lib/aiFix.ts\" --test-coverage-include=\"lib/cypherErrors.ts\" --test-coverage-include=\"lib/clipboard.ts\" --test-coverage-include=\"app/graph/confidence.ts\" --test-coverage-include=\"app/graph/chatHistory.ts\" --test-coverage-lines=100 --test-coverage-functions=100 --test-coverage-branches=100 \"app/**/*.test.ts\" \"lib/**/*.test.ts\"",
     "test:smoke": "node --test \"lib/**/*.smoke.ts\"",
     "test:e2e": "playwright test"
   },


### PR DESCRIPTION
## Changes
- **Bump `@falkordb/text-to-cypher` to 0.2.3** · picks up improved confidence scoring (confidence now reflects whether the graph data actually answers the question; non-answers score low instead of 100) and readable shortest-path results.
- **Confidence badge redesign in Chat** · the library reports confidence as a 0-100 integer (previously treated as a 0-1 fraction), so the badge now renders the value directly. New tiered styling: high (≥90, green) / medium (≥70, amber) / low (red), with a status dot, tooltip, and light/dark theme support.
- **E2E fixture updated** to the 0-100 scale.

## Verification
- TypeScript check passes
- Manually tested against a local text-to-cypher 0.2.4 server: data-backed answers show ~100, unanswerable questions show ~0-10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated confidence display in chat results to show clearer percentage-based values with high/medium/low styling and a helpful tooltip.
  * Corrected the confidence badge to match the expected scale in chat-related flows.

* **Chores**
  * Updated a package dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->