### PR TITLE
fix(graph): scope graph-info polling to its connection (cancel + epoch)

### DIFF
--- a/app/components/provider.ts
+++ b/app/components/provider.ts
@@ -170,7 +170,7 @@ type GraphContextType = {
   currentTab: Tab;
   setCurrentTab: Dispatch<SetStateAction<Tab>>;
   runQuery: (query: string, name?: string) => Promise<void>;
-  fetchCount: (name?: string) => Promise<void>;
+  fetchCount: (name?: string, options?: { signal?: AbortSignal; connectionId?: string | null; epoch?: number }) => Promise<void>;
   handleCooldown: (ticks?: number, isSetLoading?: boolean) => void;
   cooldownTicks: number | undefined;
   isLoading: boolean;

--- a/app/graph/page.tsx
+++ b/app/graph/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
-import { cn, convertToCanvasData, getMemoryUsage, getMetaStats, getSSEGraphResult, isTwoNodes, Link, MemoryValue, Node, prepareArg, securedFetch, Value } from "@/lib/utils";
+import { cn, convertToCanvasData, getConnectionEpoch, getMemoryUsage, getMetaStats, getSSEGraphResult, isAbortError, isTwoNodes, Link, MemoryValue, Node, prepareArg, securedFetch, Value } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import dynamicImport from "next/dynamic";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
@@ -170,7 +170,7 @@ export default function Page() {
         }
     }, [currentTab, panel, selectedElements.length, setPanel]);
 
