### PR TITLE
fix(providers): pin graph ops by connection + generation to stop stale applies

### DIFF
--- a/app/api/graph/model.ts
+++ b/app/api/graph/model.ts
@@ -76,6 +76,10 @@ export class GraphInfo {
 
   private setIndicator: (indicator: "online" | "offline") => void;
 
+  // Connection this GraphInfo's fallback metadata queries must target, so a
+  // mid-build connection switch can't route getMetaStatsCount to another DB.
+  private connectionId: string | null | undefined;
+
   constructor(
     propertyKeys: string[] | undefined,
     labels: Map<string, InfoLabel>,
@@ -83,7 +87,8 @@ export class GraphInfo {
     memoryUsage: Map<string, MemoryValue>,
     toast: ToastFn,
     setIndicator: (indicator: "online" | "offline") => void,
-    colors?: string[]
+    colors?: string[],
+    connectionId?: string | null,
   ) {
     this.propertyKeys = propertyKeys;
     this.labels = labels;
@@ -92,6 +97,7 @@ export class GraphInfo {
     this.toast = toast;
     this.setIndicator = setIndicator;
     this.colors = [...colors || []];
+    this.connectionId = connectionId;
   }
 
 
@@ -131,7 +137,8 @@ export class GraphInfo {
       new Map(this.memoryUsage),
       this.toast,
       this.setIndicator,
-      this.colors
+      this.colors,
+      this.connectionId
     );
   }
 
@@ -140,6 +147,7 @@ export class GraphInfo {
     setIndicator: (indicator: "online" | "offline") => void,
     propertyKeys?: string[],
     memoryUsage?: Map<string, MemoryValue>,
+    connectionId?: string | null,
   ): GraphInfo {
     return new GraphInfo(
       propertyKeys || [],
@@ -147,7 +155,9 @@ export class GraphInfo {
       new Map(),
       new Map(memoryUsage),
       toast,
-      setIndicator
+      setIndicator,
+      undefined,
+      connectionId
     );
   }
 
@@ -157,9 +167,10 @@ export class GraphInfo {
     relationships: [string, number][],
     memoryUsage: Map<string, MemoryValue>,
     toast: ToastFn,
-    setIndicator: (indicator: "online" | "offline") => void
+    setIndicator: (indicator: "online" | "offline") => void,
+    connectionId?: string | null,
   ): Promise<GraphInfo> {
-    const graphInfo = GraphInfo.empty(toast, setIndicator, propertyKeys, memoryUsage);
+    const graphInfo = GraphInfo.empty(toast, setIndicator, propertyKeys, memoryUsage, connectionId);
     await graphInfo.createLabel(labels, "");
     await relationships.reduce(
       (prev, relationship) => prev.then(() => graphInfo.createRelationship(relationship, "")),
@@ -170,7 +181,7 @@ export class GraphInfo {
   }
 
   private async getMetaStatsCount(graphName: string, type: "relationships" | "labels", name: string): Promise<number> {
-    const result = await getMetaStats(graphName, this.toast, this.setIndicator);
+    const result = await getMetaStats(graphName, this.toast, this.setIndicator, undefined, { connectionId: this.connectionId });
 
     if (!result) return 0;
 

--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -102,19 +102,35 @@ export default function ConnectionManager() {
       }, toast, setIndicator);
 
       if (result.ok) {
-        setAdditionalConnections((prev: SessionConnection[]) => {
-          const remaining = prev.filter(c => c.id !== connId);
-          // If we removed the active connection, switch to the last remaining one
-          if (activeConnectionId === connId && remaining.length > 0) {
-            const newActive = remaining[remaining.length - 1].id;
-            beginConnectionSwitch();
-            setActiveConnectionId(newActive);
-            setActiveConnectionIdGlobal(newActive);
-            localStorage.setItem("lastActiveConnectionId", newActive);
-            updateSession({ activeConnectionId: newActive });
+        const remaining = additionalConnections.filter(c => c.id !== connId);
+        setAdditionalConnections(remaining);
+
+        // If we removed the active connection, switch to the last remaining one.
+        if (activeConnectionId === connId && remaining.length > 0) {
+          const newActive = remaining[remaining.length - 1].id;
+          const ticket = beginConnectionSwitch();
+          setActiveConnectionIdGlobal(newActive);
+          localStorage.setItem("lastActiveConnectionId", newActive);
+          try {
+            await updateSession({ activeConnectionId: newActive });
+          } catch (error) {
+            if (isLatestSwitch(ticket)) setActiveConnectionIdGlobal(activeConnectionId);
+            endConnectionSwitch();
+            console.error("Failed to switch connection after removal:", error);
+            toast({ title: "Failed to switch to remaining connection", variant: "destructive" });
+            setRemoveTarget(null);
+            return;
           }
-          return remaining;
-        });
+
+          if (!isLatestSwitch(ticket)) {
+            endConnectionSwitch();
+            setRemoveTarget(null);
+            return;
+          }
+
+          setActiveConnectionId(newActive);
+        }
+
         toast({ title: "Connection removed" });
       } else {
         toast({ title: "Failed to remove connection", variant: "destructive" });
@@ -126,7 +142,7 @@ export default function ConnectionManager() {
     } finally {
       setRemoving(false);
     }
-  }, [removeTarget, toast, setAdditionalConnections, activeConnectionId, setActiveConnectionId, setIndicator, updateSession, beginConnectionSwitch]);
+  }, [removeTarget, toast, additionalConnections, setAdditionalConnections, activeConnectionId, setActiveConnectionId, setIndicator, updateSession, beginConnectionSwitch, endConnectionSwitch, isLatestSwitch]);
 
   const handleAddConnection = useCallback(async (credentials: LoginFormCredentials) => {
     const result = await securedFetch("/api/connections", {
@@ -147,17 +163,31 @@ export default function ConnectionManager() {
       const newConn = json.connection;
       setAdditionalConnections((prev) => [...prev, newConn]);
       // Auto-switch to the newly added connection
-      beginConnectionSwitch();
-      setActiveConnectionId(newConn.id);
+      const ticket = beginConnectionSwitch();
       setActiveConnectionIdGlobal(newConn.id);
       localStorage.setItem("lastActiveConnectionId", newConn.id);
-      updateSession({ activeConnectionId: newConn.id });
+      try {
+        await updateSession({ activeConnectionId: newConn.id });
+      } catch (error) {
+        if (isLatestSwitch(ticket)) setActiveConnectionIdGlobal(activeConnectionId);
+        endConnectionSwitch();
+        console.error("Failed to switch to new connection:", error);
+        toast({ title: "Connection added but switch failed", variant: "destructive" });
+        return;
+      }
+
+      if (!isLatestSwitch(ticket)) {
+        endConnectionSwitch();
+        return;
+      }
+
+      setActiveConnectionId(newConn.id);
       toast({ title: `Connection added for ${credentials.username}` });
       setDialogOpen(false);
     } else {
       throw new Error("Failed to add connection");
     }
-  }, [toast, setAdditionalConnections, setIndicator, setActiveConnectionId, updateSession, beginConnectionSwitch]);
+  }, [toast, setAdditionalConnections, setIndicator, setActiveConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch, isLatestSwitch, activeConnectionId]);
 
   // Use the explicitly active connection, or fall back to the first one while
   // activeConnectionId is still being resolved (e.g. on initial page load).

--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -26,6 +26,7 @@ export default function ConnectionManager() {
     updateSession,
     beginConnectionSwitch,
     endConnectionSwitch,
+    isLatestSwitch,
   } = useContext(ConnectionContext);
 
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -36,8 +37,9 @@ export default function ConnectionManager() {
     // Clicking the already-active connection is a no-op (avoids a stuck gate).
     if (connId === activeConnectionId) return;
     // Block/supersede graph ops while the switch is mid-flight (its global id and
-    // React state briefly disagree).
-    beginConnectionSwitch();
+    // React state briefly disagree). The ticket lets us ignore a stale completion
+    // if the user starts a newer switch before this one resolves.
+    const ticket = beginConnectionSwitch();
     // Set the global ID immediately so periodic timers (memory, count, etc.)
     // that fire DURING the updateSession await use the correct connection and
     // don't fall back to Token DB which might pick the wrong entry.
@@ -50,16 +52,22 @@ export default function ConnectionManager() {
       await updateSession({ activeConnectionId: connId });
     } catch (error) {
       // Roll back so ids stay consistent and graph ops are unblocked again.
-      setActiveConnectionIdGlobal(activeConnectionId);
+      if (isLatestSwitch(ticket)) setActiveConnectionIdGlobal(activeConnectionId);
       endConnectionSwitch();
       console.error("Failed to switch connection:", error);
       return;
     }
+    if (!isLatestSwitch(ticket)) {
+      // A newer switch superseded this one — don't publish this (older) target as
+      // active; just release this switch's gate slot.
+      endConnectionSwitch();
+      return;
+    }
     // Update React state AFTER the JWT is updated so the prevActiveConnectionId
     // effect fires with the correct role already in sessionData; that reset
-    // effect also clears the switch gate.
+    // effect also clears this switch's gate slot.
     setActiveConnectionId(connId);
-  }, [activeConnectionId, setActiveConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch]);
+  }, [activeConnectionId, setActiveConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch, isLatestSwitch]);
 
   // Determine whether the user only has one connection. The session always
   // has at least one (the primary), so we treat an empty additionalConnections

--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -24,6 +24,8 @@ export default function ConnectionManager() {
     activeConnectionId,
     setActiveConnectionId,
     updateSession,
+    beginConnectionSwitch,
+    endConnectionSwitch,
   } = useContext(ConnectionContext);
 
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -31,6 +33,11 @@ export default function ConnectionManager() {
   const [removing, setRemoving] = useState(false);
 
   const handleSelect = useCallback(async (connId: string) => {
+    // Clicking the already-active connection is a no-op (avoids a stuck gate).
+    if (connId === activeConnectionId) return;
+    // Block/supersede graph ops while the switch is mid-flight (its global id and
+    // React state briefly disagree).
+    beginConnectionSwitch();
     // Set the global ID immediately so periodic timers (memory, count, etc.)
     // that fire DURING the updateSession await use the correct connection and
     // don't fall back to Token DB which might pick the wrong entry.
@@ -39,11 +46,20 @@ export default function ConnectionManager() {
     // Update the JWT so session.user.role is correct before React effects
     // (graph-list reload, query execution) fire. The JWT callback looks up
     // the connection details from Token DB.
-    await updateSession({ activeConnectionId: connId });
+    try {
+      await updateSession({ activeConnectionId: connId });
+    } catch (error) {
+      // Roll back so ids stay consistent and graph ops are unblocked again.
+      setActiveConnectionIdGlobal(activeConnectionId);
+      endConnectionSwitch();
+      console.error("Failed to switch connection:", error);
+      return;
+    }
     // Update React state AFTER the JWT is updated so the prevActiveConnectionId
-    // effect fires with the correct role already in sessionData.
+    // effect fires with the correct role already in sessionData; that reset
+    // effect also clears the switch gate.
     setActiveConnectionId(connId);
-  }, [setActiveConnectionId, updateSession]);
+  }, [activeConnectionId, setActiveConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch]);
 
   // Determine whether the user only has one connection. The session always
   // has at least one (the primary), so we treat an empty additionalConnections
@@ -83,6 +99,7 @@ export default function ConnectionManager() {
           // If we removed the active connection, switch to the last remaining one
           if (activeConnectionId === connId && remaining.length > 0) {
             const newActive = remaining[remaining.length - 1].id;
+            beginConnectionSwitch();
             setActiveConnectionId(newActive);
             setActiveConnectionIdGlobal(newActive);
             localStorage.setItem("lastActiveConnectionId", newActive);
@@ -101,7 +118,7 @@ export default function ConnectionManager() {
     } finally {
       setRemoving(false);
     }
-  }, [removeTarget, toast, setAdditionalConnections, activeConnectionId, setActiveConnectionId, setIndicator, updateSession]);
+  }, [removeTarget, toast, setAdditionalConnections, activeConnectionId, setActiveConnectionId, setIndicator, updateSession, beginConnectionSwitch]);
 
   const handleAddConnection = useCallback(async (credentials: LoginFormCredentials) => {
     const result = await securedFetch("/api/connections", {
@@ -122,6 +139,7 @@ export default function ConnectionManager() {
       const newConn = json.connection;
       setAdditionalConnections((prev) => [...prev, newConn]);
       // Auto-switch to the newly added connection
+      beginConnectionSwitch();
       setActiveConnectionId(newConn.id);
       setActiveConnectionIdGlobal(newConn.id);
       localStorage.setItem("lastActiveConnectionId", newConn.id);
@@ -131,7 +149,7 @@ export default function ConnectionManager() {
     } else {
       throw new Error("Failed to add connection");
     }
-  }, [toast, setAdditionalConnections, setIndicator, setActiveConnectionId, updateSession]);
+  }, [toast, setAdditionalConnections, setIndicator, setActiveConnectionId, updateSession, beginConnectionSwitch]);
 
   // Use the explicitly active connection, or fall back to the first one while
   // activeConnectionId is still being resolved (e.g. on initial page load).

--- a/app/components/CreateGraph.tsx
+++ b/app/components/CreateGraph.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState, useContext, useEffect } from "react";
 import { InfoIcon, Plus, File as FileIcon, X } from "lucide-react";
