### PR TITLE
fix(auth): make Token DB the sole authority for the connection target

### DIFF
--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -1349,50 +1349,11 @@ export async function getClient(
     console.warn("Failed to resolve connection:", connErr);
   }
 
-  // Before returning SESSION_INVALID, attempt a direct reconnect using session
-  // credentials. This handles transient Token DB issues without accumulating
-  // new Token DB entries (the connection is stored in cache only).
-  try {
-    const { user: sessionUser } = session;
-    // Try to resolve password from Token DB (best-effort; works without for
-    // passwordless connections which are common in dev/CI).
-    let reconnectPassword: string | undefined;
-    try {
-      const { decrypt } = await import("../encryption");
-      const storage = StorageFactory.getStorage();
-      const tokenData = await storage.fetchTokenById(connId);
-      if (tokenData?.encrypted_password) {
-        reconnectPassword = decrypt(tokenData.encrypted_password) || undefined;
-      }
-    } catch { /* proceed without password */ }
-    const reconnectUsername = reconnectPassword ? (sessionUser.username || undefined) : undefined;
-    const { client: reconnected, role: reconnectedRole } = await newClient(
-      {
-        host: sessionUser.host,
-        port: sessionUser.port.toString(),
-        username: reconnectUsername,
-        password: reconnectPassword,
-        tls: sessionUser.tls.toString(),
-      },
-      connKey
-    );
-    return {
-      client: reconnected,
-      user: {
-        id,
-        username: sessionUser.username,
-        role: reconnectedRole,
-        host: sessionUser.host,
-        port: sessionUser.port,
-        tls: sessionUser.tls,
-        password: reconnectPassword,
-      },
-    };
-  } catch (reconnectErr) {
-    // eslint-disable-next-line no-console
-    console.warn("connId reconnect fallback failed:", reconnectErr);
-  }
-
+  // Fail closed: the Token DB connection row is the single source of truth for
+  // the connection target. If it can't be resolved to a bound row, we do NOT
+  // reconstruct the connection from JWT/session host fields — doing so would
+  // let the session pointer (connId) and the actual connection target diverge.
+  // Force the client to re-authenticate instead.
   // eslint-disable-next-line no-console
   console.warn("getClient: returning SESSION_INVALID (connId path) for session:", id, "connId:", connId);
   return NextResponse.json(


### PR DESCRIPTION
## Summary

Removes the **connId JWT-host reconnect fallback** in `getClient()` so that the **Token DB connection row is the single source of truth** for a connection's runtime target. `getClient()` now **fails closed** when a connection row can't be resolved, instead of rebuilding the FalkorDB connection from JWT/session host fields.

### The problem

In `app/api/auth/[...nextauth]/options.ts`, when a connection's Token DB row could not be resolved (missing / stale / transient DB error), `getClient()` reconnected using `session.user.host/port/username/tls` from the JWT-derived session. That let the session pointer (`activeConnectionId`) and the actual connection target **diverge**: the resulting client was labeled with `connId` X while pointing at whatever the JWT host claimed — ambiguous and hard to audit.

### The fix

`getClient()` fail-closes: if the Token DB row can't be resolved, it returns `SESSION_INVALID` (`401`, `X-Session-Invalid: 1`) and forces re-authentication. No connection is ever reconstructed from JWT host fields.

```diff
- // Before returning SESSION_INVALID, attempt a direct reconnect using session credentials.
- try { ... newClient({ host: sessionUser.host, ... }) ... }
+ // Fail closed: the Token DB connection row is the single source of truth.
```

### Scope: why JWT metadata is intentionally kept

I checked every consumer of the JWT connection metadata (`host/port/username/role/tls`). It's used in ~8 places — **all display or UX, none security**:

| Consumer | Use |
|---|---|
| `Header.tsx`, `providers.tsx` | Display host:port |
| `loginVerification.tsx` | Login-redirect logic (URL params vs session) |
| `selectGraph.tsx`, `settings/page.tsx` | Role-based **UI** gating |
| `connections/route.ts` | Defaults for new connections |
| `migrate-session/route.ts` | **Recovery** source after a Token DB wipe |

Server-side authorization is enforced by **FalkorDB ACL** via the role `getClient()` returns from the Token DB — not by `session.user.role`. Stripping these fields from the JWT would deliver **no security benefit** and would **break `migrate-session` recovery**, so they're retained. This PR deliberately does *only* the fallback removal.

### Behavioral note

The removed fallback also masked **transient** Token DB unavailability by silently reconnecting. After this change, a transient Token DB miss surfaces as `SESSION_INVALID` → re-auth. This is consistent with the app's existing fail-closed handling and is the intended trade for a single, auditable source of truth.

## Testing

- `npm run build` — ✅ compiles, strict type-check passes
- Full unit suite (`node --test`) — ✅ 196/196 pass

`getClient()` is an integration surface (next-auth `getToken`, `next/headers`, Token DB, live FalkorDB), so its fail-closed path is covered by the existing e2e session flows rather than a brittle module-mock unit test.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication reliability by treating the Token database as the authoritative source for connection details.
  * Requests now fail securely with an authentication error when a valid connection cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->