### PR TITLE
ci: fix malformed checkout step in playwright.yml

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,8 +38,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      with:
-        persist-credentials: false
         with:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Problem

The `actions/checkout` step in `.github/workflows/playwright.yml` has a malformed YAML structure since it was introduced. The `with:` block is at the wrong indentation level (6 spaces, making it a sibling of the step list item) and is duplicated — an inner `with:` is nested inside the outer one:

```yaml
# ❌ broken — with: at 6 spaces is NOT a child of the step
      - uses: actions/checkout@...
      with:
        persist-credentials: false
        with:
          persist-credentials: false
```

This causes **YAML parse error on line 39** which prevents the entire Playwright workflow from running on every commit to `staging` and every PR targeting it.

## Fix

```yaml
# ✅ correct — with: at 8 spaces, child of the step
      - uses: actions/checkout@...
        with:
          persist-credentials: false
```

Remove the duplicate outer `with:` block and fix the indentation so `with:` is a proper child of the step.

## Impact

Every Playwright CI run since this was introduced has failed immediately with `Invalid workflow file: .github/workflows/playwright.yml#L39` — no tests have been executing. This single-line fix unblocks all Playwright runs on `staging`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Playwright workflow configuration by removing an unused checkout setting. No user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->