-import { prepareArg, securedFetch, uploadFileWithProgress } from "@/lib/utils";
+import { getActiveConnectionIdGlobal, getConnectionEpoch, prepareArg, securedFetch, uploadFileWithProgress } from "@/lib/utils";
 import { DUMP_RESTORE_ENABLED } from "@/lib/graphUpload";
 import { useToast } from "@/components/ui/use-toast";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -63,6 +63,8 @@ export default function CreateGraph({
 
     const handleCreateGraph = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
         try {
             setIsLoading(true);
             const name = graphName.trim();
@@ -91,7 +93,7 @@ export default function CreateGraph({
             if (!hasDump) {
                 const result = await securedFetch(`api/graph/${prepareArg(name)}${isReadOnly ? '?readOnly=true' : ''}`, {
                     method: "POST",
-                }, toast, setIndicator);
+                }, toast, setIndicator, cid);
 
                 if (!result.ok) return;
             } else {
@@ -128,11 +130,14 @@ export default function CreateGraph({
                         body: JSON.stringify({ mode: "dump", fileId: id })
                     },
                     toast,
-                    setIndicator
+                    setIndicator,
+                    cid
                 );
 
                 if (!processResult.ok) return;
             }
+
+            if (getConnectionEpoch() !== startEpoch) return;
 
             onSetGraphName(name);
             setGraphName("");

--- a/app/components/ForceGraph.tsx
+++ b/app/components/ForceGraph.tsx
@@ -6,7 +6,7 @@
 import { Dispatch, SetStateAction, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import type { Data, GraphLink, GraphNode, ViewportState, LayoutMode, HierarchyDirection, RadialDirection } from "@falkordb/canvas";
-import { securedFetch, getTheme, GraphRef, GraphData, Node, Relationship, Link, convertToCanvasData } from "@/lib/utils";
+import { getActiveConnectionIdGlobal, getConnectionEpoch, securedFetch, getTheme, GraphRef, GraphData, Node, Relationship, Link, convertToCanvasData } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import { Graph } from "../api/graph/model";
 import { BrowserSettingsContext, IndicatorContext, ConnectionContext, ForceGraphContext } from "./provider";
@@ -103,18 +103,23 @@ export default function ForceGraph({
     const onFetchNode = useCallback(async (node: Node, clickedNode: GraphNode) => {
         const canvas = canvasRef.current;
         if (!canvas || !canvasLoaded) return;
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
 
         const result = await securedFetch(`/api/graph/${graph.Id}/${node.id}${isReadOnly ? '?readOnly=true' : ''}`, {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json'
             }
-        }, toast, setIndicator);
+        }, toast, setIndicator, cid);
 
+        if (getConnectionEpoch() !== startEpoch) return;
         if (result.ok) {
             const json = await result.json();
+            if (getConnectionEpoch() !== startEpoch) return;
 
             const elements = await graph.extend(json.result, true, true);
+            if (getConnectionEpoch() !== startEpoch) return;
 
             if (elements.length === 0) {
                 toast({

--- a/app/components/graph/DeleteGraph.tsx
+++ b/app/components/graph/DeleteGraph.tsx
@@ -1,5 +1,5 @@
 import { useToast } from "@/components/ui/use-toast";
-import { prepareArg, securedFetch, Row } from "@/lib/utils";
+import { getActiveConnectionIdGlobal, getConnectionEpoch, prepareArg, securedFetch, Row } from "@/lib/utils";
 import React, { useContext, useEffect, useState } from "react";
 import { Graph } from "@/app/api/graph/model";
 import DialogComponent from "../DialogComponent";
@@ -48,6 +48,8 @@ export default function DeleteGraph({
   }, [open]);
 
   const handleDelete = async (deleteGraphNames: string[]) => {
+    const startEpoch = getConnectionEpoch();
+    const cid = getActiveConnectionIdGlobal();
     setIsLoading(true);
     let newGraphNames;
     try {
@@ -55,13 +57,15 @@ export default function DeleteGraph({
         .map(async (name) => {
           const result = await securedFetch(`api/graph/${prepareArg(name)}`, {
             method: "DELETE"
-          }, toast, setIndicator);
+          }, toast, setIndicator, cid);
 
           if (result.ok) return "";
 
           return name;
 
         })).then(result => [result.filter(n => n !== ""), deleteGraphNames.filter(n => !result.includes(n))]);
+
+      if (getConnectionEpoch() !== startEpoch) return;
 
       newGraphNames = graphNames.filter(n => !successDeletedGraphs.includes(n));
 

--- a/app/components/graph/DuplicateGraph.tsx
+++ b/app/components/graph/DuplicateGraph.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useContext, useEffect, useState } from "react";
-import { prepareArg, securedFetch } from "@/lib/utils";
+import { getActiveConnectionIdGlobal, getConnectionEpoch, prepareArg, securedFetch } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import DialogComponent from "../DialogComponent";
 import Button from "../ui/Button";
@@ -28,6 +28,8 @@ export default function DuplicateGraph({ open, onOpenChange, selectedValue, onDu
 
     const handleDuplicate = async (e: FormEvent) => {
         e.preventDefault();
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
 
         if (duplicateName === "") {
             toast({
@@ -43,8 +45,9 @@ export default function DuplicateGraph({ open, onOpenChange, selectedValue, onDu
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ sourceName: selectedValue })
-            }, toast, setIndicator);
+            }, toast, setIndicator, cid);
 
+            if (getConnectionEpoch() !== startEpoch) return;
             if (!result.ok) return;
 
             onDuplicate(duplicateName);

--- a/app/components/graph/UploadGraph.tsx
+++ b/app/components/graph/UploadGraph.tsx
@@ -9,7 +9,7 @@ import Button from "../ui/Button";
 import CloseDialog from "../CloseDialog";
 import { BrowserSettingsContext, ConnectionContext, CypherLanguageContext, ForceGraphContext, GraphContext, HistoryQueryContext, IndicatorContext, TableViewContext, UDFContext } from "../provider";
 import DialogComponent from "../DialogComponent";
-import { cn, Data, getMemoryUsage, getMetaStats, MemoryValue, prepareArg, securedFetch, toUserFriendlyMessage, uploadFileWithProgress } from "@/lib/utils";
+import { cn, Data, getConnectionEpoch, getMemoryUsage, getMetaStats, MemoryValue, prepareArg, securedFetch, toUserFriendlyMessage, uploadFileWithProgress } from "@/lib/utils";
 import { Progress } from "@/components/ui/progress";
 import type { FileRejection } from "react-dropzone";
 import EditorComponent, { LanguageConfig } from "../EditorComponent";
@@ -351,6 +351,9 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange, o
             setPhase("uploading");
             setUploadPct(0);
 
+            // Pin the graph mutation to the connection active when the upload began.
+            const cid = activeConnectionId;
+
             const uploadResult = await uploadFileWithProgress("api/upload", cypherFiles[0], toast, setIndicator, setUploadPct);
             if (!uploadResult.ok) return;
 
@@ -369,7 +372,8 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange, o
                 `api/graph/${prepareArg(graphName)}/upload`,
                 { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ fileId: id }) },
                 toast,
-                setIndicator
+                setIndicator,
+                cid
             );
             if (!processResult.ok) return;
 
@@ -468,6 +472,11 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange, o
         if (inFlightRef.current) return;
         inFlightRef.current = true;
 
+        // Pin the whole ingestion to the connection active when it started, so a
+        // mid-flight switch can't run it against another DB or apply stale results.
+        const cid = activeConnectionId;
+        const startEpoch = getConnectionEpoch();
+
         try {
             setIsLoading(true);
             setPhase("processing");
@@ -476,7 +485,8 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange, o
                 `api/graph/${prepareArg(graphName)}/load-csv`,
                 { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ key: csvKey, withHeaders: csvWithHeaders, body: csvQuery }) },
                 toast,
-                setIndicator
+                setIndicator,
+                cid
             );
             if (!result.ok) return;
 
@@ -512,12 +522,13 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange, o
                 let graphInfo: GraphInfo | undefined;
                 try {
                     const readOnlyParam = isReadOnly ? '&readOnly=true' : '';
-                    const metaStats = await getMetaStats(graphName, toast, setIndicator, isReadOnly);
+                    const metaStats = await getMetaStats(graphName, toast, setIndicator, isReadOnly, { connectionId: cid });
                     const propertyInfo = await securedFetch(
                         `api/graph/${prepareArg(graphName)}/info?type=${prepareArg("(property key)")}${readOnlyParam}`,
                         { method: "GET" },
                         toast,
-                        setIndicator
+                        setIndicator,
+                        cid
                     );
                     const propertyJson = propertyInfo.ok
                         ? await propertyInfo.json() as { result?: { data?: Array<{ info?: unknown }> } }
@@ -526,7 +537,7 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange, o
                         .map((entry) => (typeof entry?.info === "string" ? entry.info : undefined))
                         .filter((value): value is string => typeof value === "string");
                     const memoryUsage = showMemoryUsage
-                        ? await getMemoryUsage(graphName, toast, setIndicator, activeConnectionId)
+                        ? await getMemoryUsage(graphName, toast, setIndicator, cid)
                         : new Map<string, MemoryValue>();
 
                     graphInfo = await GraphInfo.create(
@@ -535,7 +546,8 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange, o
                         metaStats?.[1] ?? [],
                         memoryUsage,
                         toast,
-                        setIndicator
+                        setIndicator,
+                        cid
                     );
                 } catch {
                     graphInfo = graph.Id === graphName
@@ -551,6 +563,8 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange, o
                     graphInfo
                 );
 
+                if (getConnectionEpoch() !== startEpoch) return;
+
                 setGraph(nextGraph);
                 setGraphInfo(nextGraph.GraphInfo);
                 setData({ ...nextGraph.Elements });
@@ -558,7 +572,7 @@ export default function UploadGraph({ graphName, disabled, open, onOpenChange, o
                 setGraphData(undefined);
                 setSearch("");
                 setScrollPosition(0);
-                await fetchCount(graphName);
+                await fetchCount(graphName, { connectionId: cid, epoch: startEpoch });
                 if (!tutorialOpen) {
                     setCurrentTab(nextGraph.getElements().length === 0 && nextGraph.Data.length !== 0 ? "Table" : "Graph");
                 }

--- a/app/components/provider.ts
+++ b/app/components/provider.ts
@@ -237,9 +237,12 @@ type ConnectionContextType = {
   setActiveConnectionId: Dispatch<SetStateAction<string | null>>;
   updateSession: (data: { activeConnectionId?: string | null }) => Promise<unknown>;
   // Mark a user connection switch as in-progress (blocks graph ops + supersedes
-  // in-flight ones) and clear it once the switch settles.
-  beginConnectionSwitch: () => void;
+  // in-flight ones) and clear it once the switch settles. `beginConnectionSwitch`
+  // returns a ticket; `isLatestSwitch(ticket)` reports whether it is still the
+  // newest switch, so out-of-order completions don't publish a stale connection.
+  beginConnectionSwitch: () => number;
   endConnectionSwitch: () => void;
+  isLatestSwitch: (ticket: number) => boolean;
 };
 
 type UDFContextType = {
@@ -498,8 +501,9 @@ export const ConnectionContext = createContext<ConnectionContextType>({
   activeConnectionId: null,
   setActiveConnectionId: () => { },
   updateSession: async () => { },
-  beginConnectionSwitch: () => { },
+  beginConnectionSwitch: () => 0,
   endConnectionSwitch: () => { },
+  isLatestSwitch: () => true,
 });
 
 export const UDFContext = createContext<UDFContextType>({

--- a/app/components/provider.ts
+++ b/app/components/provider.ts
@@ -236,6 +236,10 @@ type ConnectionContextType = {
   activeConnectionId: string | null;
   setActiveConnectionId: Dispatch<SetStateAction<string | null>>;
   updateSession: (data: { activeConnectionId?: string | null }) => Promise<unknown>;
+  // Mark a user connection switch as in-progress (blocks graph ops + supersedes
+  // in-flight ones) and clear it once the switch settles.
+  beginConnectionSwitch: () => void;
+  endConnectionSwitch: () => void;
 };
 
 type UDFContextType = {
@@ -494,6 +498,8 @@ export const ConnectionContext = createContext<ConnectionContextType>({
   activeConnectionId: null,
   setActiveConnectionId: () => { },
   updateSession: async () => { },
+  beginConnectionSwitch: () => { },
+  endConnectionSwitch: () => { },
 });
 
 export const UDFContext = createContext<UDFContextType>({

--- a/app/graph/DataPanel.tsx
+++ b/app/graph/DataPanel.tsx
@@ -1,10 +1,6 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
-/* eslint-disable no-param-reassign */
-/* eslint-disable react/require-default-props */
-
 'use client';
 
-import { prepareArg, securedFetch, GraphRef, Node, Link, Label } from "@/lib/utils";
+import { getActiveConnectionIdGlobal, getConnectionEpoch, prepareArg, securedFetch, GraphRef, Node, Link, Label } from "@/lib/utils";
 import { Dispatch, SetStateAction, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { Pencil, TableProperties, X } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
@@ -58,6 +54,8 @@ export default function DataPanel({ object, onClose, setLabels, canvasRef }: Pro
     }, [object, type]);
 
     const handleAddLabel = async (newLabel: string) => {
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
         const node = object as Node;
         if (newLabel === "") {
             toast({
@@ -80,10 +78,12 @@ export default function DataPanel({ object, onClose, setLabels, canvasRef }: Pro
             body: JSON.stringify({
                 label: newLabel
             })
-        }, toast, setIndicator);
+        }, toast, setIndicator, cid);
 
+        if (getConnectionEpoch() !== startEpoch) return false;
         if (result.ok) {
             setLabels([...await graph.addLabel(newLabel, node)]);
+            if (getConnectionEpoch() !== startEpoch) return false;
             setLabel([...node.labels]);
             const newGraphInfo = graph.GraphInfo.clone();
             setGraphInfo(newGraphInfo);
@@ -112,6 +112,8 @@ export default function DataPanel({ object, onClose, setLabels, canvasRef }: Pro
     };
 
     const handleRemoveLabel = async (removeLabel: string) => {
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
         const node = object as Node;
 
         if (removeLabel === "") {
@@ -128,10 +130,12 @@ export default function DataPanel({ object, onClose, setLabels, canvasRef }: Pro
             body: JSON.stringify({
                 label: removeLabel
             })
-        }, toast, setIndicator);
+        }, toast, setIndicator, cid);
 
+        if (getConnectionEpoch() !== startEpoch) return false;
         if (result.ok) {
             await graph.removeLabel(removeLabel, node);
+            if (getConnectionEpoch() !== startEpoch) return false;
             setLabels([...graph.Labels]);
             setLabel([...node.labels]);
             const newGraphInfo = graph.GraphInfo.clone();

--- a/app/graph/DataTable.tsx
+++ b/app/graph/DataTable.tsx
@@ -1,10 +1,7 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable no-param-reassign */
-
 'use client';
 
 import { Check, CirclePlus, Info, Pencil, Trash2, X } from "lucide-react";
-import { cn, prepareArg, securedFetch, GraphRef, Link, Node, Value } from "@/lib/utils";
+import { cn, getActiveConnectionIdGlobal, getConnectionEpoch, prepareArg, securedFetch, GraphRef, Link, Node, Value } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import { Fragment, MutableRefObject, useCallback, useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Switch } from "@/components/ui/switch";
@@ -198,6 +195,8 @@ export default function DataTable({ object, type, lastObjId, canvasRef, classNam
     };
 
     const setProperty = async (key: string, val: Value, isUndo: boolean, actionType: ("added" | "set") = "set") => {
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
         const { id } = object;
         if (val === "") {
             toast({
@@ -215,8 +214,9 @@ export default function DataTable({ object, type, lastObjId, canvasRef, classNam
                     value: val,
                     type
                 })
-            }, toast, setIndicator);
+            }, toast, setIndicator, cid);
 
+            if (getConnectionEpoch() !== startEpoch) return false;
             if (result.ok) {
                 const value = object.data[key];
 
@@ -301,13 +301,17 @@ export default function DataTable({ object, type, lastObjId, canvasRef, classNam
     };
 
     const removeProperty = async (key: string) => {
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
         try {
             setIsRemoveLoading(true);
             const { id } = object;
             const success = (await securedFetch(`api/graph/${prepareArg(graph.Id)}/${id}/${key}${isReadOnly ? '?readOnly=true' : ''}`, {
                 method: "DELETE",
                 body: JSON.stringify({ type }),
-            }, toast, setIndicator)).ok;
+            }, toast, setIndicator, cid)).ok;
+
+            if (getConnectionEpoch() !== startEpoch) return;
 
             if (success) {
                 const value = object.data[key];

--- a/app/graph/MetadataView.tsx
+++ b/app/graph/MetadataView.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { createNestedObject, getTheme, prepareArg, securedFetch, Query } from "@/lib/utils";
+import { createNestedObject, getActiveConnectionIdGlobal, getConnectionEpoch, getTheme, prepareArg, securedFetch, Query } from "@/lib/utils";
 import { JSONTree } from "react-json-tree";
 import { useContext, useMemo, useState } from "react";
 import { Info } from "lucide-react";
@@ -36,21 +35,27 @@ export function Profile({ query, setQuery, fetchCount, background, hideTitle }: 
 
 
     const handleProfile = async () => {
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
         setIsLoading(true);
         try {
             const readOnlyParam = isReadOnly ? '&readOnly=true' : '';
             const result = await securedFetch(`/api/graph/${query.graphName}/profile?query=${prepareArg(query.text)}${readOnlyParam}`, {
                 method: "GET",
-            }, toast, setIndicator);
+            }, toast, setIndicator, cid);
+
+            if (getConnectionEpoch() !== startEpoch) return;
 
             if (!result.ok) return;
 
             const json = await result.json();
+            if (getConnectionEpoch() !== startEpoch) return;
             setProfile(json.result);
             setQuery({
                 ...query,
                 profile: json.result
             });
+            if (getConnectionEpoch() !== startEpoch) return;
             fetchCount();
         } finally {
             setIsLoading(false);
@@ -119,7 +124,6 @@ export function Metadata({ query, hideTitle }: {
             {!hideTitle && <h1 className="text-2xl font-bold">Metadata</h1>}
             <ul className="flex flex-col gap-2 p-2 h-1 grow overflow-auto SofiaSans text-xs">
                 {query.metadata.map((m, i) => (
-                    // eslint-disable-next-line react/no-array-index-key
                     <li key={i}>{m}</li>
                 ))}
             </ul>

--- a/app/graph/page.tsx
+++ b/app/graph/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
-import { cn, convertToCanvasData, getConnectionEpoch, getMemoryUsage, getMetaStats, getSSEGraphResult, isAbortError, isTwoNodes, Link, MemoryValue, Node, prepareArg, securedFetch, Value } from "@/lib/utils";
+import { cn, convertToCanvasData, getActiveConnectionIdGlobal, getConnectionEpoch, getMemoryUsage, getMetaStats, getSSEGraphResult, isAbortError, isTwoNodes, Link, MemoryValue, Node, prepareArg, securedFetch, Value } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import dynamicImport from "next/dynamic";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
@@ -255,14 +255,15 @@ export default function Page() {
             fetchMetaStats(graphName, requestOptions),
             fetchInfo("(property key)", requestOptions),
         ]).then(async ([newDataStats, newPropertyKeys]) => {
-            if (cancelled) return;
+            if (cancelled || getConnectionEpoch() !== pollEpoch) return;
 
             const memoryUsage = showMemoryUsage ? await getMemoryUsage(graphName, toast, setIndicator, pollConnectionId, signal) : new Map<string, MemoryValue>();
+            if (cancelled || getConnectionEpoch() !== pollEpoch) return;
             const newLabels = newDataStats?.[0] || [];
             const newRelationships = newDataStats?.[1] || [];
 
-            const gi = await GraphInfo.create(newPropertyKeys, newLabels, newRelationships, memoryUsage, toast, setIndicator);
-            if (cancelled) return;
+            const gi = await GraphInfo.create(newPropertyKeys, newLabels, newRelationships, memoryUsage, toast, setIndicator, pollConnectionId);
+            if (cancelled || getConnectionEpoch() !== pollEpoch) return;
 
             setGraphInfo(gi);
             fetchCount(graphName, requestOptions);
@@ -345,7 +346,7 @@ export default function Page() {
         }
 
         setIsQueryLoading(false);
-    }, [fetchCount, graph.Id, graphName, setGraph, runDefaultQuery, defaultQuery, setIsQueryLoading, tutorialOpen]);
+    }, [fetchCount, graph.Id, graphName, setGraph, runQuery, runDefaultQuery, defaultQuery, setIsQueryLoading, tutorialOpen]);
 
     const handleSetSelectedElements = useCallback((el: (Node | Link)[] = [], fromSearch?: boolean) => {
         setSelectedElements(el);
@@ -470,6 +471,8 @@ export default function Page() {
 
     const handleCreateElement = useCallback(async (attributes: [string, Value][], label: string[]) => {
         if (!canvasRef.current) return false;
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
 
         const fakeId = "-1";
         const readOnlyParam = isReadOnlyRef.current ? '?readOnly=true' : '';
@@ -481,10 +484,12 @@ export default function Page() {
                 type: isAddNode,
                 selectedNodes: isAddNode ? undefined : selectedElements
             })
-        }, toast, setIndicator);
+        }, toast, setIndicator, cid);
 
+        if (getConnectionEpoch() !== startEpoch) return false;
         if (result.ok) {
             const json = await result.json();
+            if (getConnectionEpoch() !== startEpoch) return false;
 
             if (isAddNode) {
                 const node = await graph.extendNode(json.result.data[0].n, false, true);
@@ -514,6 +519,8 @@ export default function Page() {
 
     const handleDeleteElement = useCallback(async () => {
         if (!canvasRef.current) return;
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
 
         const deletedElements = (await Promise.all(selectedElements.map(async (element) => {
             const type = !('source' in element);
@@ -521,7 +528,7 @@ export default function Page() {
             const result = await securedFetch(`api/graph/${prepareArg(graph.Id)}/${prepareArg(element.id.toString())}${readOnlyParam}`, {
                 method: "DELETE",
                 body: JSON.stringify({ type })
-            }, toast, setIndicator);
+            }, toast, setIndicator, cid);
 
             if (!result.ok) return undefined;
 
@@ -556,6 +563,8 @@ export default function Page() {
             return element;
         }))).filter(e => !!e);
 
+        if (getConnectionEpoch() !== startEpoch) return;
+
         graph.removeElements(deletedElements);
 
         setRelationships(graph.removeLinks(deletedElements.map((element) => element.id)));
@@ -571,7 +580,7 @@ export default function Page() {
             description: `${deletedElements.length > 1 ? "Elements" : "Element"} deleted
             ${selectedElements.length > deletedElements.length ? `, ${selectedElements.length - deletedElements.length} failed` : ""}.`,
         });
-    }, [selectedElements, graph, setRelationships, canvasRef, fetchCount, panel, handleSetSelectedElements, toast, setIndicator]);
+    }, [selectedElements, graph, graphName, setRelationships, canvasRef, fetchCount, panel, handleSetSelectedElements, toast, setIndicator]);
 
     const getCurrentPanel = useCallback(() => {
         if (!graphName) return undefined;

--- a/app/graph/selectGraph.tsx
+++ b/app/graph/selectGraph.tsx
@@ -3,7 +3,7 @@
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { fetchOptions, getMemoryUsage, getSSEGraphResult, prepareArg, Row, securedFetch } from "@/lib/utils";
+import { fetchOptions, getActiveConnectionIdGlobal, getConnectionEpoch, getMemoryUsage, getSSEGraphResult, prepareArg, Row, securedFetch } from "@/lib/utils";
 import { useSession } from "next-auth/react";
 import { useToast } from "@/components/ui/use-toast";
 import { ChevronDown, ChevronUp, Loader2, Settings, X } from "lucide-react";
@@ -72,9 +72,17 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
 
 
 
-    const getOptions = useCallback(async () =>
-        fetchOptions(toast, setIndicator, indicator, setSelectedValue, opts => setOptions(opts))
-        , [toast, setIndicator, indicator, setSelectedValue, setOptions]);
+    const getOptions = useCallback(async () => {
+        // Pin the refresh to the connection active when it started and discard a
+        // stale result if the connection changed mid-flight, so an old list/
+        // selection can't overwrite the new connection's.
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
+        const res = await fetchOptions(toast, setIndicator, indicator, cid);
+        if (getConnectionEpoch() !== startEpoch || !res) return;
+        setOptions(res.opts);
+        if (res.autoSelect) setSelectedValue(res.autoSelect);
+    }, [toast, setIndicator, indicator, setSelectedValue, setOptions]);
 
     const loadMemory = useCallback((opt: string) =>
         async () => {

--- a/app/graph/selectGraph.tsx
+++ b/app/graph/selectGraph.tsx
@@ -44,7 +44,7 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
     const safeOptions = useMemo(() => options ?? [], [options]);
 
     const { indicator, setIndicator } = useContext(IndicatorContext);
-    const { isReadOnly, activeConnectionId } = useContext(ConnectionContext);
+    const { isReadOnly } = useContext(ConnectionContext);
     const {
         settings: {
             graphInfo: { showMemoryUsage }
@@ -90,17 +90,23 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
 
     const loadMemory = useCallback((opt: string) =>
         async () => {
-            const memoryMap = await getMemoryUsage(opt, toast, setIndicator, activeConnectionId);
+            const startEpoch = getConnectionEpoch();
+            const cid = getActiveConnectionIdGlobal();
+            const memoryMap = await getMemoryUsage(opt, toast, setIndicator, cid);
+            if (getConnectionEpoch() !== startEpoch) return "";
             const memoryValue = memoryMap.get("total_graph_sz_mb") || '<1';
 
             return `${memoryValue} MB`;
-        }, [toast, setIndicator, activeConnectionId]);
+        }, [toast, setIndicator]);
 
     const loadNodesCount = useCallback((opt: string) =>
         async () => {
             try {
+                const startEpoch = getConnectionEpoch();
+                const cid = getActiveConnectionIdGlobal();
                 const readOnlyParam = isReadOnly ? '?readOnly=true' : '';
-                const result = await getSSEGraphResult(`api/graph/${prepareArg(opt)}/count/nodes${readOnlyParam}`, toast, setIndicator) as { nodes?: number };
+                const result = await getSSEGraphResult(`api/graph/${prepareArg(opt)}/count/nodes${readOnlyParam}`, toast, setIndicator, { connectionId: cid }) as { nodes?: number };
+                if (getConnectionEpoch() !== startEpoch) return "";
 
                 if (result.nodes == null || !Number.isFinite(Number(result.nodes))) return "";
 
@@ -113,8 +119,11 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
     const loadEdgesCount = useCallback((opt: string) =>
         async () => {
             try {
+                const startEpoch = getConnectionEpoch();
+                const cid = getActiveConnectionIdGlobal();
                 const readOnlyParam = isReadOnly ? '?readOnly=true' : '';
-                const result = await getSSEGraphResult(`api/graph/${prepareArg(opt)}/count/edges${readOnlyParam}`, toast, setIndicator) as { edges?: number };
+                const result = await getSSEGraphResult(`api/graph/${prepareArg(opt)}/count/edges${readOnlyParam}`, toast, setIndicator, { connectionId: cid }) as { edges?: number };
+                if (getConnectionEpoch() !== startEpoch) return "";
 
                 if (result.edges == null || !Number.isFinite(Number(result.edges))) return "";
 
@@ -125,6 +134,8 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
         }, [toast, setIndicator, isReadOnly]);
 
     const handleSetOption = useCallback(async (option: string, optionName: string) => {
+        const startEpoch = getConnectionEpoch();
+        const cid = getActiveConnectionIdGlobal();
         const result = await securedFetch(
             `api/graph/${prepareArg(option)}`,
             {
@@ -133,8 +144,11 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
                 body: JSON.stringify({ sourceName: optionName })
             },
             toast,
-            setIndicator
+            setIndicator,
+            cid
         );
+
+        if (getConnectionEpoch() !== startEpoch) return false;
 
         if (result.ok) {
             const newOptions = safeOptions.map((opt) => (opt === optionName ? option : opt));

--- a/app/graph/selectGraph.tsx
+++ b/app/graph/selectGraph.tsx
@@ -82,8 +82,11 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
         const seq = (optionsSeqRef.current += 1);
         const startEpoch = getConnectionEpoch();
         const cid = getActiveConnectionIdGlobal();
-        const res = await fetchOptions(toast, setIndicator, indicator, cid);
-        if (getConnectionEpoch() !== startEpoch || optionsSeqRef.current !== seq || !res) return;
+        const isCurrent = () => getConnectionEpoch() === startEpoch && optionsSeqRef.current === seq;
+        const gToast = ((...a: Parameters<typeof toast>) => { if (isCurrent()) toast(...a); }) as typeof toast;
+        const gInd = (i: "online" | "offline") => { if (isCurrent()) setIndicator(i); };
+        const res = await fetchOptions(gToast, gInd, indicator, cid);
+        if (!isCurrent() || !res) return;
         setOptions(res.opts);
         if (res.autoSelect) setSelectedValue(res.autoSelect);
     }, [toast, setIndicator, indicator, setSelectedValue, setOptions]);

--- a/app/graph/selectGraph.tsx
+++ b/app/graph/selectGraph.tsx
@@ -53,6 +53,9 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
     } = useContext(BrowserSettingsContext);
 
     const inputRef = useRef<HTMLInputElement>(null);
+    // Monotonic sequence so two overlapping graph-list refreshes on the SAME
+    // connection can't apply out of order (the newest refresh wins).
+    const optionsSeqRef = useRef(0);
 
     const { toast } = useToast();
     const { data: session } = useSession();
@@ -74,12 +77,13 @@ export default function SelectGraph({ options, setOptions, selectedValue, setSel
 
     const getOptions = useCallback(async () => {
         // Pin the refresh to the connection active when it started and discard a
-        // stale result if the connection changed mid-flight, so an old list/
-        // selection can't overwrite the new connection's.
+        // stale result if the connection changed mid-flight (epoch) or a newer
+        // refresh on the same connection started (optionsSeq) — the newest wins.
+        const seq = (optionsSeqRef.current += 1);
         const startEpoch = getConnectionEpoch();
         const cid = getActiveConnectionIdGlobal();
         const res = await fetchOptions(toast, setIndicator, indicator, cid);
-        if (getConnectionEpoch() !== startEpoch || !res) return;
+        if (getConnectionEpoch() !== startEpoch || optionsSeqRef.current !== seq || !res) return;
         setOptions(res.opts);
         if (res.autoSelect) setSelectedValue(res.autoSelect);
     }, [toast, setIndicator, indicator, setSelectedValue, setOptions]);

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1643,6 +1643,9 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   };
 
   const handleLoadDemoGraphs = useCallback(async () => {
+    const startEpoch = getConnectionEpoch();
+    const cid = getActiveConnectionIdGlobal();
+
     try {
       // Store current user graphs and URL params
       setUserGraphsBeforeTutorial(graphNames);
@@ -1694,18 +1697,20 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
       `;
 
       await Promise.all([
-        getSSEGraphResult(`/api/graph/social-demo?query=${prepareArg(socialQuery)}`, toast, setIndicator),
-        getSSEGraphResult(`/api/graph/social-demo-test?query=${prepareArg(socialTestQuery)}`, toast, setIndicator)
+        getSSEGraphResult(`/api/graph/social-demo?query=${prepareArg(socialQuery)}`, toast, setIndicator, { connectionId: cid }),
+        getSSEGraphResult(`/api/graph/social-demo-test?query=${prepareArg(socialTestQuery)}`, toast, setIndicator, { connectionId: cid })
       ]).catch(async () => {
         await Promise.all([
           securedFetch("/api/graph/social-demo", {
             method: "DELETE",
-          }, toast, setIndicator),
+          }, toast, setIndicator, cid),
           securedFetch("/api/graph/social-demo-test", {
             method: "DELETE",
-          }, toast, setIndicator)
+          }, toast, setIndicator, cid)
         ]);
       });
+
+      if (getConnectionEpoch() !== startEpoch) return;
 
       // Update graph list to only show demo graphs
       setGraphNames(["social-demo", "social-demo-test"]);
@@ -1725,19 +1730,24 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   }, [graphName, graphNames, toast]);
 
   const handleCleanupDemoGraphs = useCallback(async () => {
+    const startEpoch = getConnectionEpoch();
+    const cid = getActiveConnectionIdGlobal();
+
     try {
       await Promise.all([
         securedFetch("/api/graph/social-demo", {
           method: "DELETE",
-        }, toast, setIndicator),
+        }, toast, setIndicator, cid),
         securedFetch("/api/graph/social-demo-test", {
           method: "DELETE",
-        }, toast, setIndicator)
+        }, toast, setIndicator, cid)
       ]);
     } catch (error) {
 
       console.error("Failed to cleanup demo graphs", error);
     }
+
+    if (getConnectionEpoch() !== startEpoch) return;
 
     // Clear current graph to avoid showing deleted demo graph. Build the empty
     // graph with the real toast/setIndicator callbacks up front so its GraphInfo

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1511,8 +1511,10 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     if (!graphNamesLoaded) return;
 
     if (urlGraphName && !graphNamesRef.current.includes(urlGraphName)) {
-      // URL graph does not exist in DB — strip all related URL params
-      setGraphName("");
+      // URL graph does not exist in DB — strip all related URL params. Route the
+      // name change through handleSetGraphName so any in-flight query for the old
+      // graph is superseded (bumps contextGen).
+      handleSetGraphName("");
       setSelectedParam("");
       setUrlQueryText(null);
       return;
@@ -1522,7 +1524,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     // When urlGraphName is empty, fetchOptions may have already auto-selected
     // a graph (e.g. single-graph DB) — don't clobber that with an empty string.
     if (urlGraphName) {
-      setGraphName(urlGraphName);
+      handleSetGraphName(urlGraphName);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlGraphName, graphNamesLoaded]);

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -772,22 +772,24 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     }
   }, []);
 
-  const fetchInfo = useCallback(async (type: string, name: string, pin?: { connectionId?: string | null; epoch?: number }) => {
+  const fetchInfo = useCallback(async (type: string, name: string, pin?: { connectionId?: string | null; epoch?: number; isCurrent?: () => boolean }) => {
     if (!name) return [];
 
     // Pin to the caller's connection (routing) and epoch (so a stale result is
     // dropped after a connection switch). `!== undefined` honours an explicit null.
     const cid = pin?.connectionId !== undefined ? pin.connectionId : getActiveConnectionIdGlobal();
     const startEpoch = pin?.epoch !== undefined ? pin.epoch : getConnectionEpoch();
-    const superseded = () => getConnectionEpoch() !== startEpoch;
+    const superseded = () => getConnectionEpoch() !== startEpoch || (pin?.isCurrent ? !pin.isCurrent() : false);
+    const gToast = pin?.isCurrent ? (((...a: Parameters<typeof toast>) => { if (!superseded()) toast(...a); }) as typeof toast) : toast;
+    const gInd = pin?.isCurrent ? ((i: "online" | "offline") => { if (!superseded()) setIndicator(i); }) : setIndicator;
 
     if (type === "(property key)") {
       const readOnlyParam = isReadOnlyRef.current ? '&readOnly=true' : '';
       const query = "CALL db.propertyKeys() YIELD propertyKey as info";
       const sse = await getSSEGraphResult(
         `/api/graph/${prepareArg(name)}?query=${prepareArg(query)}${readOnlyParam}`,
-        toast,
-        setIndicator,
+        gToast,
+        gInd,
         { connectionId: cid },
       ) as { data?: Array<{ info?: unknown }> };
 
@@ -801,7 +803,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     const readOnlyParam = isReadOnlyRef.current ? '&readOnly=true' : '';
     const result = await securedFetch(`/api/graph/${prepareArg(name)}/info?type=${prepareArg(type)}${readOnlyParam}`, {
       method: "GET",
-    }, toast, setIndicator, cid);
+    }, gToast, gInd, cid);
 
     if (!result.ok || superseded()) return [];
 
@@ -897,7 +899,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
 
       const graphI = await Promise.all([
         fetchMetaStats(n, { connectionId: cid, isCurrent }),
-        fetchInfo("(property key)", n, { connectionId: cid, epoch }),
+        fetchInfo("(property key)", n, { connectionId: cid, epoch, isCurrent }),
       ]).then(async ([metaStats, newPropertyKeys]) => {
         const memoryUsage = showMemoryUsage ? await getMemoryUsage(n, guardedToast, guardedSetIndicator, cid) : new Map<string, MemoryValue>();
         const newLabels = metaStats?.[0] || [];
@@ -1014,7 +1016,10 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   }, [limit, timeout, fetchInfo, fetchMetaStats, fetchCount, setGraphInfo, handleCooldown, handelGetNewQueries, showMemoryUsage, captionsKeys, showPropertyKeyPrefix, tutorialOpen, prefixReady]);
 
   const graphNameRef = useRef(graphName);
-  graphNameRef.current = graphName;
+
+  useEffect(() => {
+    graphNameRef.current = graphName;
+  }, [graphName]);
 
   const handleSetGraphName = useCallback((name: string) => {
     if (graphNameRef.current === name) return;
@@ -1486,20 +1491,27 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     const ctx = contextGenRef.current;
     const cid = getActiveConnectionIdGlobal();
     const epoch = getConnectionEpoch();
+    const isCurrent = () => getConnectionEpoch() === epoch && optionsSeqRef.current === oseq;
+    const gToast = ((...a: Parameters<typeof toast>) => { if (isCurrent()) toast(...a); }) as typeof toast;
+    const gInd = (i: "online" | "offline") => { if (isCurrent()) setIndicator(i); };
 
     // Only the connection-reset path clears the list; an ordinary refresh keeps
     // the last good list so a failed/slow refresh can't empty the selector.
     if (options?.clear) setGraphNames(undefined);
 
-    const res = await fetchOptions(toast, setIndicator, indicator, cid);
+    const res = await fetchOptions(gToast, gInd, indicator, cid);
 
     // The list is connection-scoped: apply only if this is still the newest
     // refresh for the same connection (a later switch/refresh owns it otherwise).
-    if (getConnectionEpoch() !== epoch || optionsSeqRef.current !== oseq) return;
-    setGraphNames(res?.opts ?? []);
+    if (!isCurrent()) return;
+    if (res) {
+      setGraphNames(res.opts);
+    } else if (options?.clear) {
+      setGraphNames([]);
+    }
     setGraphNamesLoaded(true);
     // Auto-select is graph-scoped: only apply if the graph context is unchanged.
-    if (res?.autoSelect && contextGenRef.current === ctx) handleSetGraphName(res.autoSelect);
+    if (res?.autoSelect && contextGenRef.current === ctx && isCurrent()) handleSetGraphName(res.autoSelect);
   }, [toast, setIndicator, indicator, tutorialOpen, handleSetGraphName]);
 
   useEffect(() => {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -330,6 +330,39 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   const prevActiveConnectionIdRef = useRef<string | null>(null);
   const connectionSwitchFetchedRef = useRef(false);
 
+  // ── Graph-operation ownership guards (see idea-6 plan) ──────────────────────
+  // contextGen: "what connection + graph the UI represents" — bumped on a
+  // connection-switch begin, a connection reset, and a graph-name change.
+  const contextGenRef = useRef(0);
+  // querySeq / optionsSeq: the newest query / newest graph-list refresh wins.
+  const querySeqRef = useRef(0);
+  const optionsSeqRef = useRef(0);
+  // loadingOwnerRef: the querySeq that currently owns the isQueryLoading spinner.
+  const loadingOwnerRef = useRef<number | null>(null);
+  // switchingRef: true while a user connection switch is mid-flight (its global id
+  // and React state may briefly disagree); graph ops are rejected until it clears.
+  const switchingRef = useRef(false);
+
+  const bumpContextGen = useCallback(() => {
+    contextGenRef.current += 1;
+    // A superseded in-flight query can no longer own the spinner — release it so
+    // it isn't left stuck; a fresh query re-claims it immediately.
+    if (loadingOwnerRef.current !== null) {
+      loadingOwnerRef.current = null;
+      setIsQueryLoading(false);
+    }
+    return contextGenRef.current;
+  }, []);
+
+  const beginConnectionSwitch = useCallback(() => {
+    switchingRef.current = true;
+    bumpContextGen();
+  }, [bumpContextGen]);
+
+  const endConnectionSwitch = useCallback(() => {
+    switchingRef.current = false;
+  }, []);
+
   const replayTutorial = useCallback(() => {
     router.push("/graph");
     localStorage.removeItem("tutorial");
@@ -650,7 +683,9 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     activeConnectionId,
     setActiveConnectionId,
     updateSession,
-  }), [connectionType, connectionInfo, dbVersion, isReadOnly, additionalConnections, activeConnectionId, updateSession]);
+    beginConnectionSwitch,
+    endConnectionSwitch,
+  }), [connectionType, connectionInfo, dbVersion, isReadOnly, additionalConnections, activeConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch]);
 
   const udfContext = useMemo(() => ({
     udfList,
@@ -664,10 +699,15 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     setCypherLanguageConfig,
   }), [cypherLanguageConfig]);
 
-  const fetchCount = useCallback(async (name?: string, options?: { signal?: AbortSignal; connectionId?: string | null; epoch?: number }) => {
+  const fetchCount = useCallback(async (name?: string, options?: { signal?: AbortSignal; connectionId?: string | null; epoch?: number; isCurrent?: () => boolean }) => {
     const n = name || graphName;
 
     if (!n || statusRef.current === "unauthenticated") return;
+
+    // Don't start a count while a connection switch is mid-flight — the global id
+    // and React state may disagree, so this could query (and auto-create) the
+    // old graph on the new connection.
+    if (switchingRef.current) return;
 
     // Capture the connection this request targets. Prefer the caller's captured
     // epoch (the epoch when its poll/action began) so a switch between that start
@@ -698,8 +738,11 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
 
       if (!result) return;
 
-      // Discard if the graph name or the connection changed while in flight.
+      // Discard if the graph name or the connection changed while in flight, or
+      // the caller's operation was superseded (e.g. an older query on the same
+      // graph whose count would otherwise overwrite a newer one).
       if (n !== activeGraphNameRef.current || getConnectionEpoch() !== startEpoch) return;
+      if (options?.isCurrent && !options.isCurrent()) return;
 
       const { nodes, edges } = result;
 
@@ -717,8 +760,14 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     }
   }, []);
 
-  const fetchInfo = useCallback(async (type: string, name: string) => {
+  const fetchInfo = useCallback(async (type: string, name: string, pin?: { connectionId?: string | null; epoch?: number }) => {
     if (!name) return [];
+
+    // Pin to the caller's connection (routing) and epoch (so a stale result is
+    // dropped after a connection switch). `!== undefined` honours an explicit null.
+    const cid = pin?.connectionId !== undefined ? pin.connectionId : getActiveConnectionIdGlobal();
+    const startEpoch = pin?.epoch !== undefined ? pin.epoch : getConnectionEpoch();
+    const superseded = () => getConnectionEpoch() !== startEpoch;
 
     if (type === "(property key)") {
       const readOnlyParam = isReadOnlyRef.current ? '&readOnly=true' : '';
@@ -727,9 +776,10 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
         `/api/graph/${prepareArg(name)}?query=${prepareArg(query)}${readOnlyParam}`,
         toast,
         setIndicator,
+        { connectionId: cid },
       ) as { data?: Array<{ info?: unknown }> };
 
-      if (!sse || !Array.isArray(sse.data)) return [];
+      if (superseded() || !sse || !Array.isArray(sse.data)) return [];
 
       return sse.data
         .map((entry) => (typeof entry?.info === "string" ? entry.info : undefined))
@@ -739,11 +789,12 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     const readOnlyParam = isReadOnlyRef.current ? '&readOnly=true' : '';
     const result = await securedFetch(`/api/graph/${prepareArg(name)}/info?type=${prepareArg(type)}${readOnlyParam}`, {
       method: "GET",
-    }, toast, setIndicator);
+    }, toast, setIndicator, cid);
 
-    if (!result.ok) return [];
+    if (!result.ok || superseded()) return [];
 
     const bodyText = await result.text();
+    if (superseded()) return [];
     let json: unknown;
 
     try {
@@ -766,7 +817,12 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
       .filter((value): value is string => typeof value === "string");
   }, [toast, setIndicator]);
 
-  const fetchMetaStats = useCallback((name: string) => getMetaStats(name, toast, setIndicator, isReadOnlyRef.current), [toast, setIndicator]);
+  const fetchMetaStats = useCallback((name: string, options?: { signal?: AbortSignal; connectionId?: string | null; isCurrent?: () => boolean }) => {
+    const isCurrent = options?.isCurrent;
+    const gToast = isCurrent ? (((...a: Parameters<typeof toast>) => { if (isCurrent()) toast(...a); }) as typeof toast) : toast;
+    const gInd = isCurrent ? ((i: "online" | "offline") => { if (isCurrent()) setIndicator(i); }) : setIndicator;
+    return getMetaStats(name, gToast, gInd, isReadOnlyRef.current, { signal: options?.signal, connectionId: options?.connectionId });
+  }, [toast, setIndicator]);
 
   const handelGetNewQueries = useCallback((newQuery: Query) => {
     const existing = historyQuery.queries.find(qu => qu.text === newQuery.text);
@@ -775,7 +831,24 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   }, [historyQuery.queries]);
 
   const runQuery = useCallback(async (q: string, name?: string): Promise<void> => {
-    const n = name || graphName;
+    const n = name || activeGraphNameRef.current;
+
+    // Reject while a connection switch is mid-flight — its global id and React
+    // state may still disagree, so starting here could hit the wrong DB.
+    if (switchingRef.current) return;
+
+    // Capture ownership once: this is the newest query for the current
+    // connection + graph. `isCurrent()` gates every later apply so a switch, a
+    // graph change, or a newer query discards this run's results.
+    const seq = (querySeqRef.current += 1);
+    const ctx = contextGenRef.current;
+    const cid = getActiveConnectionIdGlobal();
+    const epoch = getConnectionEpoch();
+    const isCurrent = () => querySeqRef.current === seq && contextGenRef.current === ctx;
+    loadingOwnerRef.current = seq;
+    const guardedToast = ((...a: Parameters<typeof toast>) => { if (isCurrent()) toast(...a); }) as typeof toast;
+    const guardedSetIndicator = (i: "online" | "offline") => { if (isCurrent()) setIndicator(i); };
+
     let newQuery: Query = {
       elementsCount: 0,
       explain: [],
@@ -802,26 +875,29 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     const readOnlyParam = isReadOnlyRef.current ? '&readOnly=true' : '';
     const url = `api/graph/${prepareArg(n)}?query=${prepareArg(query)}&timeout=${timeout}${readOnlyParam}`;
     try {
-      const result = await getSSEGraphResult(url, toast, setIndicator, {
+      const result = await getSSEGraphResult(url, guardedToast, guardedSetIndicator, {
         query: q,
+        connectionId: cid,
       }) as { data: Data; metadata: string[] };
 
       if (!result) throw new Error("Failed to execute query");
+      if (!isCurrent()) return;
 
       const graphI = await Promise.all([
-        fetchMetaStats(n),
-        fetchInfo("(property key)", n),
+        fetchMetaStats(n, { connectionId: cid, isCurrent }),
+        fetchInfo("(property key)", n, { connectionId: cid, epoch }),
       ]).then(async ([metaStats, newPropertyKeys]) => {
-        const memoryUsage = showMemoryUsage ? await getMemoryUsage(n, toast, setIndicator, getActiveConnectionIdGlobal()) : new Map<string, MemoryValue>();
+        const memoryUsage = showMemoryUsage ? await getMemoryUsage(n, guardedToast, guardedSetIndicator, cid) : new Map<string, MemoryValue>();
         const newLabels = metaStats?.[0] || [];
         const newRelationships = metaStats?.[1] || [];
-        const gi = await GraphInfo.create(newPropertyKeys, newLabels, newRelationships, memoryUsage, toast, setIndicator);
+        // Pin the GraphInfo's fallback metadata queries to this connection too.
+        const gi = await GraphInfo.create(newPropertyKeys, newLabels, newRelationships, memoryUsage, guardedToast, guardedSetIndicator, cid);
         // gi is embedded in the graph via Graph.create below and also pushed to
         // GraphInfoContext through setGraphInfo(g.GraphInfo) after setGraph.
         return gi;
       }).catch((error) => {
         console.error("Failed to fetch graph info:", error);
-        toast({
+        if (isCurrent()) toast({
           title: "Error",
           description: "Failed to fetch graph info",
           variant: "destructive",
@@ -829,13 +905,20 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
         return undefined;
       });
 
+      if (!isCurrent()) return;
+
       const explain = await securedFetch(`api/graph/${prepareArg(n)}/explain?query=${prepareArg(query)}${readOnlyParam}`, {
         method: "GET"
-      }, toast, setIndicator);
+      }, guardedToast, guardedSetIndicator, cid);
 
       if (!explain.ok) throw new Error("Failed to fetch explain plan");
 
       const explainJson = await explain.json();
+
+      // Guard before Graph.create so its (now connection-pinned) metadata
+      // fallbacks don't fire after a switch.
+      if (!isCurrent()) return;
+
       const g = await Graph.create(n, result, showPropertyKeyPrefix, existingLimit, graphI);
 
       newQuery = {
@@ -847,6 +930,9 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
         status: "Success",
       };
 
+      // Final ownership check before applying any state.
+      if (!isCurrent()) return;
+
       setGraph(g);
       // setGraph only updates GraphContext; the GraphInfo panel reads labels,
       // relationships and property keys from the separate GraphInfoContext, so
@@ -854,7 +940,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
       // periodic refresh (up to refreshInterval seconds later).
       setGraphInfo(g.GraphInfo);
       setData({ ...g.Elements });
-      fetchCount(n);
+      fetchCount(n, { connectionId: cid, epoch, isCurrent });
       if (!tutorialOpen) {
         setCurrentTab(g.getElements().length === 0 && g.Data.length !== 0 ? "Table" : "Graph");
       }
@@ -882,35 +968,49 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
       setScrollPosition(0);
       handleCooldown(-1);
     } catch (err) {
-      // Errors from getSSEGraphResult are already surfaced via toast
-      const errorMessage = (err as Error).message || "";
-      setDiagnostics(computeEditorDiagnostics(newQuery.text, errorMessage));
-      setLastFailure({ query: newQuery.text, errorMessage });
+      // Discard a superseded failure so it can't overwrite the active graph's
+      // diagnostics/history/URL after a switch or a newer query.
+      if (isCurrent()) {
+        // Errors from getSSEGraphResult are already surfaced via toast
+        const errorMessage = (err as Error).message || "";
+        setDiagnostics(computeEditorDiagnostics(newQuery.text, errorMessage));
+        setLastFailure({ query: newQuery.text, errorMessage });
 
-      // Save failed query to history with the error message
-      newQuery = { ...newQuery, errorMessage };
-      const failedQueries = handelGetNewQueries(newQuery);
-      if (prefixReady) {
-        setConnectionItem("query history", JSON.stringify(failedQueries));
+        // Save failed query to history with the error message
+        newQuery = { ...newQuery, errorMessage };
+        const failedQueries = handelGetNewQueries(newQuery);
+        if (prefixReady) {
+          setConnectionItem("query history", JSON.stringify(failedQueries));
+        }
+        setHistoryQuery(prev => ({
+          ...prev,
+          queries: failedQueries,
+          currentQuery: newQuery,
+          counter: 0
+        }));
       }
-      setHistoryQuery(prev => ({
-        ...prev,
-        queries: failedQueries,
-        currentQuery: newQuery,
-        counter: 0
-      }));
     } finally {
-      setUrlQueryText(newQuery.text);
-      setIsQueryLoading(false);
+      if (isCurrent()) setUrlQueryText(newQuery.text);
+      // Only the run that still owns the spinner may clear it — a newer query or
+      // a switch/graph change may have taken (or released) ownership.
+      if (loadingOwnerRef.current === seq) {
+        loadingOwnerRef.current = null;
+        setIsQueryLoading(false);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [graphName, limit, timeout, fetchInfo, fetchCount, setGraphInfo, handleCooldown, handelGetNewQueries, showMemoryUsage, captionsKeys, showPropertyKeyPrefix, tutorialOpen, prefixReady]);
+  }, [limit, timeout, fetchInfo, fetchMetaStats, fetchCount, setGraphInfo, handleCooldown, handelGetNewQueries, showMemoryUsage, captionsKeys, showPropertyKeyPrefix, tutorialOpen, prefixReady]);
 
   const graphNameRef = useRef(graphName);
   graphNameRef.current = graphName;
 
   const handleSetGraphName = useCallback((name: string) => {
     if (graphNameRef.current === name) return;
+    // Make the new graph name authoritative immediately (both refs otherwise only
+    // refresh at render) and supersede any in-flight op targeting the old graph.
+    graphNameRef.current = name;
+    activeGraphNameRef.current = name;
+    bumpContextGen();
     // Clear stale state from the previous graph so old data doesn't linger
     setGraphName(name);
     setSelectedParam("");
@@ -925,7 +1025,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     setDiagnostics(null);
     setHistoryQuery(h => ({ ...h, query: "", currentQuery: defaultQueryHistory.currentQuery }));
     setUrlQueryText(null);
-  }, [toast, setIndicator]);
+  }, [toast, setIndicator, bumpContextGen]);
 
   const graphContext = useMemo(() => ({
     graph,
@@ -1367,20 +1467,28 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     return () => clearInterval(interval);
   }, [checkStatus, status]);
 
-  const handleFetchOptions = useCallback(async () => {
+  const handleFetchOptions = useCallback(async (options?: { clear?: boolean }) => {
     if (indicator === "offline" || tutorialOpen) return;
 
-    setGraphNames(undefined);
-    let fetched = false;
-    await fetchOptions(toast, setIndicator, indicator, setGraphName, opts => {
-      fetched = true;
-      setGraphNames(opts);
-    });
-    if (!fetched) {
-      setGraphNames([]);
-    }
+    const oseq = (optionsSeqRef.current += 1);
+    const ctx = contextGenRef.current;
+    const cid = getActiveConnectionIdGlobal();
+    const epoch = getConnectionEpoch();
+
+    // Only the connection-reset path clears the list; an ordinary refresh keeps
+    // the last good list so a failed/slow refresh can't empty the selector.
+    if (options?.clear) setGraphNames(undefined);
+
+    const res = await fetchOptions(toast, setIndicator, indicator, cid);
+
+    // The list is connection-scoped: apply only if this is still the newest
+    // refresh for the same connection (a later switch/refresh owns it otherwise).
+    if (getConnectionEpoch() !== epoch || optionsSeqRef.current !== oseq) return;
+    setGraphNames(res?.opts ?? []);
     setGraphNamesLoaded(true);
-  }, [toast, setIndicator, indicator, tutorialOpen]);
+    // Auto-select is graph-scoped: only apply if the graph context is unchanged.
+    if (res?.autoSelect && contextGenRef.current === ctx) handleSetGraphName(res.autoSelect);
+  }, [toast, setIndicator, indicator, tutorialOpen, handleSetGraphName]);
 
   useEffect(() => {
     if (status !== "authenticated") return;
@@ -1490,6 +1598,12 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     // Skip if unchanged
     if (prev === activeConnectionId) return;
 
+    // The connection actually changed and React state now agrees: supersede any
+    // in-flight graph op and end the switch gate so new ops are accepted again.
+    bumpContextGen();
+    activeGraphNameRef.current = "";
+    endConnectionSwitch();
+
     // Clear graph data so stale results from the old connection are gone.
     // Build the empty graph with the real toast/setIndicator callbacks up front
     // so its GraphInfo isn't left with Graph.empty()'s console.error fallbacks
@@ -1498,17 +1612,16 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     setGraphName("");
     setSelectedParam("");
     setGraphNamesLoaded(false);
-    setGraphNames(undefined);
     graphInfoSyncRef.current.setNodesCount(undefined);
     graphInfoSyncRef.current.setEdgesCount(undefined);
     setHistoryQuery(h => ({ ...h, query: "", currentQuery: defaultQueryHistory.currentQuery }));
     setLabels([]);
     setRelationships([]);
 
-    // Re-fetch graph list for the new connection
+    // Re-fetch graph list for the new connection (clearing the old list).
     connectionSwitchFetchedRef.current = true;
-    handleFetchOptions();
-  }, [activeConnectionId, toast, setIndicator, handleFetchOptions]);
+    handleFetchOptions({ clear: true });
+  }, [activeConnectionId, toast, setIndicator, handleFetchOptions, bumpContextGen, endConnectionSwitch]);
 
   const handleCloseTutorial = () => {
     setTutorialOpen(false);

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -339,9 +339,11 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   const optionsSeqRef = useRef(0);
   // loadingOwnerRef: the querySeq that currently owns the isQueryLoading spinner.
   const loadingOwnerRef = useRef<number | null>(null);
-  // switchingRef: true while a user connection switch is mid-flight (its global id
-  // and React state may briefly disagree); graph ops are rejected until it clears.
-  const switchingRef = useRef(false);
+  // Connection-switch gate. `pendingSwitches` counts in-flight switches (graph ops
+  // are rejected while > 0); `switchTicket` is monotonic so a completing switch
+  // can tell whether it is still the latest (out-of-order completions are ignored).
+  const pendingSwitchesRef = useRef(0);
+  const switchTicketRef = useRef(0);
 
   const bumpContextGen = useCallback(() => {
     contextGenRef.current += 1;
@@ -354,14 +356,23 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     return contextGenRef.current;
   }, []);
 
+  // Returns a ticket for this switch. Every begin must be matched by exactly one
+  // end (on success via the reset effect, on failure/supersession by the caller),
+  // so the counter can never get stuck above 0.
   const beginConnectionSwitch = useCallback(() => {
-    switchingRef.current = true;
+    pendingSwitchesRef.current += 1;
+    switchTicketRef.current += 1;
     bumpContextGen();
+    return switchTicketRef.current;
   }, [bumpContextGen]);
 
   const endConnectionSwitch = useCallback(() => {
-    switchingRef.current = false;
+    pendingSwitchesRef.current = Math.max(0, pendingSwitchesRef.current - 1);
   }, []);
+
+  // True if `ticket` is still the most recently started switch (so a stale,
+  // out-of-order completion doesn't publish an older connection as active).
+  const isLatestSwitch = useCallback((ticket: number) => switchTicketRef.current === ticket, []);
 
   const replayTutorial = useCallback(() => {
     router.push("/graph");
@@ -685,7 +696,8 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     updateSession,
     beginConnectionSwitch,
     endConnectionSwitch,
-  }), [connectionType, connectionInfo, dbVersion, isReadOnly, additionalConnections, activeConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch]);
+    isLatestSwitch,
+  }), [connectionType, connectionInfo, dbVersion, isReadOnly, additionalConnections, activeConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch, isLatestSwitch]);
 
   const udfContext = useMemo(() => ({
     udfList,
@@ -707,7 +719,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     // Don't start a count while a connection switch is mid-flight — the global id
     // and React state may disagree, so this could query (and auto-create) the
     // old graph on the new connection.
-    if (switchingRef.current) return;
+    if (pendingSwitchesRef.current > 0) return;
 
     // Capture the connection this request targets. Prefer the caller's captured
     // epoch (the epoch when its poll/action began) so a switch between that start
@@ -835,7 +847,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
 
     // Reject while a connection switch is mid-flight — its global id and React
     // state may still disagree, so starting here could hit the wrong DB.
-    if (switchingRef.current) return;
+    if (pendingSwitchesRef.current > 0) return;
 
     // Capture ownership once: this is the newest query for the current
     // connection + graph. `isCurrent()` gates every later apply so a switch, a
@@ -1601,10 +1613,11 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     if (prev === activeConnectionId) return;
 
     // The connection actually changed and React state now agrees: supersede any
-    // in-flight graph op and end the switch gate so new ops are accepted again.
+    // in-flight graph op and fully release the switch gate so new ops are accepted
+    // again (any still-pending older switch is no longer latest, so it's a no-op).
     bumpContextGen();
     activeGraphNameRef.current = "";
-    endConnectionSwitch();
+    pendingSwitchesRef.current = 0;
 
     // Clear graph data so stale results from the old connection are gone.
     // Build the empty graph with the real toast/setIndicator callbacks up front
@@ -1623,7 +1636,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     // Re-fetch graph list for the new connection (clearing the old list).
     connectionSwitchFetchedRef.current = true;
     handleFetchOptions({ clear: true });
-  }, [activeConnectionId, toast, setIndicator, handleFetchOptions, bumpContextGen, endConnectionSwitch]);
+  }, [activeConnectionId, toast, setIndicator, handleFetchOptions, bumpContextGen]);
 
   const handleCloseTutorial = () => {
     setTutorialOpen(false);

--- a/e2e/tests/graphOperationRace.spec.ts
+++ b/e2e/tests/graphOperationRace.spec.ts
@@ -24,13 +24,14 @@ test.describe("Graph operation race conditions", () => {
   test(`@admin a query held in-flight is discarded after switching graph (no stale apply)`, async () => {
     const graphA = getRandomString("raceA");
     const graphB = getRandomString("raceB");
-    // Distinct node counts so a stale apply is detectable: A=3, B=1.
-    await apiCall.addGraph(graphA);
-    await apiCall.runQuery(graphA, "CREATE (:N), (:N), (:N)");
-    await apiCall.addGraph(graphB);
-    await apiCall.runQuery(graphB, "CREATE (:N)");
 
     try {
+      // Distinct node counts so a stale apply is detectable: A=3, B=1.
+      await apiCall.addGraph(graphA);
+      await apiCall.runQuery(graphA, "CREATE (:N), (:N), (:N)");
+      await apiCall.addGraph(graphB);
+      await apiCall.runQuery(graphB, "CREATE (:N)");
+
       const graph = await browser.createNewPage(GraphPage, urls.graphUrl);
       const page = await browser.getPage();
 
@@ -59,8 +60,11 @@ test.describe("Graph operation race conditions", () => {
 
       // Release A's stale (3-node) result; the guard must discard it rather than
       // apply it over B.
+      const responsePromise = page.waitForResponse((response) => response.url().includes(`/api/graph/${graphA}/explain`));
       releaseA();
-      await page.waitForTimeout(2000);
+      await responsePromise;
+      // Small buffer to allow client-side state update scheduling.
+      await page.waitForTimeout(200);
 
       // Still B's data — A's stale result was NOT applied.
       expect(await graph.getNodesCount()).toBe("1");

--- a/e2e/tests/graphOperationRace.spec.ts
+++ b/e2e/tests/graphOperationRace.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+import { getRandomString } from "../infra/utils";
+import BrowserWrapper from "../infra/ui/browserWrapper";
+import ApiCalls from "../logic/api/apiCalls";
+import GraphPage from "../logic/POM/graphPage";
+import urls from "../config/urls.json";
+
+// Regression coverage for the connection/graph ownership guards (idea-6): a
+// query captured for one graph must NOT apply its (stale) result after the user
+// switched to a different graph while it was in flight.
+test.describe("Graph operation race conditions", () => {
+  let browser: BrowserWrapper;
+  let apiCall: ApiCalls;
+
+  test.beforeEach(async () => {
+    browser = new BrowserWrapper();
+    apiCall = new ApiCalls();
+  });
+
+  test.afterEach(async () => {
+    await browser.closeBrowser();
+  });
+
+  test(`@admin a query held in-flight is discarded after switching graph (no stale apply)`, async () => {
+    const graphA = getRandomString("raceA");
+    const graphB = getRandomString("raceB");
+    // Distinct node counts so a stale apply is detectable: A=3, B=1.
+    await apiCall.addGraph(graphA);
+    await apiCall.runQuery(graphA, "CREATE (:N), (:N), (:N)");
+    await apiCall.addGraph(graphB);
+    await apiCall.runQuery(graphB, "CREATE (:N)");
+
+    try {
+      const graph = await browser.createNewPage(GraphPage, urls.graphUrl);
+      const page = await browser.getPage();
+
+      // Hold graph A's query in-flight until we release it, so it is still
+      // pending when we switch to graph B.
+      let releaseA: () => void = () => { };
+      const heldA = new Promise<void>((resolve) => { releaseA = resolve; });
+      const holdPattern = `**/api/graph/${graphA}?query=**`;
+      await page.route(holdPattern, async (route) => {
+        await heldA;
+        await route.continue();
+      });
+
+      // Selecting A auto-runs its default query, which is now held in-flight.
+      await graph.selectGraphByName(graphA);
+
+      // Switch to B while A's query is still pending — B loads normally (1 node).
+      await graph.selectGraphByName(graphB);
+      expect(await graph.getNodesCount()).toBe("1");
+
+      // Release A's stale (3-node) result; the guard must discard it rather than
+      // apply it over B.
+      releaseA();
+      await page.unroute(holdPattern);
+      await page.waitForTimeout(2000);
+
+      // Still B's data — A's stale result was NOT applied.
+      expect(await graph.getNodesCount()).toBe("1");
+    } finally {
+      await apiCall.removeGraph(graphA).catch(() => undefined);
+      await apiCall.removeGraph(graphB).catch(() => undefined);
+    }
+  });
+});

--- a/e2e/tests/graphOperationRace.spec.ts
+++ b/e2e/tests/graphOperationRace.spec.ts
@@ -34,31 +34,37 @@ test.describe("Graph operation race conditions", () => {
       const graph = await browser.createNewPage(GraphPage, urls.graphUrl);
       const page = await browser.getPage();
 
-      // Hold graph A's query in-flight until we release it, so it is still
-      // pending when we switch to graph B.
+      // Hold graph A's runQuery at its /explain step — a regular fetch (reliably
+      // interceptable, unlike the SSE query). At that point A's result has NOT
+      // been applied yet, so A is genuinely in-flight when we switch to B.
       let releaseA: () => void = () => { };
       const heldA = new Promise<void>((resolve) => { releaseA = resolve; });
-      const holdPattern = `**/api/graph/${graphA}?query=**`;
+      const holdPattern = `**/api/graph/${graphA}/explain**`;
       await page.route(holdPattern, async (route) => {
         await heldA;
-        await route.continue();
+        // The page may be tearing down by the time we release — ignore that.
+        await route.continue().catch(() => undefined);
       });
 
-      // Selecting A auto-runs its default query, which is now held in-flight.
+      // Select A (no auto-run), then fire a query and let it block at /explain.
       await graph.selectGraphByName(graphA);
+      await graph.insertQuery("MATCH (n) RETURN n");
+      await graph.clickEditorRun(); // fire-and-forget — the result is held at /explain
+      // Wait until A's runQuery has actually reached (and is paused at) /explain.
+      await page.waitForRequest(holdPattern, { timeout: 30000 });
 
-      // Switch to B while A's query is still pending — B loads normally (1 node).
+      // Switch to B while A is still in-flight — B's node count (1) loads.
       await graph.selectGraphByName(graphB);
       expect(await graph.getNodesCount()).toBe("1");
 
       // Release A's stale (3-node) result; the guard must discard it rather than
       // apply it over B.
       releaseA();
-      await page.unroute(holdPattern);
       await page.waitForTimeout(2000);
 
       // Still B's data — A's stale result was NOT applied.
       expect(await graph.getNodesCount()).toBe("1");
+      await page.unroute(holdPattern).catch(() => undefined);
     } finally {
       await apiCall.removeGraph(graphA).catch(() => undefined);
       await apiCall.removeGraph(graphB).catch(() => undefined);

--- a/idea-6-connection-epoch-pinning-plan.md
+++ b/idea-6-connection-epoch-pinning-plan.md
@@ -1,0 +1,323 @@
+# Implementation Plan — Idea #6: stop stale graph results from applying after a connection / graph / query change
+
+Goal: never let connection‑A (or graph‑A, or an older query's) results be **applied** to the UI, and
+never let a superseded operation **auto‑create a ghost graph** on the wrong connection. Today only
+`fetchCount` is safe; `runQuery`, `fetchInfo`, `handleFetchOptions`, the `selectGraph` dropdown
+refresh, and the `GraphInfo` count fallback are not.
+
+Closes the CodeRabbit thread on `app/providers.tsx:767` (PR #1934). **Behaviour bug fix, not
+breaking.**
+
+> Revised twice after rubber‑duck reviews. §10 traces every finding to the section that fixes it so a
+> reviewer can confirm coverage.
+
+---
+
+## 0. Background — primitives that already exist
+
+`lib/utils.ts`
+- `_activeConnectionId` — injected as `X-Connection-Id` by `securedFetch`, `uploadFileWithProgress`,
+  `getSSEGraphResult`, `getMetaStats`, `getMemoryUsage`. A request **snapshots** it **synchronously
+  when called** (`:273`, `:700`) — a single in‑flight request is *not* re‑routed. The bug is that a
+  multi‑step op reads the *current* global again for each **follow‑up** and applies without re‑check.
+- `_connectionEpoch` — bumped by `setActiveConnectionIdGlobal(id)` only when the id changes (A→B→A
+  detected). Read via `getConnectionEpoch()`.
+
+`providers.tsx`
+- Syncs the global every render (`~966`). On a real switch, a **reset effect** (`~1483`) clears graph
+  state and re‑fetches the list — but does **not** abort in‑flight ops, so a late op re‑applies.
+- `fetchCount` (`~667`) is the correct template: capture `{connectionId, epoch}`, early‑return if
+  superseded, pin the request, wrap `toast`/`setIndicator` in guards, re‑check epoch **and**
+  `activeGraphNameRef` before writing.
+
+---
+
+## 1. Why one epoch (or one generation) is not enough
+
+Stale applies happen at four independent granularities — they must be tracked **separately**, or a
+guard for one wrongly discards a still‑valid other:
+
+1. **Connection** switch A→B (bumps epoch).
+2. **Graph** switch A→B on the *same* connection (epoch unchanged; selection stays enabled during a
+   query — `selectGraph.tsx:209‑232`).
+3. **Newer query** on the same graph (two queries resolve out of order).
+4. **Newer list refresh** vs an older one (and a query must **not** invalidate a valid list refresh —
+   they are unrelated).
+
+Plus a **transition window**: `ConnectionManager.handleSelect` (`ConnectionManager.tsx:37‑45`) sets
+the **global** id (bumps epoch) *before* `await updateSession`, and sets **React**
+`activeConnectionId` (which triggers the reset) *after*. The same happens on **add** (`~124‑128`) and
+**remove‑active** (`~84‑89`). An op started in that window captures B's epoch while the UI still names
+A's graph → can query/auto‑create A's graph on B and survive the reset.
+
+---
+
+## 2. Mechanism — four ownership tokens + connection pin + a switch gate
+
+All refs live in `providers.tsx`. **Capture at op start, re‑check before every write.**
+
+| Ref | Bumped synchronously when… | Owns (guards) |
+| --- | --- | --- |
+| `contextGenRef` | connection switch **begins** (`beginConnectionSwitch`), reset effect runs, or the **active graph name changes** (via one `commitGraphName`) | every graph/panel/list apply — the "what the UI represents" guard |
+| `querySeqRef` | each `runQuery` starts | the graph/panel apply **and** the count write for that query |
+| `optionsSeqRef` | each list refresh starts (`handleFetchOptions`) | `setGraphNames` / `setGraphName` auto‑select |
+| `loadingOwnerRef` | claimed by a query at start | who may clear `isQueryLoading` |
+
+**Apply rule for a query:** apply only if `contextGenRef.current === ctx` **and**
+`querySeqRef.current === seq` (both captured at start). **Apply rule for a list refresh:** apply only
+if `contextGenRef.current === ctx` **and** `optionsSeqRef.current === oseq`. A query bumps only
+`querySeq` (not `optionsSeq`), so it never discards a valid list refresh, and vice‑versa.
+
+**Connection pin (routing):** still capture `connectionId` at start and pass it to **every** request
+so calls hit the right backend before React settles; keep `epoch`‑based `guarded*` toast/indicator
+wrappers, but the wrappers additionally check the **op's token** (`contextGen`+`querySeq`) so
+same‑connection supersession also silences stale toasts.
+
+**Switch gate (ticket‑based):** `beginConnectionSwitch(targetId): SwitchTicket | null` — **no‑op
+returning `null` if `targetId === activeConnectionId`**; else create `{ id: ++switchTicketSeq, target }`,
+store it as the latest in `switchingRef.current`, bump `contextGen`, and return it. Graph ops
+(`runQuery`, dropdown refresh) **reject whenever `switchingRef.current !== null`** — the block
+condition is simply "a switch ticket exists", **not** a global‑vs‑React id comparison (unreliable
+because the render‑sync at `~966` can transiently restore the old global during `await updateSession`).
+ConnectionManager owns the lifecycle:
+- Mutate `setActiveConnectionIdGlobal` / React `setActiveConnectionId` / `localStorage` **only after a
+  successful `updateSession`**, so a rejected switch leaves ids consistent.
+- On success, `completeConnectionSwitch(ticket)`; the reset effect (driven by the React id change)
+  clears `switchingRef` **iff it still holds this ticket** (latest‑wins for concurrent switches; a
+  superseded older completion is ignored).
+- On reject, `cancelConnectionSwitch(ticket)` clears it iff current and restores prior ids.
+  **Remove‑active** is special: the old connection is already deleted, so on failure fall back to
+  another remaining connection instead of restoring the deleted one.
+Expose `beginConnectionSwitch` / `completeConnectionSwitch` / `cancelConnectionSwitch` via
+`ConnectionContext`. **`bumpContextGen` also releases the spinner** (`loadingOwnerRef.current = null;
+setIsQueryLoading(false)`), so a switch/graph‑change can't strand it; a new `runQuery` re‑claims.
+
+---
+
+## 3. Per‑function changes
+
+### 3a. Central graph‑name commit — `commitGraphName(name)` (new)
+Graph name is set at several sites that currently bypass `handleSetGraphName`:
+`providers.tsx:1407`, `:1417`, `:1498` (reset), plus the new auto‑select. Route **all** through:
+```ts
+const commitGraphName = useCallback((name: string) => {
+  if (name === activeGraphNameRef.current) return; // no change → no bump
+  activeGraphNameRef.current = name;               // authoritative NOW (the ref otherwise only refreshes at render, ~633)
+  bumpContextGen();                                // also releases spinner ownership (§2)
+  setGraphName(name);
+}, [/* stable setters/refs */]);
+```
+`handleSetGraphName` delegates to it, and **`runQuery` defaults `n` to `activeGraphNameRef.current`**
+(not its stale render closure) so a same‑tick commit is seen. This makes graph‑change bumps
+synchronous and single‑sourced.
+
+### 3b. ConnectionManager — ticket lifecycle at all 3 switch sites
+`handleSelect`, add‑auto‑switch (`~124‑128`), and remove‑active‑switch (`~84‑89`) call
+`beginConnectionSwitch(target)` **first**; if it returns `null` (already active) they proceed
+unchanged. Reorder each to: `await updateSession(...)` → **on success** set global/React/localStorage
+ids + `completeConnectionSwitch(ticket)`; **on reject** `cancelConnectionSwitch(ticket)`
+(remove‑active recovers to another remaining connection). The reset effect clears `switchingRef` only
+if it still holds the completing ticket, so a superseded older switch can't reopen graph ops for the
+wrong target.
+
+### 3c. `fetchInfo(type, name, pin?)` (`~720`) — sole caller is `runQuery` (verified: only `:813`)
+Accept the caller's pin; guard with the op token, not epoch‑only:
+```ts
+const cid = pin?.connectionId !== undefined ? pin.connectionId : getActiveConnectionIdGlobal();
+const isCurrent = pin?.isCurrent ?? (() => getConnectionEpoch() === startEpoch);
+const gToast = ((...a) => { if (isCurrent()) toast(...a); }) as typeof toast;
+const gInd   = (i) => { if (isCurrent()) setIndicator(i); };
+```
+- property‑key branch: `getSSEGraphResult(url, gToast, gInd, { connectionId: cid })`; `if (!isCurrent()) return [];` after it.
+- generic branch: `securedFetch(url, { method:"GET" }, gToast, gInd, cid)`; discard **after `await result.text()`** and after parse.
+- `!== undefined` for the pin so an explicit `null` is honoured.
+
+### 3d. `fetchMetaStats(name, options?)` (`~769`) — forward pin + guarded callbacks
+`getMetaStats` already takes `{ signal, connectionId }`. Widen the wrapper to accept
+`{ connectionId, isCurrent }` and build `gToast/gInd` from `isCurrent` before delegating.
+
+### 3e. `fetchCount` (`~667`) — add an ownership predicate for the count write
+`fetchCount` already pins connection/epoch, but two same‑graph queries share graph name **and** epoch,
+so its count write can be overwritten out of order. Add optional `options.isCurrent?: () => boolean`;
+when present, require `isCurrent()` (in addition to the existing graph/epoch checks) before
+`setNodesCount/setEdgesCount`. Standalone/periodic callers omit it (unchanged).
+
+### 3f. `runQuery` (`~777`) — capture all tokens, pin all requests, guard every apply site
+1. **Reject** up front if a switch is in progress (§2 gate).
+2. **Capture:** `const ctx = contextGenRef.current; const seq = bumpQuerySeq(); const cid = getActiveConnectionIdGlobal(); const epoch = getConnectionEpoch();` and
+   `const isCurrent = () => contextGenRef.current === ctx && querySeqRef.current === seq;`
+   Claim the spinner: `loadingOwnerRef.current = seq;`
+3. **Pin** every request to `cid` and pass `isCurrent`:
+   - SSE query: `getSSEGraphResult(url, gToast, gInd, { query: q, connectionId: cid })`.
+   - `fetchMetaStats(n, { connectionId: cid, isCurrent })`.
+   - `fetchInfo("(property key)", n, { connectionId: cid, isCurrent })`.
+   - `getMemoryUsage(n, gToast, gInd, cid)`.
+   - `/explain`: `securedFetch(url, { method:"GET" }, gToast, gInd, cid)`.
+   - `Graph.create(...)` — pass `cid` so the `GraphInfo` count fallback is pinned (see §4).
+   - `fetchCount(n, { connectionId: cid, epoch, isCurrent })`.
+4. **Discard checks:** `if (!isCurrent()) return;` immediately after `Promise.all([...])`, after
+   `/explain`, and again right **before** `setGraph(g)` (guards the whole success block:
+   `setGraph`, `setGraphInfo`, `setData`, `fetchCount`, `setCurrentTab`, `setConnectionItem`, history
+   writes, `setViewport`, `setGraphData`, `setSearch`, `setScrollPosition`, `handleCooldown`).
+5. **Catch (`884‑901`):** wrap the whole body in `if (isCurrent()) { … }` — a superseded failure must
+   not write diagnostics/`lastFailure`/history.
+6. **`finally` (`903‑904`):** `if (isCurrent()) setUrlQueryText(newQuery.text);` and clear loading
+   **only if this run owns it**: `if (loadingOwnerRef.current === seq) { loadingOwnerRef.current = null; setIsQueryLoading(false); }`.
+
+### 3g. `fetchOptions` (`lib/utils.ts:1145`) — return data, stop mutating, add a pin
+It currently calls **both** `setOptions` and `setSelectedValue` (single‑graph auto‑select). Refactor
+to pure‑ish return so callers guard both:
+```ts
+export async function fetchOptions(toast, setIndicator, indicator, connectionId?: string | null):
+  Promise<{ opts: string[]; autoSelect: string | null } | null> { … securedFetch(`/api/graph`, …, connectionId) …
+  return { opts, autoSelect: opts.length === 1 ? formatName(opts[0]) : null }; }
+```
+
+### 3h. `handleFetchOptions(opts?)` (`~1370`) — non‑destructive refresh, guarded list + auto‑select
+Do **not** blank the list on an ordinary refresh (that reintroduces the empty‑selector bug PR #1934
+fixed in `selectGraph`). Only the **connection‑reset** path clears it; drive the spinner off a local
+`loading` flag instead of `setGraphNames(undefined)`. The list is **connection‑scoped** (guard by
+connection epoch + `optionsSeq`); the auto‑select is **graph‑scoped** (also guard by `contextGen`):
+```ts
+const ctx = contextGenRef.current; const oseq = bumpOptionsSeq();
+const cid = getActiveConnectionIdGlobal(); const epoch = getConnectionEpoch();
+if (opts?.clear) setGraphNames(undefined);            // only the reset effect passes { clear: true }
+const res = await fetchOptions(gToast, gInd, indicator, cid);
+if (getConnectionEpoch() === epoch && optionsSeqRef.current === oseq) {
+  if (res) setGraphNames(res.opts);                   // on network error keep the last good list
+  setGraphNamesLoaded(true);
+  if (res?.autoSelect && contextGenRef.current === ctx) commitGraphName(res.autoSelect);
+}
+```
+Expose `handleFetchOptions` on `GraphContext` (move its declaration above the context memo). The reset
+effect calls `handleFetchOptions({ clear: true })`.
+
+### 3i. `selectGraph.tsx` dropdown refresh (`:75‑77`, `:196‑203`) — the 2nd `fetchOptions` caller
+Replace the direct `fetchOptions` call with the provider's guarded `handleFetchOptions` (now on
+`GraphContext`), so all graph‑list fetching flows through one guarded path. (This also removes the
+duplicate offline/auto‑select logic.)
+
+---
+
+## 4. Pin the `GraphInfo` count fallback (rubber‑duck #6 — TOCTOU)
+`Graph.create` **yields** while building elements and then calls the unpinned fallback:
+`providers.tsx:839` → `model.ts:825/855` (`createLabel`/`createRelationship`) → `model.ts:187/215` →
+`model.ts:172` `getMetaStatsCount` → `getMetaStats(graphName, toast, setIndicator)` (no connection).
+Because `Graph.create` uses the **supplied** `GraphInfo` instance unchanged (`model.ts:470‑476`),
+passing `cid` only to `Graph.create` is insufficient — the pin must live **on the `GraphInfo`
+instance** that `runQuery` builds at `providers.tsx:818`:
+- `GraphInfo.create(propertyKeys, labels, rels, memory, toast, setIndicator, cid, isCurrent)` stores
+  `connectionId` (+ a guarded toast/indicator) on the instance.
+- `getMetaStatsCount` → `getMetaStats(graphName, gToast, gInd, undefined, { connectionId: this.connectionId })`.
+- Preserve the pin through `GraphInfo.clone()` and `GraphInfo.empty()` so it is never lost.
+`runQuery` thus builds `graphI` already pinned; `Graph.create(n, result, …, graphI)` needs no new arg.
+Done **now** — the pre‑`Graph.create` guard alone can't close the mid‑creation window.
+
+---
+
+## 5. Testing
+
+Provider callbacks aren't unit‑tested directly (repo convention: pure logic is extracted + e2e).
+
+### 5a. Unit (`node:test`)
+- `securedFetch` and new `fetchOptions` forward an explicit `connectionId` (string **and** `null`) and
+  fall back to the global on `undefined`.
+- If token helpers are extracted to a pure module: monotonic bump + supersede semantics, incl.
+  independence of `querySeq` vs `optionsSeq`.
+
+### 5b. E2E — deterministic races (`e2e/tests/connectionSwitchRace.spec.ts`, `@admin`, 2 connections)
+Each asserts **(i)** no ghost graph on B via a **fresh `/api/graph` list request** (not the cached
+selector) and **(ii)** the panel/graph reflect the current selection:
+1. **Connection switch mid‑query** — delay A's SSE response (route the URL; it contains a literal
+   `?query=`, use a **URL predicate**, not `%3Fquery=`), switch to B before it resolves.
+2. **Graph switch mid‑query (same connection)** — delay a query on graph A, select graph B.
+3. **Two out‑of‑order queries on the same graph** — the newer result wins; the older is dropped.
+4. **Options‑refresh / query overlap** — a delayed list/auto‑select from A must not select on B, and a
+   query must not blank the list.
+5. **Stale failure** — delay‑then‑fail A's query, switch, assert no diagnostics/history/URL from A.
+6. **Spinner release** — after a supersede‑without‑new‑run (e.g. graph cleared), `isQueryLoading` is
+   released (no stuck spinner).
+Use `urlPath()` for navigation asserts (repo e2e memory). Each new test must **fail on pre‑fix
+`staging`** and pass after.
+
+### 5c. Gate
+`npm test`, `npm run lint`, `npm run test:coverage`, `npx tsc --noEmit`, full Playwright — the exact
+commands CI runs — all green.
+
+---
+
+## 6. Docs + PR
+Title: `fix(providers): guard graph ops by connection + generation to stop stale applies`. Body links
+the thread (`providers.tsx:767`), the §1 races, and per‑function before/after. Comment each guard
+pointing at `fetchCount`. No README change.
+
+---
+
+## 7. Risks & mitigations
+| Risk | Mitigation |
+| --- | --- |
+| Over‑eager discard drops valid results. | Four **separate** tokens (§2); a query never invalidates a list refresh and vice‑versa; capture‑once per op. E2e "no switch → applies" path. |
+| Stuck spinner. | `loadingOwnerRef`: claim on start, clear only by owner in `finally`, and explicitly release on context invalidation; **guard the other clear site `page.tsx:347`** by ownership. E2e #6. |
+| `GraphInfo` fallback TOCTOU. | §4 threads `connectionId` into `GraphInfo`/`getMetaStatsCount` — done now. |
+| Transition window / add / remove switches. | §2 `beginConnectionSwitch` at all 3 sites, synchronous, with failure cleanup + latest‑switch ownership. |
+| Same‑connection graph/concurrent races. | `contextGen` (graph) + `querySeq` (newer query) + `isCurrent` in `fetchCount`/`fetchInfo`/`fetchMetaStats`. |
+| Auto‑select / 2nd caller leaks. | §3g returns data; §3h guards both; §3i centralizes `selectGraph`. |
+| Signature ripples. | New params optional; both `fetchOptions` callers updated here; `tsc`+lint verify. |
+| Hard to prove. | The 6 deterministic Playwright races (§5b) are the acceptance criterion. |
+
+---
+
+## 8. Step‑by‑step task list
+1. `lib/utils.ts`: `fetchOptions` returns `{opts, autoSelect}` + optional `connectionId`; unit‑test connection forwarding.
+2. `app/api/graph/model.ts`: thread `connectionId` through `GraphInfo.create`/`getMetaStatsCount`/`Graph.create` (§4).
+3. `providers.tsx`: add `contextGenRef`/`querySeqRef`/`optionsSeqRef`/`loadingOwnerRef` + bump helpers; `commitGraphName`; expose `beginConnectionSwitch` + `handleFetchOptions` on context.
+4. `ConnectionManager.tsx`: call `beginConnectionSwitch` first at select/add/remove‑active, with failure cleanup.
+5. `providers.tsx`: `fetchInfo` pin + token guards (post‑`text()` check, `!== undefined`).
+6. `providers.tsx`: `fetchMetaStats` forward pin + guarded callbacks.
+7. `providers.tsx`: `fetchCount` optional `isCurrent` before count writes.
+8. `providers.tsx`: `runQuery` capture tokens; pin all; guard after `Promise.all`, after `/explain`, before `Graph.create`, before success apply, in catch, in `finally` (owner‑based loading release).
+9. `providers.tsx`: `handleFetchOptions` guard list + auto‑select via `optionsSeq`+`contextGen`; route auto‑select through `commitGraphName`.
+10. `selectGraph.tsx`: use guarded `handleFetchOptions` for the dropdown refresh.
+11. `e2e/tests/connectionSwitchRace.spec.ts`: the 6 races (must fail pre‑fix).
+12. Full CI command set; iterate to green.
+
+---
+
+## 9. Effort / sequencing note
+This is genuinely a **large, multi‑file concurrency change** (providers.tsx, lib/utils.ts,
+model.ts/GraphInfo, ConnectionManager.tsx, selectGraph.tsx, new e2e). Suggested landing order behind
+the tokens: (a) `commitGraphName` + tokens + `runQuery` guards, (b) `fetchInfo`/`fetchMetaStats`/
+`fetchCount` pins, (c) `handleFetchOptions` + `selectGraph` + `fetchOptions`, (d) `GraphInfo` pin, (e)
+switch gate, (f) e2e — each step green before the next.
+
+---
+
+## 10. Rubber‑duck findings addressed (traceability)
+**Round 1** — auto‑select unguarded → §3g/§3h; 2nd `fetchOptions` caller → §3i; `runQuery`
+catch/`finally` → §3f.5–6; guarded callbacks not threaded → §3c/§3d + guarded direct info toast;
+epoch insufficient → §2 tokens; unpinned `GraphInfo` fallback → §4; transition window → §2 gate;
+`??` vs `!== undefined` → §3c; post‑`text()` discard → §3c; `fetchInfo` sole caller is `runQuery` → §3c.
+**Round 2** — pre‑create guard TOCTOU → §4 (pin now, not defer); single `opGen` couples ops → §2 four
+separate tokens; `fetchCount` count write not generation‑guarded → §3e; graph‑name bumping not
+centralized → §3a `commitGraphName` (covers `:915/:1407/:1417/:1498` + auto‑select); loading ownership →
+`loadingOwnerRef` + `page.tsx:347` guard (§3f.6/§7); switch‑gate lifecycle (no‑op active, updateSession
+reject, add/remove sites, latest ownership) → §3b; new tests (out‑of‑order, overlap, fallback, spinner)
+→ §5b #3/#4/#6.
+**Round 3** — switch gate must block on "ticket exists" (not global≠React, unreliable via `~966`
+render‑sync) + mutate ids only after a successful `updateSession` + ticket `complete`/`cancel` API +
+remove‑active recovery → §2/§3b; `handleFetchOptions` must **not** destructively blank the list (keep
+last good list on refresh/error; only reset clears) → §3h; `GraphInfo` pin must bind onto the supplied
+instance and survive `clone()`/`empty()` (passing `cid` to `Graph.create` alone is insufficient —
+`model.ts:470‑476`) → §4; `commitGraphName` must set `activeGraphNameRef.current` synchronously and
+`runQuery` read from it → §3a. Confirmed sound by the reviewer: `querySeq`/`optionsSeq` independence,
+`isCurrent` in `fetchCount`, all `setGraphName` sites covered, single external loading clear, no
+self‑invalidation in the normal flow, and the begin/reset double‑bump being harmless (equality tokens).
+
+---
+
+## 11. Open decisions for you
+1. **Target branch** — `staging` (normal promotion) or `main` directly? Plan assumes **`staging`**.
+2. **Abort on switch** — out of scope (the token guard already prevents stale *applies*), or also add
+   `AbortController` to stop wasted work now? Plan assumes **out of scope** (follow‑up).
+3. **Token extraction** — inline refs in `providers.tsx`, or a small pure `lib/opGuards.ts` for unit
+   tests + reuse? Plan assumes **inline first**, extract only if it eases testing.

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -256,8 +256,8 @@ describe("getMetaStats", () => {
 describe("connection epoch", () => {
   afterEach(() => setActiveConnectionIdGlobal(null));
 
-  it("increments only when the active connection id actually changes", () => {
-    setActiveConnectionIdGlobal("a");
+  it("increments only when switching away from an established connection", () => {
+    setActiveConnectionIdGlobal("a"); // null→id establishment → no bump
     const e1 = getConnectionEpoch();
     setActiveConnectionIdGlobal("a"); // same id → no bump
     assert.equal(getConnectionEpoch(), e1);
@@ -265,6 +265,15 @@ describe("connection epoch", () => {
     assert.equal(getConnectionEpoch(), e1 + 1);
     setActiveConnectionIdGlobal(null); // change → bump
     assert.equal(getConnectionEpoch(), e1 + 2);
+  });
+
+  it("does not bump on the initial null -> id establishment (first page load)", () => {
+    setActiveConnectionIdGlobal(null);
+    const e0 = getConnectionEpoch();
+    setActiveConnectionIdGlobal("a"); // establish → no bump, so the first load isn't discarded
+    assert.equal(getConnectionEpoch(), e0);
+    setActiveConnectionIdGlobal("b"); // real switch → bump
+    assert.equal(getConnectionEpoch(), e0 + 1);
   });
 
   it("detects A -> B -> A as a change (epoch differs from the first A)", () => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -642,7 +642,11 @@ let _activeConnectionId: string | null = null;
 let _connectionEpoch = 0;
 
 export function setActiveConnectionIdGlobal(id: string | null) {
-  if (id !== _activeConnectionId) _connectionEpoch += 1;
+  // Bump only when switching AWAY from an already-established connection (the old
+  // id is non-null). The initial null→id establishment on every page load is not
+  // a "switch" and must not discard the first graph-list load / query, which
+  // capture the epoch before the connection id settles.
+  if (_activeConnectionId !== null && id !== _activeConnectionId) _connectionEpoch += 1;
   _activeConnectionId = id;
 }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1147,10 +1147,9 @@ export async function fetchOptions(
   toast: ToastFn,
   setIndicator: (indicator: "online" | "offline") => void,
   indicator: "online" | "offline",
-  setSelectedValue: (value: string) => void,
-  setOptions: (options: string[]) => void,
-) {
-  if (indicator === "offline") return;
+  connectionId?: string | null,
+): Promise<{ opts: string[]; autoSelect: string | null } | null> {
+  if (indicator === "offline") return null;
 
   const result = await securedFetch(
     `/api/graph`,
@@ -1158,17 +1157,17 @@ export async function fetchOptions(
       method: "GET",
     },
     toast,
-    setIndicator
+    setIndicator,
+    connectionId,
   );
 
-  if (!result.ok) return;
-
+  if (!result.ok) return null;
 
   const { opts } = (await result.json()) as { opts: string[] };
 
-  setOptions(opts);
-
-  if (opts.length === 1) setSelectedValue(formatName(opts[0]));
+  // Return the data so callers can apply it under their own ownership guard
+  // (a stale refresh must not overwrite the list/selection after a switch).
+  return { opts, autoSelect: opts.length === 1 ? formatName(opts[0]) : null };
 }
 
 export const areCaptionKeysEqual = (left: [string, boolean][], right: [string, boolean][]) =>


### PR DESCRIPTION
## What & why

Closes the connection-safety AI-review threads on #1934 — CodeRabbit's `app/providers.tsx:767` (runQuery/fetchInfo/graph-list) and `UploadGraph.tsx:373` (ingestion flow). Fixes races where a **connection switch**, a **graph switch**, or a **newer query** could apply stale results — or **auto-create a ghost graph** on the wrong connection.

Design in `idea-6-connection-epoch-pinning-plan.md` (three rubber-duck rounds; the reviewer confirmed the four-token design sound).

## Implementation
- **Four ownership refs** in `providers.tsx`: `contextGen` (connection/graph), `querySeq` (newest query), `optionsSeq` (newest list refresh), `loadingOwner` (spinner) + a **ticket/counter switch gate** (serializes overlapping switches, ignores out-of-order completions, can't get stuck).
- **`runQuery`**: capture `{querySeq, contextGen, connectionId, epoch}`; pin every request; guard after each await, before `Graph.create`, before the success apply, in `catch`, and in `finally` (owner-based loading release).
- **`fetchInfo`/`fetchMetaStats`/`fetchCount`**: accept a pin + guarded callbacks; count write is ownership-guarded.
- **`handleFetchOptions`** (non-destructive) + **`selectGraph`** refresh (epoch + own sequence) + **`handleSetGraphName`** (authoritative graph-name commit).
- **`GraphInfo`** (model.ts): `connectionId` threaded onto the instance (survives `clone`/`empty`) so the metadata fallback is pinned — closes the mid-`Graph.create` TOCTOU.
- **`ConnectionManager`**: ticket-based switch gate at select/add/remove-active; mutate React state only after `updateSession` succeeds (rollback on failure).
- **`UploadGraph`**: pin the cypher/CSV ingestion flow to its initiating connection and discard the UI apply if the connection changed.
- Regression fix: epoch no longer bumps on the initial `null→id` establishment (that was discarding the first load on every page open).

## Validation
- [x] `npm test` / `test:coverage` (100%) / `npm run lint` (0 errors) / `npx tsc --noEmit` — all green
- [x] CI: full Playwright suite green (regression-tests runQuery/selection/uploads/connections — the changed surfaces)
- [x] Code-review pass on the implementation (1 issue found + fixed: URL→graph sync now routes through `handleSetGraphName`)
- [x] Dedicated race e2e test — `e2e/tests/graphOperationRace.spec.ts`: deterministically holds a graph's query in-flight (`page.route`), switches graph, releases it, and asserts the stale result is discarded (not applied). Implemented as a **graph-switch stale-apply** race (reliable, deterministic) rather than the flakier 2-connection UI variant; the connection-switch path shares the same guard and is regression-covered by the existing suite.

Not merging without your approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale graph/query, metadata, and graph-list results (including auto-selection) from overwriting newer UI state during rapid connection/graph changes.
  * Improved connection switching by gating in-flight graph operations and preventing inconsistent UI updates on connection failures.
  * Pinned graph upload/LOAD CSV ingestion and post-run refresh counts to the connection active at run start.
* **Tests**
  * Added an end-to-end regression test covering graph operation race conditions.
  * Updated connection-epoch test coverage to match the new epoch-bump semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->