-    const fetchInfo = useCallback(async (type: string) => {
+    const fetchInfo = useCallback(async (type: string, options?: { signal?: AbortSignal; connectionId?: string | null }) => {
         if (!graphName) return [];
 
         if (type === "(property key)") {
@@ -180,6 +180,7 @@ export default function Page() {
                 `/api/graph/${prepareArg(graphName)}?query=${prepareArg(query)}${readOnlyParam}`,
                 toast,
                 setIndicator,
+                { signal: options?.signal, connectionId: options?.connectionId },
             ) as { data?: Array<{ info?: unknown }> };
 
             if (!sse || !Array.isArray(sse.data)) return [];
@@ -190,8 +191,12 @@ export default function Page() {
         }
 
         const readOnlyParam = isReadOnlyRef.current ? '&readOnly=true' : '';
+        const headers = new Headers();
+        if (options?.connectionId) headers.set("X-Connection-Id", options.connectionId);
         const result = await securedFetch(`/api/graph/${prepareArg(graphName)}/info?type=${prepareArg(type)}${readOnlyParam}`, {
             method: "GET",
+            headers,
+            signal: options?.signal,
         }, toast, setIndicator);
 
         if (!result.ok) return [];
@@ -219,7 +224,7 @@ export default function Page() {
             .filter((value): value is string => typeof value === "string");
     }, [graphName, setIndicator, toast]);
 
-    const fetchMetaStats = useCallback((name: string) => getMetaStats(name, toast, setIndicator, isReadOnlyRef.current), [setIndicator, toast]);
+    const fetchMetaStats = useCallback((name: string, options?: { signal?: AbortSignal; connectionId?: string | null }) => getMetaStats(name, toast, setIndicator, isReadOnlyRef.current, options), [setIndicator, toast]);
 
     useEffect(() => {
         if (!graphName) {
@@ -234,14 +239,29 @@ export default function Page() {
         // change) or unmounts, so a late poll can't write stale metadata onto the
         // graph that is now active (setGraphInfo mutates the current graph).
         let cancelled = false;
+        // AbortController closes in-flight EventSource/fetch requests on cleanup so
+        // a superseded poll can't surface a stale error toast or flip the
+        // indicator offline for the connection that is now active.
+        const controller = new AbortController();
+        const { signal } = controller;
+        // Pin every request in this run to the connection active at start, so the
+        // whole poll targets one connection even if the global changes mid-flight.
+        // activeConnectionId is intentionally NOT an effect dependency: a
+        // connection switch always resets graphName (providers.tsx), which re-runs
+        // this effect and aborts the old poll. Re-running on activeConnectionId
+        // directly would fire a query for the *previous* graph against the *new*
+        // connection (auto-creating it) before graphName is cleared.
+        const pollConnectionId = activeConnectionId;
+        const pollEpoch = getConnectionEpoch();
+        const requestOptions = { signal, connectionId: pollConnectionId, epoch: pollEpoch };
 
         const handleSetInfo = () => Promise.all([
-            fetchMetaStats(graphName),
-            fetchInfo("(property key)"),
+            fetchMetaStats(graphName, requestOptions),
+            fetchInfo("(property key)", requestOptions),
         ]).then(async ([newDataStats, newPropertyKeys]) => {
             if (cancelled) return;
 
-            const memoryUsage = showMemoryUsage ? await getMemoryUsage(graphName, toast, setIndicator, activeConnectionId) : new Map<string, MemoryValue>();
+            const memoryUsage = showMemoryUsage ? await getMemoryUsage(graphName, toast, setIndicator, pollConnectionId, signal) : new Map<string, MemoryValue>();
             const newLabels = newDataStats?.[0] || [];
             const newRelationships = newDataStats?.[1] || [];
 
@@ -249,9 +269,9 @@ export default function Page() {
             if (cancelled) return;
 
             setGraphInfo(gi);
-            fetchCount(graphName);
+            fetchCount(graphName, requestOptions);
         }).catch((error) => {
-            if (cancelled) return;
+            if (cancelled || isAbortError(error)) return;
             toast({
                 title: "Error",
                 description: (error as Error).message || "Failed to fetch graph info",
@@ -274,6 +294,7 @@ export default function Page() {
 
         return () => {
             cancelled = true;
+            controller.abort();
             clearInterval(interval);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -602,6 +602,10 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   isReadOnlyRef.current = isReadOnly;
   const activeGraphNameRef = useRef(graphName);
   activeGraphNameRef.current = graphName;
+  // Ref for the auth status so fetchCount reads the latest value without adding
+  // `status` to its deps (which would churn every consumer of that callback).
+  const statusRef = useRef(status);
+  statusRef.current = status;
 
   const connectionContext = useMemo(() => ({
     connectionType,
@@ -628,7 +632,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   const fetchCount = useCallback(async (name?: string, options?: { signal?: AbortSignal; connectionId?: string | null; epoch?: number }) => {
     const n = name || graphName;
 
-    if (!n || status === "unauthenticated") return;
+    if (!n || statusRef.current === "unauthenticated") return;
 
     // Capture the connection this request targets. Prefer the caller's captured
     // epoch (the epoch when its poll/action began) so a switch between that start

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,7 +3,7 @@
 import { SessionProvider, useSession } from "next-auth/react";
 import { ThemeProvider } from 'next-themes';
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { fetchOptions, getDefaultQuery, getQueryWithLimit, getSSEGraphResult, prepareArg, securedFetch, setActiveConnectionIdGlobal, getActiveConnectionIdGlobal, Tab, getMemoryUsage, GraphRef, ConnectionType, ConnectionInfo, UDFEntry, UDFEntryWithCode, getMetaStats, HistoryQuery, GraphData, Label, Relationship, Query, Data, MemoryValue } from "@/lib/utils";
+import { fetchOptions, getDefaultQuery, getQueryWithLimit, getSSEGraphResult, prepareArg, securedFetch, setActiveConnectionIdGlobal, getActiveConnectionIdGlobal, getConnectionEpoch, isAbortError, Tab, getMemoryUsage, GraphRef, ConnectionType, ConnectionInfo, UDFEntry, UDFEntryWithCode, getMetaStats, HistoryQuery, GraphData, Label, Relationship, Query, Data, MemoryValue } from "@/lib/utils";
 import { serverEncrypt, serverDecrypt, looksServerEncrypted, isLegacyEncrypted, legacyDecrypt, clearLegacyEncryptionKey } from "@/lib/server-encryption";
 import { CHAT_API_KEYS_STORAGE_KEY, SELECTED_CHAT_API_KEY_ID_STORAGE_KEY, getSelectedChatApiKey, persistSelectedChatApiKeyId } from "@/lib/chat-api-key-storage";
 import { getConnectionItem, setConnectionItem, removeConnectionItem, setConnectionPrefix, clearConnectionPrefix, migrateToScopedStorage } from "@/lib/connection-storage";
@@ -625,24 +625,49 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     setSelectedUdf
   }), [selectedUdf, udfList]);
 
-  const fetchCount = useCallback(async (name?: string) => {
+  const fetchCount = useCallback(async (name?: string, options?: { signal?: AbortSignal; connectionId?: string | null; epoch?: number }) => {
     const n = name || graphName;
 
     if (!n || status === "unauthenticated") return;
 
+    // Capture the connection this request targets. Prefer the caller's captured
+    // epoch (the epoch when its poll/action began) so a switch between that start
+    // and this call is caught; otherwise capture it now.
+    const connectionId = options?.connectionId !== undefined ? options.connectionId : getActiveConnectionIdGlobal();
+    const startEpoch = options?.epoch !== undefined ? options.epoch : getConnectionEpoch();
+
+    // Already superseded: skip the request entirely so we never query a stale
+    // graph against a switched connection (which could auto-create it).
+    if (getConnectionEpoch() !== startEpoch) return;
+
+    // Suppress the request's toast / indicator side effects if the connection is
+    // switched while it is in flight — getSSEGraphResult fires them internally
+    // before we can inspect the epoch, and not every caller passes an AbortSignal.
+    const guardedToast = ((...args: Parameters<typeof toast>) => {
+      if (getConnectionEpoch() === startEpoch) toast(...args);
+    }) as typeof toast;
+    const guardedSetIndicator = (indicator: "online" | "offline") => {
+      if (getConnectionEpoch() === startEpoch) setIndicator(indicator);
+    };
+
     try {
       const readOnlyParam = isReadOnlyRef.current ? '?readOnly=true' : '';
-      const result = await getSSEGraphResult(`api/graph/${prepareArg(n)}/count${readOnlyParam}`, toast, setIndicator) as { nodes?: number; edges?: number };
+      const result = await getSSEGraphResult(`api/graph/${prepareArg(n)}/count${readOnlyParam}`, guardedToast, guardedSetIndicator, {
+        signal: options?.signal,
+        connectionId,
+      }) as { nodes?: number; edges?: number };
 
       if (!result) return;
 
-      if (n !== activeGraphNameRef.current) return;
+      // Discard if the graph name or the connection changed while in flight.
+      if (n !== activeGraphNameRef.current || getConnectionEpoch() !== startEpoch) return;
 
       const { nodes, edges } = result;
 
       graphInfoSyncRef.current.setEdgesCount(edges);
       graphInfoSyncRef.current.setNodesCount(nodes);
     } catch (error) {
+      if (isAbortError(error)) return;
       console.error(error);
     }
   }, [graphName, toast]);

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -287,7 +287,13 @@ describe("abort helpers", () => {
     const native = new Error("stop");
     native.name = "AbortError";
     assert.equal(isAbortError(native), true);
+    // Real fetch / AbortController aborts reject with a DOMException, which is
+    // not an `instanceof Error` in browsers — it must still be recognized.
+    assert.equal(isAbortError(new DOMException("Aborted", "AbortError")), true);
+    // Any object whose name is "AbortError" (defensive against host differences).
+    assert.equal(isAbortError({ name: "AbortError" }), true);
     assert.equal(isAbortError(new Error("boom")), false);
+    assert.equal(isAbortError(new DOMException("Timeout", "TimeoutError")), false);
     assert.equal(isAbortError(null), false);
     assert.equal(isAbortError("AbortError"), false);
   });

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -183,6 +183,35 @@ describe("getSSEGraphResult error handling", () => {
       mock.restore();
     }
   });
+
+  it("propagates options.query and the server message into the error toast payload", async () => {
+    const mock = installMockEventSource();
+    const toasts: Array<Record<string, unknown>> = [];
+    try {
+      const query = "MATCH (n) RETURN n";
+      const promise = getSSEGraphResult(
+        "api/graph/demo?query=RETURN 1",
+        (t) => { toasts.push(t as Record<string, unknown>); },
+        () => {},
+        { query },
+      );
+      const instance = mock.getInstance();
+
+      instance.listeners.error({ data: JSON.stringify({ message: "Syntax error near WHERE", status: 400 }) } as MessageEvent);
+
+      await assert.rejects(promise);
+      assert.equal(toasts.length, 1);
+      const payload = toasts[0];
+      // The originating query is carried through for error highlighting/debugging.
+      assert.equal(payload.query, query);
+      assert.equal(payload.variant, "destructive");
+      assert.equal(typeof payload.title, "string");
+      // The raw server message is preserved (verbatim or behind "See more").
+      assert.ok(JSON.stringify(payload).includes("Syntax error near WHERE"));
+    } finally {
+      mock.restore();
+    }
+  });
 });
 
 describe("getMetaStats", () => {

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { getMetaStats, getSSEGraphResult, securedFetch, setActiveConnectionIdGlobal } from "./utils.ts";
+import { createAbortError, getConnectionEpoch, getMetaStats, getSSEGraphResult, isAbortError, securedFetch, setActiveConnectionIdGlobal } from "./utils.ts";
 
 const noopToast = () => {};
 const noopIndicator = () => {};
@@ -221,5 +221,125 @@ describe("getMetaStats", () => {
   it("returns undefined for an empty name without opening a connection", async () => {
     const result = await getMetaStats("", () => {}, () => {});
     assert.equal(result, undefined);
+  });
+});
+
+describe("connection epoch", () => {
+  afterEach(() => setActiveConnectionIdGlobal(null));
+
+  it("increments only when the active connection id actually changes", () => {
+    setActiveConnectionIdGlobal("a");
+    const e1 = getConnectionEpoch();
+    setActiveConnectionIdGlobal("a"); // same id → no bump
+    assert.equal(getConnectionEpoch(), e1);
+    setActiveConnectionIdGlobal("b"); // change → bump
+    assert.equal(getConnectionEpoch(), e1 + 1);
+    setActiveConnectionIdGlobal(null); // change → bump
+    assert.equal(getConnectionEpoch(), e1 + 2);
+  });
+
+  it("detects A -> B -> A as a change (epoch differs from the first A)", () => {
+    setActiveConnectionIdGlobal("a");
+    const eA = getConnectionEpoch();
+    setActiveConnectionIdGlobal("b");
+    setActiveConnectionIdGlobal("a"); // same id as start, but connection was switched
+    assert.notEqual(getConnectionEpoch(), eA);
+  });
+});
+
+describe("abort helpers", () => {
+  it("createAbortError produces an AbortError-named error recognized by isAbortError", () => {
+    const err = createAbortError();
+    assert.equal(err.name, "AbortError");
+    assert.equal(isAbortError(err), true);
+  });
+
+  it("isAbortError recognizes native AbortError and rejects non-aborts", () => {
+    const native = new Error("stop");
+    native.name = "AbortError";
+    assert.equal(isAbortError(native), true);
+    assert.equal(isAbortError(new Error("boom")), false);
+    assert.equal(isAbortError(null), false);
+    assert.equal(isAbortError("AbortError"), false);
+  });
+});
+
+describe("getSSEGraphResult connection routing & cancellation", () => {
+  afterEach(() => setActiveConnectionIdGlobal(null));
+
+  it("uses an explicit connectionId in the stream URL instead of the global", async () => {
+    const mock = installMockEventSource();
+    try {
+      setActiveConnectionIdGlobal("global-conn");
+      const promise = getSSEGraphResult(
+        "api/graph/demo?query=RETURN 1",
+        () => {},
+        () => {},
+        { connectionId: "explicit-conn" },
+      );
+      const instance = mock.getInstance();
+      assert.ok(instance.url.includes("connectionId=explicit-conn"));
+      assert.ok(!instance.url.includes("global-conn"));
+      instance.listeners.result({ data: JSON.stringify({ ok: true }) } as MessageEvent);
+      assert.deepEqual(await promise, { ok: true });
+    } finally {
+      mock.restore();
+    }
+  });
+
+  it("rejects with AbortError and never opens a stream when the signal is pre-aborted", async () => {
+    const mock = installMockEventSource();
+    const controller = new AbortController();
+    controller.abort();
+    try {
+      await assert.rejects(
+        getSSEGraphResult("api/graph/demo?query=1", () => {}, () => {}, { signal: controller.signal }),
+        (e) => isAbortError(e),
+      );
+      // EventSource was never constructed.
+      assert.throws(() => mock.getInstance());
+    } finally {
+      mock.restore();
+    }
+  });
+
+  it("aborting in flight closes the stream, rejects AbortError, and suppresses toasts/indicator", async () => {
+    const mock = installMockEventSource();
+    const controller = new AbortController();
+    const toasts: MockToast[] = [];
+    const indicators: string[] = [];
+    try {
+      const promise = getSSEGraphResult(
+        "api/graph/demo?query=1",
+        (t) => { toasts.push(t as MockToast); },
+        (i) => { indicators.push(i); },
+        { signal: controller.signal },
+      );
+      const instance = mock.getInstance();
+
+      controller.abort();
+      assert.equal(instance.closed, true);
+
+      // A late server error event that arrives after abort must not toast.
+      instance.listeners.error?.({ data: JSON.stringify({ message: "boom", status: 500 }) } as MessageEvent);
+
+      await assert.rejects(promise, (e) => isAbortError(e));
+      assert.equal(toasts.length, 0);
+      assert.equal(indicators.length, 0);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  it("getMetaStats resolves to undefined (no throw) when its request is aborted", async () => {
+    const mock = installMockEventSource();
+    const controller = new AbortController();
+    controller.abort();
+    try {
+      const result = await getMetaStats("demo", () => {}, () => {}, false, { signal: controller.signal });
+      assert.equal(result, undefined);
+    } finally {
+      mock.restore();
+    }
   });
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -259,36 +259,71 @@ export async function getSSEGraphResult(
   url: string,
   toast: ToastFn,
   setIndicator: (indicator: "online" | "offline") => void,
-  errorContext?: { query?: string }
+  options?: { query?: string; signal?: AbortSignal; connectionId?: string | null }
 ): Promise<unknown> {
+  const signal = options?.signal;
+  // Already superseded before we even open the stream.
+  if (signal?.aborted) return Promise.reject(createAbortError());
+
   return new Promise((resolve, reject) => {
-    let handled = false;
+    let settled = false;
+
+    // Route through an explicit connection id when provided, so every request in
+    // a batch targets the same connection even if the global changes mid-flight.
+    const connId = options?.connectionId !== undefined ? options.connectionId : _activeConnectionId;
 
     // EventSource doesn't support headers — inject connectionId as a query param.
     let effectiveUrl = normalizeApiUrl(url);
-    if (_activeConnectionId) {
+    if (connId) {
       const sep = effectiveUrl.includes("?") ? "&" : "?";
-      effectiveUrl += `${sep}connectionId=${encodeURIComponent(_activeConnectionId)}`;
+      effectiveUrl += `${sep}connectionId=${encodeURIComponent(connId)}`;
     }
 
     const evtSource = new EventSource(effectiveUrl);
+
+    const onAbort = () => {
+      // Superseded (e.g. graph/connection switch): close silently — no toast, no
+      // indicator change — and reject so callers can drop the result.
+      finishReject(createAbortError());
+    };
+
+    function cleanup() {
+      if (signal) signal.removeEventListener("abort", onAbort);
+      evtSource.close();
+    }
+    function finishResolve(value: unknown) {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    }
+    function finishReject(error: Error) {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    }
+
+    if (signal) signal.addEventListener("abort", onAbort);
+
     evtSource.addEventListener("result", (event: MessageEvent) => {
+      if (settled) return;
       const payloadText = typeof event.data === "string" ? event.data : "";
 
       try {
         const result = JSON.parse(payloadText);
-        evtSource.close();
         setIndicator("online");
-        resolve(result);
+        finishResolve(result);
       } catch (error) {
         console.error("Failed to parse SSE result event:", error);
-        evtSource.close();
         setIndicator("offline");
-        reject(new Error("Invalid server response"));
+        finishReject(new Error("Invalid server response"));
       }
     });
 
     evtSource.addEventListener("error", (event: MessageEvent) => {
+      if (settled) return;
+
       const eventData = typeof (event as { data?: unknown }).data === "string"
         ? (event as { data?: string }).data
         : "";
@@ -298,7 +333,12 @@ export async function getSSEGraphResult(
       // offline/network error instead of a generic "Request failed".
       if (!eventData) return;
 
-      handled = true;
+      // Superseded while the error was arriving — drop it without a toast.
+      if (signal?.aborted) {
+        finishReject(createAbortError());
+        return;
+      }
+
       let rawMessage: unknown = "";
       let rawStatus: unknown = 0;
       let code: string | undefined;
@@ -325,34 +365,37 @@ export async function getSSEGraphResult(
       const parsedStatus = Number(rawStatus);
       const status = Number.isFinite(parsedStatus) ? parsedStatus : 0;
 
-      evtSource.close();
-
       if (status === 401 && code === "SESSION_INVALID") {
         triggerSessionInvalidationSignOut();
         setIndicator("offline");
-        reject(new Error(message));
+        finishReject(new Error(message));
         return;
       }
 
-      const friendly = toUserFriendlyMessage(message, status, errorContext);
-      toast({ title: friendly.title, description: friendly.description, variant: "destructive", rawMessage: friendly.rawMessage, hint: friendly.hint, hintLink: friendly.hintLink, query: errorContext?.query });
+      const friendly = toUserFriendlyMessage(message, status, options?.query ? { query: options.query } : undefined);
+      toast({ title: friendly.title, description: friendly.description, variant: "destructive", rawMessage: friendly.rawMessage, hint: friendly.hint, hintLink: friendly.hintLink, query: options?.query });
 
       if (status === 401 || status >= 500) setIndicator("offline");
 
-      reject(new Error(message));
+      finishReject(new Error(message));
     });
 
     evtSource.onerror = () => {
-      if (handled) return;
+      if (settled) return;
 
-      evtSource.close();
+      // Superseded — drop it without a toast / offline flip.
+      if (signal?.aborted) {
+        finishReject(createAbortError());
+        return;
+      }
+
       toast({
         title: "Error",
         description: "Network or server error",
         variant: "destructive",
       });
       setIndicator("offline");
-      reject(new Error("Network or server error"));
+      finishReject(new Error("Network or server error"));
     };
   });
 }
@@ -571,13 +614,37 @@ function triggerSessionInvalidationSignOut(): void {
 // Not initialised from localStorage to avoid overriding restricted-user sessions.
 // providers.tsx keeps it in sync after every render.
 let _activeConnectionId: string | null = null;
+// Monotonic counter bumped whenever the active connection id actually changes.
+// Async callers can capture it before a request and re-check it before applying
+// results, so a switch (including A→B→A, where the id repeats) is still detected.
+let _connectionEpoch = 0;
 
 export function setActiveConnectionIdGlobal(id: string | null) {
+  if (id !== _activeConnectionId) _connectionEpoch += 1;
   _activeConnectionId = id;
 }
 
 export function getActiveConnectionIdGlobal(): string | null {
   return _activeConnectionId;
+}
+
+export function getConnectionEpoch(): number {
+  return _connectionEpoch;
+}
+
+/** Error thrown when an in-flight request is superseded (e.g. a graph/connection
+ *  switch aborts its AbortSignal). Callers should treat it as a no-op, not a
+ *  failure — it must never surface a toast. */
+export function createAbortError(): Error {
+  const err = new Error("The operation was aborted.");
+  err.name = "AbortError";
+  return err;
+}
+
+/** True when the given error is an abort (from createAbortError or a native
+ *  fetch/AbortController abort). */
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
 }
 
 function normalizeApiUrl(input: string): string {
@@ -646,14 +713,25 @@ export const between = (hash: number, from: number, to: number) => {
 export const getDefaultQuery = (q?: string) =>
   q || "MATCH (n) OPTIONAL MATCH (n)-[e]-(m) RETURN * LIMIT 100";
 
-export const getMetaStats = async (name: string, toast: ToastFn, setIndicator: (indicator: "online" | "offline") => void, isReadOnly?: boolean) => {
+export const getMetaStats = async (
+  name: string,
+  toast: ToastFn,
+  setIndicator: (indicator: "online" | "offline") => void,
+  isReadOnly?: boolean,
+  options?: { signal?: AbortSignal; connectionId?: string | null },
+) => {
   if (!name) return undefined;
 
   const q = "CALL db.meta.stats() YIELD labels, relTypes RETURN labels, relTypes as relationships";
   const readOnlyParam = isReadOnly ? '&readOnly=true' : '';
 
   try {
-    const result = await getSSEGraphResult(`/api/graph/${prepareArg(name)}?query=${encodeURIComponent(q)}${readOnlyParam}`, toast, setIndicator) as { data: { labels: { [key: string]: number }, relationships: { [key: string]: number } }[] };
+    const result = await getSSEGraphResult(
+      `/api/graph/${prepareArg(name)}?query=${encodeURIComponent(q)}${readOnlyParam}`,
+      toast,
+      setIndicator,
+      { signal: options?.signal, connectionId: options?.connectionId },
+    ) as { data: { labels: { [key: string]: number }, relationships: { [key: string]: number } }[] };
 
     if (!result) return undefined;
 
@@ -671,6 +749,8 @@ export const getMetaStats = async (name: string, toast: ToastFn, setIndicator: (
 
     return [l, r];
   } catch (error) {
+    // A superseded request (graph/connection switch) is not a real failure.
+    if (isAbortError(error)) return undefined;
     console.error("Failed to fetch meta stats:", error);
     return undefined;
   }
@@ -747,7 +827,8 @@ export const getMemoryUsage = async (
   // Pass activeConnectionId explicitly from React context/closure.
   // This avoids relying on the module-level global _activeConnectionId
   // which can be reset to null by Next.js HMR between renders.
-  connectionId?: string | null
+  connectionId?: string | null,
+  signal?: AbortSignal,
 ): Promise<Map<string, MemoryValue>> => {
   // Use plain fetch (not securedFetch) so NOPERM / version-too-low 400 errors
   // from restricted users don't produce error toasts — memory usage is an
@@ -758,11 +839,12 @@ export const getMemoryUsage = async (
     if (effectiveConnId) {
       headers.set("X-Connection-Id", effectiveConnId);
     }
-    const result = await fetch(`/api/graph/${prepareArg(name)}/memory`, { headers });
+    const result = await fetch(`/api/graph/${prepareArg(name)}/memory`, { headers, signal });
     if (!result.ok) return new Map();
     const json = await result.json();
     return processEntries(json.result);
   } catch {
+    // Includes AbortError when superseded — treat as "no memory info".
     return new Map();
   }
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -642,9 +642,15 @@ export function createAbortError(): Error {
 }
 
 /** True when the given error is an abort (from createAbortError or a native
- *  fetch/AbortController abort). */
+ *  fetch/AbortController abort). Native aborts reject with a DOMException named
+ *  "AbortError", which is NOT an `instanceof Error` in browsers — so match on
+ *  the `name` of any object rather than the Error prototype. */
 export function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
 }
 
 function normalizeApiUrl(input: string): string {


### PR DESCRIPTION
## Summary

Fixes a **connection-switch race** in the periodic graph-info poll (and `fetchCount`): after the user switched DB connection or graph, an in-flight poll could **apply stale metadata/counts**, **show a stale error toast / flip the indicator offline** for a connection the user already left, or (in a transition window) **query the previous graph against the new connection** — which FalkorDB auto-creates.

This was flagged during rubber-duck review of PR #1934 as a *pre-existing* race and split out here as requested.

## Where it happens (concrete example)

Graph-info is refreshed by an interval poll in `app/graph/page.tsx` that calls `fetchMetaStats` → `getMetaStats`, `fetchInfo("(property key)")` → `getSSEGraphResult`, `getMemoryUsage`, then `setGraphInfo(...)` and `fetchCount(...)`. Every request read the **module-global** `_activeConnectionId` at send time, and results were applied unconditionally.

**Scenario — stale counts + wrong-connection query (A → B):**
1. User is on connection **A**, graph `social`. A poll tick fires: `db.meta.stats()` / `db.propertyKeys()` / `/count` requests go out to **A**.
2. Before they resolve, the user switches to connection **B**.
3. The in-flight requests resolve. Previously:
   - `setGraphInfo`/`fetchCount` wrote **A's** labels/counts onto the graph now shown for **B**.
   - If a request instead *failed*, `getSSEGraphResult` toasted "…could not…" and flipped the status indicator **offline for B**, even though B is fine.
   - `getMetaStats` (global id) and `getMemoryUsage` (captured id) could target **different** connections within the same poll.

**Scenario — A → B → A (ABA):** `fetchCount` only compared the graph *name* (`activeGraphNameRef`). Because the graph name repeats across connections, a stale `A` count could pass the check and overwrite the correct one.

## The fix

The poll is now fully **connection-scoped** using three composable mechanisms:

1. **Explicit connection routing.** `getSSEGraphResult` / `getMetaStats` / `getMemoryUsage` / `fetchCount` accept an explicit `connectionId`; the poll captures the connection id **once** at start and threads it to every request, so a whole poll targets one connection even if the global changes mid-flight.
2. **AbortSignal cancellation.** The poll uses one `AbortController` per run and `controller.abort()` on cleanup. `getSSEGraphResult` closes the `EventSource` on abort and rejects with an `AbortError` **without toasting or flipping the indicator**. `getMetaStats`/`getMemoryUsage` treat abort as a no-op.
3. **Connection epoch.** `getConnectionEpoch()` is bumped in `setActiveConnectionIdGlobal` only when the id actually changes (so it catches **A→B→A** where the id repeats). Async callers capture it at the operation's start and re-check before opening a request and before applying results / side-effects.

`fetchCount` additionally wraps `toast`/`setIndicator` in epoch guards, so even callers that don't pass a signal can't surface a stale error toast, and short-circuits before querying when the epoch is already stale (so it never queries a stale graph against a switched connection).

`activeConnectionId` is intentionally **not** a poll dependency: a connection switch always resets `graphName` (in `providers.tsx`), which re-runs the effect and aborts the old poll. Depending on it directly would fire a query for the *previous* graph against the *new* connection before `graphName` is cleared.

## Tests

Added to `lib/utils.test.ts` (node:test, mock `EventSource`):
- connection epoch: increments only on real change; detects A→B→A.
- abort helpers: `createAbortError` / `isAbortError`.
- `getSSEGraphResult`: uses an explicit `connectionId` in the stream URL instead of the global; rejects (no `EventSource` opened) when pre-aborted; aborting in flight closes the stream, rejects `AbortError`, and **suppresses toast + indicator**.
- `getMetaStats`: resolves to `undefined` (no throw/toast) when aborted.

Full suite: **204 unit tests pass**, `tsc` clean, `npm run lint` clean (0 errors), `next build` passes.

## Review

Reviewed with the rubber-duck agent across three rounds; two blocking issues found and fixed (the `activeConnectionId`-dep wrong-graph query, and unsignaled `fetchCount` stale toasts), plus the epoch-capture-timing refinement. Final verdict: **no blocking issues; the poll path is correct.**

## Scope / follow-up (not in this PR)

This PR scopes to the graph-info poll + `fetchCount`. It deliberately does **not** rework unsignaled, user-triggered one-shot callers (e.g. `MetadataView.handleProfile`, which also captures a stale `graphName` for its own `securedFetch` profile query). Fully eliminating *all* connection-switch races requires threading connection-scoped context / lifecycle signals through those paths (or removing the mutable global connection id) — a broader change best done separately. This PR does not claim to eliminate every connection-switch race.

> Do not merge without approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced graph polling to safely cancel in-flight requests and ignore stale results during rapid connection changes.
  - Added connection-aware routing for SSE/meta/counter updates, including consistent handling of aborts to prevent incorrect toasts or indicator/offline state changes.
  - Improved memory-info and count fetching to respect per-request cancellation and return “no data” on abort.
- **Tests**
  - Expanded coverage for connection-epoch supersession, abort detection/no-op behavior, SSE error payload handling, and cancellation semantics (including mid-flight abort).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->