### PR TITLE
chore(deps): ignore TypeScript 7.0.x in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,11 +16,11 @@ updates:
         update-types:
           - "patch"
     ignore:
-      # TypeScript 7 (native Go compiler) ships no JS Compiler API, which
+      # TypeScript 7.0 (native Go compiler) ships no JS Compiler API, which
       # Next.js relies on for `next build` type-checking, so the bump breaks
-      # the build. Remove this once we're on Next.js >= 16.3.0 (experimental
-      # useTypeScriptCli) or TypeScript 7.1 restores the programmatic API.
+      # the build. Scoped to 7.0.x only: TypeScript 7.1 is expected to restore
+      # the programmatic API, so allow Dependabot to propose 7.1+ when it lands.
       # See https://github.com/vercel/next.js/pull/95639
       - dependency-name: "typescript"
-        versions: ["7.x"]
+        versions: ["7.0.x"]
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,12 @@ updates:
       npm-minor-patch:
         update-types:
           - "patch"
-    
+    ignore:
+      # TypeScript 7 (native Go compiler) ships no JS Compiler API, which
+      # Next.js relies on for `next build` type-checking, so the bump breaks
+      # the build. Remove this once we're on Next.js >= 16.3.0 (experimental
+      # useTypeScriptCli) or TypeScript 7.1 restores the programmatic API.
+      # See https://github.com/vercel/next.js/pull/95639
+      - dependency-name: "typescript"
+        versions: ["7.x"]
+


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` rule for the `typescript` **7.0.x** line (npm ecosystem). Scoped to 7.0.x only — **7.1+ is intentionally allowed**.

## Why

TypeScript 7.0 is the new native (Go) compiler rewrite. Its npm package no longer exposes the JavaScript **Compiler API** at the package root (`main` is gone; `exports["."]` points to `lib/version.cjs`). Next.js relies on that JS API for the `next build` type-check step, so bumping `typescript` to 7.0.x fails the build:

```
Running TypeScript ...
It looks like you're trying to use TypeScript but do not have the required package(s) installed.
Next.js build worker exited with code: 1
```

This is exactly what breaks **#1929** (Dependabot `typescript 6.0.3 → 7.0.2`), taking down `build`, `security-scan` (Docker build) and `Vercel`.

## Why 7.0.x only (not 7.x)

**TypeScript 7.1** is expected to restore the programmatic JS Compiler API that Next.js needs. Scoping the ignore to `7.0.x` lets Dependabot propose **7.1+** once it lands (CI will then verify compatibility), rather than blocking the entire major line.

## Context / related

- Interim Next.js support landed in [vercel/next.js#95639](https://github.com/vercel/next.js/pull/95639) (`experimental.useTypeScriptCli`), shipping in **Next.js 16.3.0** (currently canary/preview; `latest` is still 16.2.10).
- 6.x patch/minor updates are unaffected.

Note: #1929 can be closed once this merges — Dependabot will stop re-proposing the 7.0.x bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency updates to skip TypeScript 7.x versions on the staging branch to help maintain build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->