### PR TITLE
chore(deps): bump AWS SDK packages to 3.1086.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "falkordb-browser",
       "version": "2.2.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1085.0",
-        "@aws-sdk/lib-storage": "^3.1085.0",
-        "@aws-sdk/s3-request-presigner": "^3.1085.0",
+        "@aws-sdk/client-s3": "^3.1086.0",
+        "@aws-sdk/lib-storage": "^3.1086.0",
+        "@aws-sdk/s3-request-presigner": "^3.1086.0",
         "@falkordb/canvas": "^0.2.5",
         "@falkordb/text-to-cypher": "^0.2.3",
         "@hookform/resolvers": "^5.4.0",
@@ -238,14 +238,14 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1085.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1085.0.tgz",
-      "integrity": "sha512-O0xe8sR50AYkwxlvRRsV0qytEO2dtXQTQ1CF3YBBdE5xtVkbu27H0vGa1mjQi1/+fbYM80AWEIPai5jZmXyubw==",
+      "version": "3.1086.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1086.0.tgz",
+      "integrity": "sha512-6+7mVMPKetZmmF2L1yRJ+rN9b1OwVgc5sju2mj8ixdxuGjtVZ0ekFlcWGBFMQT9gpFk55PPLBng/XRYO3qah5A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.16",
         "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/credential-provider-node": "^3.972.66",
+        "@aws-sdk/credential-provider-node": "^3.972.67",
         "@aws-sdk/middleware-sdk-s3": "^3.972.62",
         "@aws-sdk/signature-v4-multi-region": "^3.996.39",
         "@aws-sdk/types": "^3.974.0",
@@ -354,9 +354,9 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
-      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.67.tgz",
+      "integrity": "sha512-oYlzWst56rlhhjbYnexwv5hVLYe1cW4liLObhDfxDLI4RAQzleMVHQgQgx7XsC4HKj4e3kjT8v9DId+Pi/dndw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.57",
@@ -427,9 +427,9 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.1085.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1085.0.tgz",
-      "integrity": "sha512-S+yCGIMxQ5Zs2A5ZDdYfXwOxu5kKjBaCQVOxp6+mnwCQYXUNkBD/aKCnW1eniMTavzz3YidhD5eTFpDlcUv2gQ==",
+      "version": "3.1086.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1086.0.tgz",
+      "integrity": "sha512-mjuWMFIBPiZIKwGZovqb4kBCRD0wg1LpfH7hme6/m9WEDNrBnerJuA/h1yUwEL4dZbUlhT1aDUb6OQUE/E7nYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.29.2",
@@ -443,7 +443,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.1085.0"
+        "@aws-sdk/client-s3": "^3.1086.0"
       }
     },
     "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1085.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1085.0.tgz",
-      "integrity": "sha512-h8fv0zGAHPCjCpmAYdCeFE6trxXxLRxza0NRIajMZdnFgugtcIWcRAdAtc7rHvRTaXsej/I5YWXbq9SgKuCKow==",
+      "version": "3.1086.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1086.0.tgz",
+      "integrity": "sha512-FRFuW9fjHilkGQLiumNiIF0MMGZEeH7ppfmBYchL5rinZyD6OECakTwHG4XP1GEG5d+nPqC0YCNV24rhNocY5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.1",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1085.0",
-    "@aws-sdk/lib-storage": "^3.1085.0",
-    "@aws-sdk/s3-request-presigner": "^3.1085.0",
+    "@aws-sdk/client-s3": "^3.1086.0",
+    "@aws-sdk/lib-storage": "^3.1086.0",
+    "@aws-sdk/s3-request-presigner": "^3.1086.0",
     "@falkordb/canvas": "^0.2.5",
     "@falkordb/text-to-cypher": "^0.2.3",
     "@hookform/resolvers": "^5.4.0",


### PR DESCRIPTION
Combines the three open Dependabot AWS SDK PRs into one, since these packages share interdependent peer ranges and should move together.

Supersedes:
- #1943 — `@aws-sdk/s3-request-presigner` 3.1085.0 → 3.1086.0
- #1944 — `@aws-sdk/lib-storage` 3.1085.0 → 3.1086.0
- #1945 — `@aws-sdk/client-s3` 3.1085.0 → 3.1086.0

### Changes
- Bumped all three `@aws-sdk/*` deps to `^3.1086.0` in `package.json`
- Regenerated `package-lock.json` via `npm install`

### Validation (local)
- `npm run test:coverage` — 338 pass, 100% line/branch/func coverage
- `npx next build` — succeeds

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying cloud storage components to newer versions.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->