### PR TITLE
fix(connection): serialize + validate the switch session mutation (idea-7)

### DIFF
--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -26,6 +26,9 @@ export default function ConnectionManager() {
     updateSession,
     beginConnectionSwitch,
     endConnectionSwitch,
+    handoffConnectionSwitch,
+    isConnectionSwitchInProgress,
+    getLastCommittedConnId,
     isLatestSwitch,
   } = useContext(ConnectionContext);
 
@@ -41,33 +44,42 @@ export default function ConnectionManager() {
     // if the user starts a newer switch before this one resolves.
     const ticket = beginConnectionSwitch();
     // Set the global ID immediately so periodic timers (memory, count, etc.)
-    // that fire DURING the updateSession await use the correct connection and
-    // don't fall back to Token DB which might pick the wrong entry.
+    // that fire DURING the commit use the correct connection.
     setActiveConnectionIdGlobal(connId);
     localStorage.setItem("lastActiveConnectionId", connId);
-    // Update the JWT so session.user.role is correct before React effects
-    // (graph-list reload, query execution) fire. The JWT callback looks up
-    // the connection details from Token DB.
+    let handedOff = false;
     try {
+      // Commit the JWT (serialized + validated). Throws on failure so we roll back.
       await updateSession({ activeConnectionId: connId });
+      if (!isLatestSwitch(ticket)) {
+        // A newer switch superseded this one — don't publish this (older) target;
+        // the finally releases this switch's gate ticket.
+        return;
+      }
+      // Publish React state AFTER the JWT commit, and hand this ticket to the reset
+      // effect so the gate stays closed until graph state is re-pinned.
+      handoffConnectionSwitch(ticket, connId);
+      handedOff = true;
+      setActiveConnectionId(connId);
     } catch (error) {
-      // Roll back so ids stay consistent and graph ops are unblocked again.
-      if (isLatestSwitch(ticket)) setActiveConnectionIdGlobal(activeConnectionId);
-      endConnectionSwitch();
       console.error("Failed to switch connection:", error);
-      return;
+      if (isLatestSwitch(ticket)) {
+        // Converge all three states on the last validated connection (which
+        // exists), not on this failed target.
+        const rollbackId = getLastCommittedConnId() ?? activeConnectionId;
+        setActiveConnectionIdGlobal(rollbackId);
+        if (rollbackId !== null) localStorage.setItem("lastActiveConnectionId", rollbackId);
+        if (rollbackId !== activeConnectionId) {
+          // The rollback changes React state → release via that reset effect too.
+          handoffConnectionSwitch(ticket, rollbackId);
+          handedOff = true;
+          setActiveConnectionId(rollbackId);
+        }
+      }
+    } finally {
+      if (!handedOff) endConnectionSwitch(ticket);
     }
-    if (!isLatestSwitch(ticket)) {
-      // A newer switch superseded this one — don't publish this (older) target as
-      // active; just release this switch's gate slot.
-      endConnectionSwitch();
-      return;
-    }
-    // Update React state AFTER the JWT is updated so the prevActiveConnectionId
-    // effect fires with the correct role already in sessionData; that reset
-    // effect also clears this switch's gate slot.
-    setActiveConnectionId(connId);
-  }, [activeConnectionId, setActiveConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch, isLatestSwitch]);
+  }, [activeConnectionId, setActiveConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch, handoffConnectionSwitch, getLastCommittedConnId, isLatestSwitch]);
 
   // Determine whether the user only has one connection. The session always
   // has at least one (the primary), so we treat an empty additionalConnections
@@ -89,48 +101,86 @@ export default function ConnectionManager() {
     const { conn, isLast } = removeTarget;
     const connId = conn.id;
 
+    // If this is the last connection, sign out instead (before any switch/ticket).
+    if (isLast) {
+      setRemoving(true);
+      try {
+        await signOut({ callbackUrl: "/login" });
+      } finally {
+        setRemoving(false);
+      }
+      return;
+    }
+
+    // Don't remove while a connection switch is mid-flight — the gate set can't
+    // identify the in-flight target, so block all removals (safe + simple).
+    if (isConnectionSwitchInProgress()) {
+      toast({ title: "Please wait for the connection switch to finish", variant: "destructive" });
+      return;
+    }
+
     setRemoving(true);
     try {
-      // If this is the last connection, sign out instead.
-      if (isLast) {
-        await signOut({ callbackUrl: "/login" });
+      const removingActive = activeConnectionId === connId;
+      const remaining = additionalConnections.filter(c => c.id !== connId);
+
+      if (removingActive && remaining.length > 0) {
+        // Commit-before-delete: move the session to a valid replacement BEFORE
+        // deleting the old row, so the JWT never points at a deleted connection.
+        const newActive = remaining[remaining.length - 1].id;
+        const ticket = beginConnectionSwitch();
+        setActiveConnectionIdGlobal(newActive);
+        localStorage.setItem("lastActiveConnectionId", newActive);
+        let handedOff = false;
+        try {
+          await updateSession({ activeConnectionId: newActive });
+          if (!isLatestSwitch(ticket)) { setRemoveTarget(null); return; }
+          handoffConnectionSwitch(ticket, newActive);
+          handedOff = true;
+          setActiveConnectionId(newActive);
+        } catch (error) {
+          console.error("Failed to switch connection after removal:", error);
+          toast({ title: "Failed to switch to remaining connection", variant: "destructive" });
+          if (isLatestSwitch(ticket)) {
+            const rollbackId = getLastCommittedConnId() ?? activeConnectionId;
+            setActiveConnectionIdGlobal(rollbackId);
+            if (rollbackId !== null) localStorage.setItem("lastActiveConnectionId", rollbackId);
+            if (rollbackId !== activeConnectionId) {
+              handoffConnectionSwitch(ticket, rollbackId);
+              handedOff = true;
+              setActiveConnectionId(rollbackId);
+            }
+          }
+          setRemoveTarget(null);
+          return;   // nothing deleted — the old connection is still valid
+        } finally {
+          if (!handedOff) endConnectionSwitch(ticket);
+        }
+      }
+
+      // Only now delete the (no-longer-active) old connection.
+      let result: Response;
+      try {
+        result = await securedFetch(`/api/connections/${encodeURIComponent(connId)}`, {
+          method: "DELETE",
+        }, toast, setIndicator);
+      } catch (error) {
+        // Ambiguous network failure — don't assume the row survived; refetch the list.
+        console.error("Failed to remove connection:", error);
+        try {
+          const listRes = await securedFetch("/api/connections", { method: "GET" }, toast, setIndicator);
+          if (listRes.ok) {
+            const listJson = await listRes.json();
+            if (listJson?.connections) setAdditionalConnections(listJson.connections);
+          }
+        } catch { /* best-effort refresh */ }
+        setRemoveTarget(null);
         return;
       }
 
-      const result = await securedFetch(`/api/connections/${encodeURIComponent(connId)}`, {
-        method: "DELETE",
-      }, toast, setIndicator);
-
       if (result.ok) {
-        const remaining = additionalConnections.filter(c => c.id !== connId);
+        // Update the list only after a successful DELETE.
         setAdditionalConnections(remaining);
-
-        // If we removed the active connection, switch to the last remaining one.
-        if (activeConnectionId === connId && remaining.length > 0) {
-          const newActive = remaining[remaining.length - 1].id;
-          const ticket = beginConnectionSwitch();
-          setActiveConnectionIdGlobal(newActive);
-          localStorage.setItem("lastActiveConnectionId", newActive);
-          try {
-            await updateSession({ activeConnectionId: newActive });
-          } catch (error) {
-            if (isLatestSwitch(ticket)) setActiveConnectionIdGlobal(activeConnectionId);
-            endConnectionSwitch();
-            console.error("Failed to switch connection after removal:", error);
-            toast({ title: "Failed to switch to remaining connection", variant: "destructive" });
-            setRemoveTarget(null);
-            return;
-          }
-
-          if (!isLatestSwitch(ticket)) {
-            endConnectionSwitch();
-            setRemoveTarget(null);
-            return;
-          }
-
-          setActiveConnectionId(newActive);
-        }
-
         toast({ title: "Connection removed" });
       } else {
         toast({ title: "Failed to remove connection", variant: "destructive" });
@@ -142,7 +192,7 @@ export default function ConnectionManager() {
     } finally {
       setRemoving(false);
     }
-  }, [removeTarget, toast, additionalConnections, setAdditionalConnections, activeConnectionId, setActiveConnectionId, setIndicator, updateSession, beginConnectionSwitch, endConnectionSwitch, isLatestSwitch]);
+  }, [removeTarget, toast, additionalConnections, setAdditionalConnections, activeConnectionId, setActiveConnectionId, setIndicator, updateSession, beginConnectionSwitch, endConnectionSwitch, handoffConnectionSwitch, isConnectionSwitchInProgress, getLastCommittedConnId, isLatestSwitch]);
 
   const handleAddConnection = useCallback(async (credentials: LoginFormCredentials) => {
     const result = await securedFetch("/api/connections", {
@@ -162,32 +212,39 @@ export default function ConnectionManager() {
       const json = await result.json();
       const newConn = json.connection;
       setAdditionalConnections((prev) => [...prev, newConn]);
-      // Auto-switch to the newly added connection
+      // Auto-switch to the newly added connection.
       const ticket = beginConnectionSwitch();
       setActiveConnectionIdGlobal(newConn.id);
       localStorage.setItem("lastActiveConnectionId", newConn.id);
+      let handedOff = false;
       try {
         await updateSession({ activeConnectionId: newConn.id });
+        if (!isLatestSwitch(ticket)) return;
+        handoffConnectionSwitch(ticket, newConn.id);
+        handedOff = true;
+        setActiveConnectionId(newConn.id);
+        toast({ title: `Connection added for ${credentials.username}` });
+        setDialogOpen(false);
       } catch (error) {
-        if (isLatestSwitch(ticket)) setActiveConnectionIdGlobal(activeConnectionId);
-        endConnectionSwitch();
         console.error("Failed to switch to new connection:", error);
         toast({ title: "Connection added but switch failed", variant: "destructive" });
-        return;
+        if (isLatestSwitch(ticket)) {
+          const rollbackId = getLastCommittedConnId() ?? activeConnectionId;
+          setActiveConnectionIdGlobal(rollbackId);
+          if (rollbackId !== null) localStorage.setItem("lastActiveConnectionId", rollbackId);
+          if (rollbackId !== activeConnectionId) {
+            handoffConnectionSwitch(ticket, rollbackId);
+            handedOff = true;
+            setActiveConnectionId(rollbackId);
+          }
+        }
+      } finally {
+        if (!handedOff) endConnectionSwitch(ticket);
       }
-
-      if (!isLatestSwitch(ticket)) {
-        endConnectionSwitch();
-        return;
-      }
-
-      setActiveConnectionId(newConn.id);
-      toast({ title: `Connection added for ${credentials.username}` });
-      setDialogOpen(false);
     } else {
       throw new Error("Failed to add connection");
     }
-  }, [toast, setAdditionalConnections, setIndicator, setActiveConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch, isLatestSwitch, activeConnectionId]);
+  }, [toast, setAdditionalConnections, setIndicator, setActiveConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch, handoffConnectionSwitch, getLastCommittedConnId, isLatestSwitch, activeConnectionId]);
 
   // Use the explicitly active connection, or fall back to the first one while
   // activeConnectionId is still being resolved (e.g. on initial page load).

--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -192,6 +192,8 @@ export default function ConnectionManager() {
       } catch (error) {
         // Ambiguous network failure — don't assume the row survived; refetch the list.
         console.error("Failed to remove connection:", error);
+        // securedFetch only toasts for HTTP responses, so surface the thrown error.
+        toast({ title: "Failed to remove connection", variant: "destructive" });
         try {
           const listRes = await securedFetch("/api/connections", { method: "GET" }, toast, setIndicator);
           if (listRes.ok) {

--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useContext, useState } from "react";
+import { useCallback, useContext, useRef, useState } from "react";
 import { signOut, useSession } from "next-auth/react";
 import { Check, ChevronDown, LogOut, Plus } from "lucide-react";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -35,10 +35,19 @@ export default function ConnectionManager() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<{ conn: SessionConnection; isLast: boolean } | null>(null);
   const [removing, setRemoving] = useState(false);
+  // Mirrors `removing` synchronously so handleSelect can block a switch while a
+  // removal (commit + DELETE) is mid-flight — the two must be mutually exclusive
+  // so a select can't target a connection that is being deleted.
+  const removingRef = useRef(false);
 
   const handleSelect = useCallback(async (connId: string) => {
-    // Clicking the already-active connection is a no-op (avoids a stuck gate).
-    if (connId === activeConnectionId) return;
+    // A no-op only when nothing is pending; while a switch is in flight, re-selecting
+    // the displayed connection must be allowed so it can supersede the pending one
+    // (e.g. A→B→A must end on A, not B).
+    if (connId === activeConnectionId && !isConnectionSwitchInProgress()) return;
+    // Mutually exclusive with a removal: don't switch onto a connection whose DELETE
+    // may be in flight.
+    if (removingRef.current) return;
     // Block/supersede graph ops while the switch is mid-flight (its global id and
     // React state briefly disagree). The ticket lets us ignore a stale completion
     // if the user starts a newer switch before this one resolves.
@@ -56,11 +65,20 @@ export default function ConnectionManager() {
         // the finally releases this switch's gate ticket.
         return;
       }
-      // Publish React state AFTER the JWT commit, and hand this ticket to the reset
-      // effect so the gate stays closed until graph state is re-pinned.
-      handoffConnectionSwitch(ticket, connId);
-      handedOff = true;
-      setActiveConnectionId(connId);
+      if (connId === activeConnectionId) {
+        // React already shows this connection (A→B→A): setActiveConnectionId would
+        // be a no-op so the reset effect won't fire — release the ticket directly
+        // and re-pin the global rather than handing off to an effect that won't run.
+        setActiveConnectionIdGlobal(connId);
+        endConnectionSwitch(ticket);
+        handedOff = true;
+      } else {
+        // Publish React state AFTER the JWT commit, and hand this ticket to the reset
+        // effect so the gate stays closed until graph state is re-pinned.
+        handoffConnectionSwitch(ticket, connId);
+        handedOff = true;
+        setActiveConnectionId(connId);
+      }
     } catch (error) {
       console.error("Failed to switch connection:", error);
       if (isLatestSwitch(ticket)) {
@@ -69,6 +87,7 @@ export default function ConnectionManager() {
         const rollbackId = getLastCommittedConnId() ?? activeConnectionId;
         setActiveConnectionIdGlobal(rollbackId);
         if (rollbackId !== null) localStorage.setItem("lastActiveConnectionId", rollbackId);
+        else localStorage.removeItem("lastActiveConnectionId");
         if (rollbackId !== activeConnectionId) {
           // The rollback changes React state → release via that reset effect too.
           handoffConnectionSwitch(ticket, rollbackId);
@@ -79,7 +98,7 @@ export default function ConnectionManager() {
     } finally {
       if (!handedOff) endConnectionSwitch(ticket);
     }
-  }, [activeConnectionId, setActiveConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch, handoffConnectionSwitch, getLastCommittedConnId, isLatestSwitch]);
+  }, [activeConnectionId, setActiveConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch, handoffConnectionSwitch, isConnectionSwitchInProgress, getLastCommittedConnId, isLatestSwitch]);
 
   // Determine whether the user only has one connection. The session always
   // has at least one (the primary), so we treat an empty additionalConnections
@@ -104,10 +123,12 @@ export default function ConnectionManager() {
     // If this is the last connection, sign out instead (before any switch/ticket).
     if (isLast) {
       setRemoving(true);
+      removingRef.current = true;
       try {
         await signOut({ callbackUrl: "/login" });
       } finally {
         setRemoving(false);
+        removingRef.current = false;
       }
       return;
     }
@@ -120,6 +141,9 @@ export default function ConnectionManager() {
     }
 
     setRemoving(true);
+    // Held through the whole commit + DELETE so handleSelect can't switch onto the
+    // connection being deleted (mutual exclusion).
+    removingRef.current = true;
     try {
       const removingActive = activeConnectionId === connId;
       const remaining = additionalConnections.filter(c => c.id !== connId);
@@ -145,6 +169,7 @@ export default function ConnectionManager() {
             const rollbackId = getLastCommittedConnId() ?? activeConnectionId;
             setActiveConnectionIdGlobal(rollbackId);
             if (rollbackId !== null) localStorage.setItem("lastActiveConnectionId", rollbackId);
+            else localStorage.removeItem("lastActiveConnectionId");
             if (rollbackId !== activeConnectionId) {
               handoffConnectionSwitch(ticket, rollbackId);
               handedOff = true;
@@ -191,6 +216,7 @@ export default function ConnectionManager() {
       setRemoveTarget(null);
     } finally {
       setRemoving(false);
+      removingRef.current = false;
     }
   }, [removeTarget, toast, additionalConnections, setAdditionalConnections, activeConnectionId, setActiveConnectionId, setIndicator, updateSession, beginConnectionSwitch, endConnectionSwitch, handoffConnectionSwitch, isConnectionSwitchInProgress, getLastCommittedConnId, isLatestSwitch]);
 
@@ -232,6 +258,7 @@ export default function ConnectionManager() {
           const rollbackId = getLastCommittedConnId() ?? activeConnectionId;
           setActiveConnectionIdGlobal(rollbackId);
           if (rollbackId !== null) localStorage.setItem("lastActiveConnectionId", rollbackId);
+          else localStorage.removeItem("lastActiveConnectionId");
           if (rollbackId !== activeConnectionId) {
             handoffConnectionSwitch(ticket, rollbackId);
             handedOff = true;

--- a/app/components/provider.ts
+++ b/app/components/provider.ts
@@ -237,11 +237,18 @@ type ConnectionContextType = {
   setActiveConnectionId: Dispatch<SetStateAction<string | null>>;
   updateSession: (data: { activeConnectionId?: string | null }) => Promise<unknown>;
   // Mark a user connection switch as in-progress (blocks graph ops + supersedes
-  // in-flight ones) and clear it once the switch settles. `beginConnectionSwitch`
+  // in-flight ones) and release it once the switch settles. `beginConnectionSwitch`
   // returns a ticket; `isLatestSwitch(ticket)` reports whether it is still the
   // newest switch, so out-of-order completions don't publish a stale connection.
+  // The winning/rollback ticket is handed to the reset effect via
+  // `handoffConnectionSwitch` (keyed by target); others are released by the caller
+  // via `endConnectionSwitch(ticket)`. `isConnectionSwitchInProgress` gates graph
+  // ops and blocks removals; `getLastCommittedConnId` is the last validated commit.
   beginConnectionSwitch: () => number;
-  endConnectionSwitch: () => void;
+  endConnectionSwitch: (ticket: number) => void;
+  handoffConnectionSwitch: (ticket: number, targetId: string | null) => void;
+  isConnectionSwitchInProgress: () => boolean;
+  getLastCommittedConnId: () => string | null;
   isLatestSwitch: (ticket: number) => boolean;
 };
 
@@ -503,6 +510,9 @@ export const ConnectionContext = createContext<ConnectionContextType>({
   updateSession: async () => { },
   beginConnectionSwitch: () => 0,
   endConnectionSwitch: () => { },
+  handoffConnectionSwitch: () => { },
+  isConnectionSwitchInProgress: () => false,
+  getLastCommittedConnId: () => null,
   isLatestSwitch: () => true,
 });
 

--- a/app/components/serializedRunner.test.ts
+++ b/app/components/serializedRunner.test.ts
@@ -238,6 +238,17 @@ describe("commitWithValidation", () => {
     assert.deepEqual(result, { activeConnectionId: null });
   });
 
+  it("labels the error 'null' when a null-target commit exhausts its retries", async () => {
+    await assert.rejects(
+      () => commitWithValidation(
+        null,
+        makeDeps({ update: async () => ({ activeConnectionId: "conn-x" }) }),
+        { ...fastOpts, maxAttempts: 2 },
+      ),
+      /Failed to commit active connection null to session/,
+    );
+  });
+
   it("uses default options when none are provided", async () => {
     const result = await commitWithValidation(
       "conn-A",

--- a/app/components/serializedRunner.test.ts
+++ b/app/components/serializedRunner.test.ts
@@ -137,6 +137,7 @@ function makeDeps(overrides: Partial<CommitDeps> & { committed?: string[] } = {}
     update: overrides.update ?? (async () => ({ activeConnectionId: null })),
     getStatus: overrides.getStatus ?? (() => "authenticated"),
     onCommitted: overrides.onCommitted ?? ((id) => { committed.push(id ?? "null"); }),
+    isCancelled: overrides.isCancelled,
   };
 }
 
@@ -148,11 +149,24 @@ describe("commitWithValidation", () => {
     const result = await commitWithValidation(
       "conn-C",
       makeDeps({ update: async () => ({ activeConnectionId: "conn-C" }), committed,
-        onCommitted: (id) => { committed.push(id ?? "null"); } }),
+        onCommitted: (id) => { committed.push(id ?? "null"); }, isCancelled: () => false }),
       fastOpts,
     );
     assert.deepEqual(result, { activeConnectionId: "conn-C" });
     assert.deepEqual(committed, ["conn-C"]);
+  });
+
+  it("aborts a cancelled commit without calling update", async () => {
+    let updateCalls = 0;
+    await assert.rejects(
+      () => commitWithValidation(
+        "conn-C",
+        makeDeps({ isCancelled: () => true, update: async () => { updateCalls += 1; return { activeConnectionId: "conn-C" }; } }),
+        fastOpts,
+      ),
+      /Commit for conn-C cancelled \(auth changed\)/,
+    );
+    assert.equal(updateCalls, 0, "a cancelled commit never performs a write");
   });
 
   it("retries past a no-op (undefined) result then commits", async () => {

--- a/app/components/serializedRunner.test.ts
+++ b/app/components/serializedRunner.test.ts
@@ -1,0 +1,248 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createSerializedRunner,
+  waitUntil,
+  commitWithValidation,
+  delay,
+  type CommitDeps,
+} from "./serializedRunner.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// Flush pending microtasks + one macrotask so chained .then callbacks run.
+const tick = () => new Promise((resolve) => { setTimeout(resolve, 0); });
+
+const noopSleep = async () => {};
+
+// ---------------------------------------------------------------------------
+// createSerializedRunner
+// ---------------------------------------------------------------------------
+
+describe("createSerializedRunner", () => {
+  it("runs calls in submission order, never overlapping, even when they complete out of order", async () => {
+    const started: string[] = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const gates: Record<string, ReturnType<typeof deferred<string>>> = {};
+
+    const run = createSerializedRunner((id: string) => {
+      started.push(id);
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      const g = deferred<string>();
+      gates[id] = g;
+      return g.promise.finally(() => { inFlight -= 1; });
+    });
+
+    const pA = run("A");
+    const pB = run("B");
+    const pC = run("C");
+    await tick();
+    assert.deepEqual(started, ["A"], "only the first call starts");
+
+    gates.A.resolve("ra");
+    assert.equal(await pA, "ra");
+    await tick();
+    assert.deepEqual(started, ["A", "B"]);
+
+    gates.B.resolve("rb");
+    assert.equal(await pB, "rb");
+    await tick();
+    assert.deepEqual(started, ["A", "B", "C"]);
+
+    gates.C.resolve("rc");
+    assert.equal(await pC, "rc");
+    assert.equal(maxInFlight, 1, "at most one call in flight at a time");
+  });
+
+  it("surfaces each caller's own rejection and does not break the chain", async () => {
+    const run = createSerializedRunner((id: string) =>
+      id === "B" ? Promise.reject(new Error("boom")) : Promise.resolve(id));
+
+    const pA = run("A");
+    const pB = run("B");
+    const pC = run("C");
+
+    assert.equal(await pA, "A");
+    await assert.rejects(() => pB, /boom/);
+    assert.equal(await pC, "C", "a rejected call does not stall later calls");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// waitUntil
+// ---------------------------------------------------------------------------
+
+describe("waitUntil", () => {
+  it("returns true immediately when the predicate already holds", async () => {
+    const ok = await waitUntil(() => true, 1000, { sleep: noopSleep, now: () => 0 });
+    assert.equal(ok, true);
+  });
+
+  it("returns true once the predicate becomes true", async () => {
+    let calls = 0;
+    const ok = await waitUntil(() => { calls += 1; return calls >= 3; }, 1000, {
+      sleep: noopSleep,
+      now: () => 0,
+    });
+    assert.equal(ok, true);
+    assert.equal(calls, 3);
+  });
+
+  it("returns false when the timeout elapses first", async () => {
+    let t = 0;
+    const ok = await waitUntil(() => false, 100, {
+      sleep: noopSleep,
+      now: () => { const v = t; t += 1000; return v; },
+    });
+    assert.equal(ok, false);
+  });
+
+  it("works with the real default timer path", async () => {
+    let ready = false;
+    setTimeout(() => { ready = true; }, 5);
+    const ok = await waitUntil(() => ready, 1000, { intervalMs: 1 });
+    assert.equal(ok, true);
+  });
+});
+
+describe("delay", () => {
+  it("resolves after the given time", async () => {
+    const start = Date.now();
+    await delay(5);
+    assert.ok(Date.now() - start >= 4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commitWithValidation
+// ---------------------------------------------------------------------------
+
+function makeDeps(overrides: Partial<CommitDeps> & { committed?: string[] } = {}): CommitDeps {
+  const committed = overrides.committed ?? [];
+  return {
+    update: overrides.update ?? (async () => ({ activeConnectionId: null })),
+    getStatus: overrides.getStatus ?? (() => "authenticated"),
+    onCommitted: overrides.onCommitted ?? ((id) => { committed.push(id ?? "null"); }),
+  };
+}
+
+const fastOpts = { sleep: noopSleep, now: () => 0, readyTimeoutMs: 100, backoffMs: 0 };
+
+describe("commitWithValidation", () => {
+  it("commits when the returned session reflects the target and records it", async () => {
+    const committed: string[] = [];
+    const result = await commitWithValidation(
+      "conn-C",
+      makeDeps({ update: async () => ({ activeConnectionId: "conn-C" }), committed,
+        onCommitted: (id) => { committed.push(id ?? "null"); } }),
+      fastOpts,
+    );
+    assert.deepEqual(result, { activeConnectionId: "conn-C" });
+    assert.deepEqual(committed, ["conn-C"]);
+  });
+
+  it("retries past a no-op (undefined) result then commits", async () => {
+    let attempts = 0;
+    const result = await commitWithValidation(
+      "conn-C",
+      makeDeps({
+        update: async () => {
+          attempts += 1;
+          return attempts === 1 ? undefined : { activeConnectionId: "conn-C" };
+        },
+      }),
+      fastOpts,
+    );
+    assert.deepEqual(result, { activeConnectionId: "conn-C" });
+    assert.equal(attempts, 2);
+  });
+
+  it("throws after maxAttempts when update keeps returning null (transport error)", async () => {
+    let attempts = 0;
+    await assert.rejects(
+      () => commitWithValidation(
+        "conn-C",
+        makeDeps({ update: async () => { attempts += 1; return null; } }),
+        { ...fastOpts, maxAttempts: 3 },
+      ),
+      /Failed to commit active connection conn-C/,
+    );
+    assert.equal(attempts, 3);
+  });
+
+  it("retries when the returned activeConnectionId does not match the target", async () => {
+    let attempts = 0;
+    await assert.rejects(
+      () => commitWithValidation(
+        "conn-C",
+        makeDeps({ update: async () => { attempts += 1; return { activeConnectionId: "conn-B" }; } }),
+        { ...fastOpts, maxAttempts: 2 },
+      ),
+      /Failed to commit/,
+    );
+    assert.equal(attempts, 2);
+  });
+
+  it("waits until the provider is authenticated before committing", async () => {
+    let statusCalls = 0;
+    let updateCalls = 0;
+    const result = await commitWithValidation(
+      "conn-C",
+      makeDeps({
+        getStatus: () => { statusCalls += 1; return statusCalls >= 3 ? "authenticated" : "loading"; },
+        update: async () => { updateCalls += 1; return { activeConnectionId: "conn-C" }; },
+      }),
+      fastOpts,
+    );
+    assert.deepEqual(result, { activeConnectionId: "conn-C" });
+    assert.equal(updateCalls, 1, "update only fires once the provider is ready");
+  });
+
+  it("fails the attempt (no update) when the ready-wait times out", async () => {
+    let updateCalls = 0;
+    let t = 0;
+    await assert.rejects(
+      () => commitWithValidation(
+        "conn-C",
+        makeDeps({
+          getStatus: () => "loading",
+          update: async () => { updateCalls += 1; return { activeConnectionId: "conn-C" }; },
+        }),
+        { sleep: noopSleep, now: () => { const v = t; t += 1000; return v; }, readyTimeoutMs: 100, backoffMs: 0, maxAttempts: 2 },
+      ),
+      /Failed to commit/,
+    );
+    assert.equal(updateCalls, 0, "update never fires while unauthenticated");
+  });
+
+  it("supports a null target and works without an onCommitted callback", async () => {
+    const result = await commitWithValidation(
+      null,
+      { update: async () => ({ activeConnectionId: null }), getStatus: () => "authenticated" },
+      fastOpts,
+    );
+    assert.deepEqual(result, { activeConnectionId: null });
+  });
+
+  it("uses default options when none are provided", async () => {
+    const result = await commitWithValidation(
+      "conn-A",
+      makeDeps({ update: async () => ({ activeConnectionId: "conn-A" }) }),
+    );
+    assert.deepEqual(result, { activeConnectionId: "conn-A" });
+  });
+});

--- a/app/components/serializedRunner.ts
+++ b/app/components/serializedRunner.ts
@@ -18,9 +18,11 @@ export const delay = (ms: number): Promise<void> =>
 export function createSerializedRunner<A extends unknown[], R>(
   fn: (...args: A) => Promise<R>,
 ): (...args: A) => Promise<R> {
+  // `tail` is kept non-rejecting (its assignment below always ends in `.catch`),
+  // so we can chain `.then` onto it directly without another guard.
   let tail: Promise<unknown> = Promise.resolve();
   return (...args: A): Promise<R> => {
-    const run = tail.catch(() => undefined).then(() => fn(...args));
+    const run = tail.then(() => fn(...args));
     // Advance the chain tail without letting a rejection break ordering.
     tail = run.catch(() => undefined);
     return run;

--- a/app/components/serializedRunner.ts
+++ b/app/components/serializedRunner.ts
@@ -67,6 +67,9 @@ export interface CommitDeps {
   getStatus: () => string;
   /** Called with the target once a commit is validated as successful. */
   onCommitted?: (targetId: string | null) => void;
+  /** Abort the commit (without a write) when it becomes stale — e.g. the auth
+   * session changed (sign-out / re-login) while this commit was queued. */
+  isCancelled?: () => boolean;
 }
 
 export interface CommitOptions {
@@ -98,6 +101,11 @@ export async function commitWithValidation(
   const sleep = opts.sleep ?? delay;
 
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    // Abandon a queued commit whose session is no longer current (e.g. the user
+    // signed out and back in while it waited) so it can't commit cross-session.
+    if (deps.isCancelled?.()) {
+      throw new Error(`Commit for ${targetId} cancelled (auth changed)`);
+    }
     const ready = await waitUntil(() => deps.getStatus() === "authenticated", readyTimeoutMs, {
       now: opts.now,
       sleep,

--- a/app/components/serializedRunner.ts
+++ b/app/components/serializedRunner.ts
@@ -1,0 +1,116 @@
+// Pure, dependency-injected helpers for serializing + validating the
+// connection-switch session mutation. Extracted from providers.tsx so they can be
+// unit-tested under node:test (route/.tsx files can't resolve @/ aliases and pull
+// in React). See idea-7-serialize-connection-switch-plan.md §3a.
+
+/** Resolves after `ms` milliseconds. */
+export const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Serializes calls to `fn` so overlapping invocations run strictly in submission
+ * order — the next call never starts until the previous one settles. The
+ * predecessor's outcome is swallowed for *sequencing* only; each caller still
+ * receives its own call's real result/rejection.
+ */
+export function createSerializedRunner<A extends unknown[], R>(
+  fn: (...args: A) => Promise<R>,
+): (...args: A) => Promise<R> {
+  let tail: Promise<unknown> = Promise.resolve();
+  return (...args: A): Promise<R> => {
+    const run = tail.catch(() => undefined).then(() => fn(...args));
+    // Advance the chain tail without letting a rejection break ordering.
+    tail = run.catch(() => undefined);
+    return run;
+  };
+}
+
+export interface WaitOptions {
+  intervalMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Polls `predicate` until it returns true or `timeoutMs` elapses. Returns whether
+ * the predicate became true within the timeout. `now`/`sleep` are injectable so
+ * tests don't rely on real timers.
+ */
+export async function waitUntil(
+  predicate: () => boolean,
+  timeoutMs: number,
+  opts: WaitOptions = {},
+): Promise<boolean> {
+  const intervalMs = opts.intervalMs ?? 50;
+  const now = opts.now ?? (() => Date.now());
+  const sleep = opts.sleep ?? delay;
+  const start = now();
+  while (!predicate()) {
+    if (now() - start >= timeoutMs) return false;
+    await sleep(intervalMs);
+  }
+  return true;
+}
+
+export interface CommitResult {
+  activeConnectionId?: string | null;
+}
+
+export interface CommitDeps {
+  /** Performs the session mutation (next-auth `useSession().update`). */
+  update: (data: { activeConnectionId?: string | null }) => Promise<unknown>;
+  /** Current next-auth session status (`"loading" | "authenticated" | ...`). */
+  getStatus: () => string;
+  /** Called with the target once a commit is validated as successful. */
+  onCommitted?: (targetId: string | null) => void;
+}
+
+export interface CommitOptions {
+  maxAttempts?: number;
+  readyTimeoutMs?: number;
+  backoffMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Commits `targetId` to the session, defeating next-auth's quirks: `update()`
+ * no-ops (returns undefined) while the provider is loading and turns transport
+ * errors into `null` rather than rejecting. So we (a) wait until the provider is
+ * authenticated, (b) accept the commit only when the returned session actually
+ * reflects `targetId`, (c) retry a bounded number of times, and (d) throw on
+ * exhaustion so callers' rollback runs. We deliberately do NOT time-box the
+ * `update()` await: a non-aborting timeout could let a stale response land after a
+ * newer commit — the very race this closes.
+ */
+export async function commitWithValidation(
+  targetId: string | null,
+  deps: CommitDeps,
+  opts: CommitOptions = {},
+): Promise<CommitResult> {
+  const maxAttempts = opts.maxAttempts ?? 3;
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 3000;
+  const backoffMs = opts.backoffMs ?? 150;
+  const sleep = opts.sleep ?? delay;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const ready = await waitUntil(() => deps.getStatus() === "authenticated", readyTimeoutMs, {
+      now: opts.now,
+      sleep,
+    });
+    if (ready) {
+      const result = (await deps.update({ activeConnectionId: targetId })) as
+        | CommitResult
+        | null
+        | undefined;
+      if (result && result.activeConnectionId === targetId) {
+        deps.onCommitted?.(targetId);
+        return result;
+      }
+    }
+    await sleep(backoffMs);
+  }
+  throw new Error(`Failed to commit active connection ${targetId ?? "null"} to session`);
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -350,6 +350,9 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   const switchTicketRef = useRef(0);
   const committedSwitchRef = useRef<{ ticket: number; targetId: string | null } | null>(null);
   const lastCommittedConnIdRef = useRef<string | null>(null);
+  // Bumped on auth reset (sign-out) so a queued session commit from a previous
+  // session is abandoned instead of committing into a later (re-login) session.
+  const authGenRef = useRef(0);
 
   const bumpContextGen = useCallback(() => {
     contextGenRef.current += 1;
@@ -705,18 +708,23 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   // update so overlapping switches commit to the JWT cookie in submission order, and
   // only a validated commit (returned session actually reflects the target) counts.
   // Created once so its FIFO chain persists across renders.
-  const commitRunnerRef = useRef<((data: { activeConnectionId?: string | null }) => Promise<unknown>) | undefined>(undefined);
+  const commitRunnerRef = useRef<((data: { activeConnectionId?: string | null }, isCancelled: () => boolean) => Promise<unknown>) | undefined>(undefined);
   if (!commitRunnerRef.current) {
-    commitRunnerRef.current = createSerializedRunner((data: { activeConnectionId?: string | null }) =>
+    commitRunnerRef.current = createSerializedRunner((data: { activeConnectionId?: string | null }, isCancelled: () => boolean) =>
       commitWithValidation(data.activeConnectionId ?? null, {
         update: (d) => updateSessionRef.current(d),
         getStatus: () => statusRef.current,
         onCommitted: (id) => { lastCommittedConnIdRef.current = id; },
+        isCancelled,
       }));
   }
   const commitActiveConnection = useCallback((data: { activeConnectionId?: string | null }) => {
     const runner = commitRunnerRef.current;
-    return runner ? runner(data) : Promise.resolve(undefined);
+    if (!runner) return Promise.resolve(undefined);
+    // Pin this commit to the current auth session; if a sign-out bumps the auth
+    // generation while it is queued, it aborts instead of committing cross-session.
+    const gen = authGenRef.current;
+    return runner(data, () => authGenRef.current !== gen);
   }, []);
 
   // Seed the last-good connection from the authenticated session so a rollback can
@@ -1226,6 +1234,8 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
         pendingSwitchTicketsRef.current.clear();
         committedSwitchRef.current = null;
         lastCommittedConnIdRef.current = null;
+        // Abandon any queued session commits from this (now ended) session.
+        authGenRef.current += 1;
       }
       return;
     }
@@ -1259,19 +1269,19 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
             const target = lastId && conns.find(c => c.id === lastId)
               ? lastId
               : conns[0].id;
-            setActiveConnectionId(target);
+            // Pin the global so the commit's own request routes to `target`, but
+            // publish React state only AFTER the JWT commit validates — a failed
+            // commit must not leave the UI on a connection the session doesn't
+            // reflect. Route through the serialized commit so a concurrent user
+            // switch can't be reordered against this establishment write.
             setActiveConnectionIdGlobal(target);
-            // Sync activeConnectionId into the JWT so session.user reflects
-            // the correct connection's role/host/port. The JWT callback looks
-            // up the full connection details from Token DB.
             if (!cancelled) {
-              // Route through the serialized commit so a concurrent user switch
-              // can't be reordered against this establishment write; best-effort
-              // (a failed commit must not abort establishment).
               try {
                 await commitActiveConnection({ activeConnectionId: target });
+                if (!cancelled) setActiveConnectionId(target);
               } catch (commitErr) {
                 console.warn("Initial session commit failed:", commitErr);
+                if (!cancelled) setActiveConnectionIdGlobal(null);
               }
             }
 
@@ -1304,13 +1314,15 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
                 const migratedConn: SessionConnection = migrateJson.connection;
                 const migratedConns = [migratedConn];
                 setAdditionalConnections(migratedConns);
-                setActiveConnectionId(migratedConn.id);
+                // Publish React state only after the commit validates (see above).
                 setActiveConnectionIdGlobal(migratedConn.id);
                 if (!cancelled) {
                   try {
                     await commitActiveConnection({ activeConnectionId: migratedConn.id });
+                    if (!cancelled) setActiveConnectionId(migratedConn.id);
                   } catch (commitErr) {
                     console.warn("Migrated session commit failed:", commitErr);
+                    if (!cancelled) setActiveConnectionIdGlobal(null);
                   }
                 }
               }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -15,6 +15,7 @@ import { setFunctionCandidates } from "@/lib/cypherSuggestions";
 import { udfFunctionNames } from "@/lib/cypherLang";
 import { computeEditorDiagnostics, type DiagnosticsResult } from "@/lib/cypherDiagnostics";
 import { isAiFixSupported } from "@/lib/aiFix";
+import { createSerializedRunner, commitWithValidation } from "./components/serializedRunner";
 import { PanelImperativeHandle } from "react-resizable-panels";
 import type { Data as CanvasData, HierarchyDirection, LayoutMode, RadialDirection, ViewportState } from "@falkordb/canvas";
 import LoginVerification from "./loginVerification";
@@ -339,11 +340,16 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   const optionsSeqRef = useRef(0);
   // loadingOwnerRef: the querySeq that currently owns the isQueryLoading spinner.
   const loadingOwnerRef = useRef<number | null>(null);
-  // Connection-switch gate. `pendingSwitches` counts in-flight switches (graph ops
-  // are rejected while > 0); `switchTicket` is monotonic so a completing switch
-  // can tell whether it is still the latest (out-of-order completions are ignored).
-  const pendingSwitchesRef = useRef(0);
+  // Connection-switch gate. `pendingSwitchTickets` holds the tickets of in-flight
+  // switches (graph ops are rejected while the set is non-empty); `switchTicket` is
+  // monotonic so a completing switch can tell whether it is still the latest.
+  // `committedSwitch` is the winning/rollback ticket handed to the reset effect,
+  // keyed by target so a batched-away intermediate state can't release the wrong
+  // ticket. `lastCommittedConnId` is the newest connection whose JWT commit validated.
+  const pendingSwitchTicketsRef = useRef<Set<number>>(new Set());
   const switchTicketRef = useRef(0);
+  const committedSwitchRef = useRef<{ ticket: number; targetId: string | null } | null>(null);
+  const lastCommittedConnIdRef = useRef<string | null>(null);
 
   const bumpContextGen = useCallback(() => {
     contextGenRef.current += 1;
@@ -356,19 +362,33 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     return contextGenRef.current;
   }, []);
 
-  // Returns a ticket for this switch. Every begin must be matched by exactly one
-  // end (on success via the reset effect, on failure/supersession by the caller),
-  // so the counter can never get stuck above 0.
+  // Returns a ticket for this switch. Every begin is matched by exactly one release
+  // (the winning/rollback ticket via the reset effect, others via the caller's
+  // finally), so the gate set can never get stuck non-empty.
   const beginConnectionSwitch = useCallback(() => {
-    pendingSwitchesRef.current += 1;
     switchTicketRef.current += 1;
+    pendingSwitchTicketsRef.current.add(switchTicketRef.current);
     bumpContextGen();
     return switchTicketRef.current;
   }, [bumpContextGen]);
 
-  const endConnectionSwitch = useCallback(() => {
-    pendingSwitchesRef.current = Math.max(0, pendingSwitchesRef.current - 1);
+  const endConnectionSwitch = useCallback((ticket: number) => {
+    pendingSwitchTicketsRef.current.delete(ticket);
   }, []);
+
+  // Hand the winning (or state-changing rollback) ticket to the reset effect, which
+  // releases it only once React reaches `targetId`. Retire any prior handed-off
+  // ticket first (its own newer live ticket keeps the gate closed) so the ref can't
+  // leak a superseded handoff.
+  const handoffConnectionSwitch = useCallback((ticket: number, targetId: string | null) => {
+    const prev = committedSwitchRef.current;
+    if (prev && prev.ticket !== ticket) pendingSwitchTicketsRef.current.delete(prev.ticket);
+    committedSwitchRef.current = { ticket, targetId };
+  }, []);
+
+  const isConnectionSwitchInProgress = useCallback(() => pendingSwitchTicketsRef.current.size > 0, []);
+
+  const getLastCommittedConnId = useCallback(() => lastCommittedConnIdRef.current, []);
 
   // True if `ticket` is still the most recently started switch (so a stale,
   // out-of-order completion doesn't publish an older connection as active).
@@ -681,6 +701,32 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
   const statusRef = useRef(status);
   statusRef.current = status;
 
+  // Serialized + validated session-commit (idea-7 §3a): wraps the raw next-auth
+  // update so overlapping switches commit to the JWT cookie in submission order, and
+  // only a validated commit (returned session actually reflects the target) counts.
+  // Created once so its FIFO chain persists across renders.
+  const commitRunnerRef = useRef<((data: { activeConnectionId?: string | null }) => Promise<unknown>) | undefined>(undefined);
+  if (!commitRunnerRef.current) {
+    commitRunnerRef.current = createSerializedRunner((data: { activeConnectionId?: string | null }) =>
+      commitWithValidation(data.activeConnectionId ?? null, {
+        update: (d) => updateSessionRef.current(d),
+        getStatus: () => statusRef.current,
+        onCommitted: (id) => { lastCommittedConnIdRef.current = id; },
+      }));
+  }
+  const commitActiveConnection = useCallback((data: { activeConnectionId?: string | null }) => {
+    const runner = commitRunnerRef.current;
+    return runner ? runner(data) : Promise.resolve(undefined);
+  }, []);
+
+  // Seed the last-good connection from the authenticated session so a rollback can
+  // converge with the existing JWT even before the first user switch commits.
+  useEffect(() => {
+    if (status === "authenticated" && lastCommittedConnIdRef.current === null && sessionData?.activeConnectionId != null) {
+      lastCommittedConnIdRef.current = sessionData.activeConnectionId;
+    }
+  }, [status, sessionData]);
+
   const connectionContext = useMemo(() => ({
     connectionType,
     setConnectionType,
@@ -693,11 +739,14 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     setAdditionalConnections,
     activeConnectionId,
     setActiveConnectionId,
-    updateSession,
+    updateSession: commitActiveConnection,
     beginConnectionSwitch,
     endConnectionSwitch,
+    handoffConnectionSwitch,
+    isConnectionSwitchInProgress,
+    getLastCommittedConnId,
     isLatestSwitch,
-  }), [connectionType, connectionInfo, dbVersion, isReadOnly, additionalConnections, activeConnectionId, updateSession, beginConnectionSwitch, endConnectionSwitch, isLatestSwitch]);
+  }), [connectionType, connectionInfo, dbVersion, isReadOnly, additionalConnections, activeConnectionId, commitActiveConnection, beginConnectionSwitch, endConnectionSwitch, handoffConnectionSwitch, isConnectionSwitchInProgress, getLastCommittedConnId, isLatestSwitch]);
 
   const udfContext = useMemo(() => ({
     udfList,
@@ -719,7 +768,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     // Don't start a count while a connection switch is mid-flight — the global id
     // and React state may disagree, so this could query (and auto-create) the
     // old graph on the new connection.
-    if (pendingSwitchesRef.current > 0) return;
+    if (pendingSwitchTicketsRef.current.size > 0) return;
 
     // Capture the connection this request targets. Prefer the caller's captured
     // epoch (the epoch when its poll/action began) so a switch between that start
@@ -849,7 +898,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
 
     // Reject while a connection switch is mid-flight — its global id and React
     // state may still disagree, so starting here could hit the wrong DB.
-    if (pendingSwitchesRef.current > 0) return;
+    if (pendingSwitchTicketsRef.current.size > 0) return;
 
     // Capture ownership once: this is the newest query for the current
     // connection + graph. `isCurrent()` gates every later apply so a switch, a
@@ -1174,6 +1223,9 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
         setActiveConnectionId(null);
         setActiveConnectionIdGlobal(null);
         sessionSyncedRef.current = false;
+        pendingSwitchTicketsRef.current.clear();
+        committedSwitchRef.current = null;
+        lastCommittedConnIdRef.current = null;
       }
       return;
     }
@@ -1213,9 +1265,14 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
             // the correct connection's role/host/port. The JWT callback looks
             // up the full connection details from Token DB.
             if (!cancelled) {
-              await updateSessionRef.current({
-                activeConnectionId: target,
-              });
+              // Route through the serialized commit so a concurrent user switch
+              // can't be reordered against this establishment write; best-effort
+              // (a failed commit must not abort establishment).
+              try {
+                await commitActiveConnection({ activeConnectionId: target });
+              } catch (commitErr) {
+                console.warn("Initial session commit failed:", commitErr);
+              }
             }
 
           } else {
@@ -1250,9 +1307,11 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
                 setActiveConnectionId(migratedConn.id);
                 setActiveConnectionIdGlobal(migratedConn.id);
                 if (!cancelled) {
-                  await updateSessionRef.current({
-                    activeConnectionId: migratedConn.id,
-                  });
+                  try {
+                    await commitActiveConnection({ activeConnectionId: migratedConn.id });
+                  } catch (commitErr) {
+                    console.warn("Migrated session commit failed:", commitErr);
+                  }
                 }
               }
             }
@@ -1265,7 +1324,7 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     })();
 
     return () => { cancelled = true; };
-  }, [status, toast]);
+  }, [status, toast, commitActiveConnection]);
 
   useEffect(() => {
     if (status !== "authenticated" || !prefixReady) return;
@@ -1619,17 +1678,29 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     const prev = prevActiveConnectionIdRef.current;
     prevActiveConnectionIdRef.current = activeConnectionId;
 
+    // Release a handed-off switch ticket once React reaches its target — even for a
+    // rollback to the same id or the first establishment (which skip the reset
+    // below) — so its gate ticket doesn't leak. On a real change we release only
+    // AFTER graph state is reset (at the end), so no graph op runs against a
+    // mismatched connection/graph in between.
+    const releaseHandoff = () => {
+      const h = committedSwitchRef.current;
+      if (h && h.targetId === activeConnectionId) {
+        endConnectionSwitch(h.ticket);
+        committedSwitchRef.current = null;
+      }
+    };
+
     // Skip the very first selection (initial mount / login) and null resets
-    if (prev === null || activeConnectionId === null) return;
+    if (prev === null || activeConnectionId === null) { releaseHandoff(); return; }
     // Skip if unchanged
-    if (prev === activeConnectionId) return;
+    if (prev === activeConnectionId) { releaseHandoff(); return; }
 
     // The connection actually changed and React state now agrees: supersede any
-    // in-flight graph op and fully release the switch gate so new ops are accepted
-    // again (any still-pending older switch is no longer latest, so it's a no-op).
+    // in-flight graph op. The switch gate is released via the handed-off ticket at
+    // the end of this effect (after graph state is reset), not by zeroing the gate.
     bumpContextGen();
     activeGraphNameRef.current = "";
-    pendingSwitchesRef.current = 0;
 
     // Clear graph data so stale results from the old connection are gone.
     // Build the empty graph with the real toast/setIndicator callbacks up front
@@ -1648,7 +1719,11 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
     // Re-fetch graph list for the new connection (clearing the old list).
     connectionSwitchFetchedRef.current = true;
     handleFetchOptions({ clear: true });
-  }, [activeConnectionId, toast, setIndicator, handleFetchOptions, bumpContextGen]);
+
+    // Graph state is reset above → now release this switch's gate ticket so new
+    // ops are accepted again for the new connection.
+    releaseHandoff();
+  }, [activeConnectionId, toast, setIndicator, handleFetchOptions, bumpContextGen, endConnectionSwitch]);
 
   const handleCloseTutorial = () => {
     setTutorialOpen(false);

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1281,7 +1281,8 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
                 if (!cancelled) setActiveConnectionId(target);
               } catch (commitErr) {
                 console.warn("Initial session commit failed:", commitErr);
-                if (!cancelled) setActiveConnectionIdGlobal(null);
+                // Only roll back the global if a newer action hasn't moved it.
+                if (!cancelled && getActiveConnectionIdGlobal() === target) setActiveConnectionIdGlobal(null);
               }
             }
 
@@ -1322,7 +1323,8 @@ function ProvidersWithSession({ children, nonce }: { children: React.ReactNode; 
                     if (!cancelled) setActiveConnectionId(migratedConn.id);
                   } catch (commitErr) {
                     console.warn("Migrated session commit failed:", commitErr);
-                    if (!cancelled) setActiveConnectionIdGlobal(null);
+                    // Only roll back the global if a newer action hasn't moved it.
+                    if (!cancelled && getActiveConnectionIdGlobal() === migratedConn.id) setActiveConnectionIdGlobal(null);
                   }
                 }
               }

--- a/e2e/logic/POM/connectionManagerComponent.ts
+++ b/e2e/logic/POM/connectionManagerComponent.ts
@@ -50,6 +50,31 @@ export default class ConnectionManagerComponent extends BasePage {
         return labels;
     }
 
+    async getConnectionIds(): Promise<string[]> {
+        await this.waitForPageIdle();
+        if (!await this.dropdownContent.isVisible()) {
+            await this.openDropdown();
+        }
+        const items = await this.connectionItems.all();
+        const ids: string[] = [];
+        for (const item of items) {
+            const testId = await item.getAttribute("data-testid");
+            if (testId) ids.push(testId.replace("connection-item-", ""));
+        }
+        return ids;
+    }
+
+    async selectConnectionById(id: string): Promise<void> {
+        if (!await this.dropdownContent.isVisible()) {
+            await this.openDropdown();
+        }
+        await interactWhenVisible(
+            this.page.getByTestId(`connection-item-${id}`),
+            (el) => el.click(),
+            `Select connection ${id}`,
+        );
+    }
+
     async hasActiveConnection(): Promise<boolean> {
         if (!await this.dropdownContent.isVisible()) {
             await this.openDropdown();

--- a/e2e/logic/POM/connectionManagerComponent.ts
+++ b/e2e/logic/POM/connectionManagerComponent.ts
@@ -50,20 +50,6 @@ export default class ConnectionManagerComponent extends BasePage {
         return labels;
     }
 
-    async getConnectionIds(): Promise<string[]> {
-        await this.waitForPageIdle();
-        if (!await this.dropdownContent.isVisible()) {
-            await this.openDropdown();
-        }
-        const items = await this.connectionItems.all();
-        const ids: string[] = [];
-        for (const item of items) {
-            const testId = await item.getAttribute("data-testid");
-            if (testId) ids.push(testId.replace("connection-item-", ""));
-        }
-        return ids;
-    }
-
     async selectConnectionById(id: string): Promise<void> {
         if (!await this.dropdownContent.isVisible()) {
             await this.openDropdown();

--- a/e2e/tests/connectionManager.spec.ts
+++ b/e2e/tests/connectionManager.spec.ts
@@ -50,52 +50,68 @@ test.describe("Connection Manager Tests", () => {
     const page = await browser.getPage();
     const origin = new URL(page.url()).origin;
 
+    // The originally-active connection (A) — we switch A→B→C among the two we add.
+    const activeId = (await (await page.request.get(`${origin}/api/auth/session`)).json()).activeConnectionId as string;
+
     // Need ≥3 connections to do A→B→C (selecting the active one is a no-op). Add two
-    // extra connections to the same local FalkorDB via the API.
+    // extra connections to the same local FalkorDB via the API, capturing their ids.
+    const added: string[] = [];
     for (let i = 0; i < 2; i += 1) {
       const res = await page.request.post(`${origin}/api/connections`, {
         data: { host: "localhost", port: "6379" },
       });
       expect(res.ok()).toBe(true);
+      added.push((await res.json()).connection.id as string);
     }
-    await page.reload();
-    await connManager.waitForPageIdle();
+    const [connB, connC] = added;
 
-    const ids = await connManager.getConnectionIds();
-    expect(ids.length).toBeGreaterThanOrEqual(3);
+    try {
+      await page.reload();
+      await connManager.waitForPageIdle();
 
-    // Pick two targets distinct from the currently-active connection.
-    const activeRes = await page.request.get(`${origin}/api/auth/session`);
-    const activeId = (await activeRes.json()).activeConnectionId as string;
-    const [connB, connC] = ids.filter((id) => id !== activeId);
-    expect(connB).toBeTruthy();
-    expect(connC).toBeTruthy();
+      // Hold B's session-update POST in-flight until C has also been triggered.
+      let releaseFirst: () => void = () => {};
+      const firstHeld = new Promise<void>((resolve) => { releaseFirst = resolve; });
+      let heldOnce = false;
+      await page.route("**/api/auth/session", async (route) => {
+        const req = route.request();
+        if (req.method() === "POST" && !heldOnce && (req.postData() || "").includes(connB)) {
+          heldOnce = true;
+          await firstHeld;
+        }
+        await route.continue();
+      });
 
-    // Hold B's session-update POST in-flight until C has also been triggered.
-    let releaseFirst: () => void = () => {};
-    const firstHeld = new Promise<void>((resolve) => { releaseFirst = resolve; });
-    let heldOnce = false;
-    await page.route("**/api/auth/session", async (route) => {
-      const req = route.request();
-      if (req.method() === "POST" && !heldOnce && (req.postData() || "").includes(connB)) {
-        heldOnce = true;
-        await firstHeld;
+      // Switch to B (its update is held), then to C (queued behind B by the serializer).
+      await connManager.selectConnectionById(connB);
+      await connManager.selectConnectionById(connC);
+
+      // Release B's update; the serializer then runs C's update, so the JWT ends on C.
+      releaseFirst();
+
+      await expect.poll(async () => {
+        const res = await page.request.get(`${origin}/api/auth/session`);
+        return (await res.json()).activeConnectionId;
+      }, { timeout: 15000 }).toBe(connC);
+
+      await page.unroute("**/api/auth/session");
+    } finally {
+      // Cleanup: move the session back to the original connection (so we don't delete
+      // the active row), then remove the two temporary connections from the shared
+      // session so they don't accumulate across tests/runs.
+      try {
+        await page.unroute("**/api/auth/session").catch(() => {});
+        await connManager.selectConnectionById(activeId);
+        await expect.poll(async () => {
+          const res = await page.request.get(`${origin}/api/auth/session`);
+          return (await res.json()).activeConnectionId;
+        }, { timeout: 15000 }).toBe(activeId);
+      } catch {
+        // best-effort — still attempt to delete the temporary connections below
       }
-      await route.continue();
-    });
-
-    // Switch to B (its update is held), then to C (queued behind B by the serializer).
-    await connManager.selectConnectionById(connB);
-    await connManager.selectConnectionById(connC);
-
-    // Release B's update; the serializer then runs C's update, so the JWT ends on C.
-    releaseFirst();
-
-    await expect.poll(async () => {
-      const res = await page.request.get(`${origin}/api/auth/session`);
-      return (await res.json()).activeConnectionId;
-    }, { timeout: 15000 }).toBe(connC);
-
-    await page.unroute("**/api/auth/session");
+      for (const id of added) {
+        await page.request.delete(`${origin}/api/connections/${id}`).catch(() => {});
+      }
+    }
   });
 });

--- a/e2e/tests/connectionManager.spec.ts
+++ b/e2e/tests/connectionManager.spec.ts
@@ -40,4 +40,62 @@ test.describe("Connection Manager Tests", () => {
       expect(label).toMatch(/@.*:\d+/);
     }
   });
+
+  // Regression for idea-7: overlapping connection switches (A→B→C) must converge
+  // the persisted JWT on the LAST-selected connection. The switch session mutation
+  // is serialized, so holding B's /api/auth/session update in-flight while C is
+  // triggered must still end on C (never on the superseded B).
+  test(`@admin overlapping connection switches converge on the last-selected connection`, async () => {
+    const connManager = await browser.createNewPage(ConnectionManagerComponent, urls.graphUrl);
+    const page = await browser.getPage();
+    const origin = new URL(page.url()).origin;
+
+    // Need ≥3 connections to do A→B→C (selecting the active one is a no-op). Add two
+    // extra connections to the same local FalkorDB via the API.
+    for (let i = 0; i < 2; i += 1) {
+      const res = await page.request.post(`${origin}/api/connections`, {
+        data: { host: "localhost", port: "6379" },
+      });
+      expect(res.ok()).toBe(true);
+    }
+    await page.reload();
+    await connManager.waitForPageIdle();
+
+    const ids = await connManager.getConnectionIds();
+    expect(ids.length).toBeGreaterThanOrEqual(3);
+
+    // Pick two targets distinct from the currently-active connection.
+    const activeRes = await page.request.get(`${origin}/api/auth/session`);
+    const activeId = (await activeRes.json()).activeConnectionId as string;
+    const [connB, connC] = ids.filter((id) => id !== activeId);
+    expect(connB).toBeTruthy();
+    expect(connC).toBeTruthy();
+
+    // Hold B's session-update POST in-flight until C has also been triggered.
+    let releaseFirst: () => void = () => {};
+    const firstHeld = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    let heldOnce = false;
+    await page.route("**/api/auth/session", async (route) => {
+      const req = route.request();
+      if (req.method() === "POST" && !heldOnce && (req.postData() || "").includes(connB)) {
+        heldOnce = true;
+        await firstHeld;
+      }
+      await route.continue();
+    });
+
+    // Switch to B (its update is held), then to C (queued behind B by the serializer).
+    await connManager.selectConnectionById(connB);
+    await connManager.selectConnectionById(connC);
+
+    // Release B's update; the serializer then runs C's update, so the JWT ends on C.
+    releaseFirst();
+
+    await expect.poll(async () => {
+      const res = await page.request.get(`${origin}/api/auth/session`);
+      return (await res.json()).activeConnectionId;
+    }, { timeout: 15000 }).toBe(connC);
+
+    await page.unroute("**/api/auth/session");
+  });
 });

--- a/idea-7-serialize-connection-switch-plan.md
+++ b/idea-7-serialize-connection-switch-plan.md
@@ -1,0 +1,337 @@
+# Implementation Plan — Idea #7: converge overlapping connection switches (minimal, single-tab)
+
+Goal: when a user triggers overlapping connection switches (A→B→C) **in one tab**, the persisted JWT
+cookie, the React UI state, the module-global id, and the switch gate must all converge on the
+**last successfully-committed** connection — and a failed or superseded switch must never leave those
+out of sync or leave the gate stuck.
+
+Closes the **🔴 Critical** CodeRabbit thread on PR #1951
+(`app/components/ConnectionManager.tsx#L51-69` + `app/providers.tsx#L1615-1620`):
+
+> **The ticket still does not serialize the session mutation.** An older `updateSession` can complete
+> after the latest switch and overwrite the JWT/session before failing `isLatestSwitch`. Resetting all
+> pending slots then reopens graph operations while that older session mutation remains in flight.
+> Serialize session updates or enforce latest-wins server-side.
+
+**Behaviour bug fix, not breaking.** Follow-up to the ownership-token work merged in #1951.
+
+> **Scope decision (agreed with @barakb): minimal, single-tab.** Two rubber-duck rounds proved the
+> naïve "just serialize `updateSession`" fix insufficient and shrank the real severity (§1–§2). This
+> plan fixes the realistic single-tab case with bounded risk; cross-tab / focus-refetch coordination
+> and server-authoritative last-wins are explicitly **out of scope** and documented in §4/§7.
+
+---
+
+## 0. Background — verified facts (merged code + next-auth internals)
+
+`app/providers.tsx`
+- `updateSession = useSession().update` (`:161`), exposed on `ConnectionContext` (`:696`), mirrored to
+  `updateSessionRef` (`:166-167`). A render-synchronous `statusRef` already exists (`:681-682`).
+- Switch gate: `pendingSwitchesRef` **counter** (`:345`), `beginConnectionSwitch()` (`:362`, bumps
+  counter + `switchTicketRef` + `bumpContextGen`), `endConnectionSwitch()` (`:369`, decrements),
+  `isLatestSwitch(ticket)` (`:375`).
+- Graph ops are gated: `fetchCount` (`:722`) and `runQuery` (`:852`) early-return while
+  `pendingSwitchesRef.current > 0`.
+- The reset effect (`:1617-1655`) **zeroes the whole gate** — `pendingSwitchesRef.current = 0`
+  (`:1632`) — and bumps `contextGen`, resets graph state, on a real React `activeConnectionId` change.
+- The module-global id is re-synced to React state **after every render** by a dependency-free effect
+  (`:1083`): `useEffect(() => { setActiveConnectionIdGlobal(activeConnectionId); })`.
+- Auto-select on load uses **localStorage `lastActiveConnectionId`** then `conns[0]` (`:1202-1209`) —
+  **not** the JWT.
+- Internal establishment/migration writes call `updateSessionRef.current(...)` directly (`:1216`,
+  `:1253`).
+
+`app/components/ConnectionManager.tsx` — three switch sites (`handleSelect` `:52`, `confirmRemove`
+`:115`, `handleAddConnection` `:170`): `beginConnectionSwitch()` → `setActiveConnectionIdGlobal(id)` →
+`localStorage.setItem` → `await updateSession({activeConnectionId:id})` → `isLatestSwitch` guard →
+`setActiveConnectionId(id)`, with a rollback `catch`. Selecting the active id is a no-op (`:37-38`).
+
+`app/api/auth/[...nextauth]/options.ts`
+- `getClient()` resolves the connection **primarily from `X-Connection-Id`** (`:1098`), falling back to
+  the JWT `session.activeConnectionId` only when the header is absent (`:1112-1113`); role/host/port
+  come from `fetchTokenById(connId)` (`:1289-1300`).
+- JWT `trigger === "update"` (`:892-913`) sets `token.activeConnectionId` **before** the Token DB
+  lookup; `session` callback (`:923-927`) returns `activeConnectionId` + `user.{role,host,port,tls}`.
+
+next-auth (`node_modules`, verified)
+- `react.js:337` — `update()` returns `undefined` immediately **while `loading`** (no HTTP write).
+- `client.js:38-40` — transport errors become **`null`, not a rejection**; `update()` resolves `null`.
+- `update()` returns the session body (incl. `activeConnectionId`) on success and broadcasts a
+  cross-tab event (`react.js:344-350`).
+- Ordinary session GETs (focus / cross-tab, `react.js:243-320`) **also re-set the JWT cookie**
+  (`@auth/core/lib/actions/session.js:44-49`) and do **not** set `loading` — unserialized writers.
+
+---
+
+## 1. Corrected severity (verified)
+
+The stale JWT does **not** misroute normal graph queries: header-routed ops (`securedFetch`/SSE inject
+`X-Connection-Id` from the global) hit the newest connection + its Token DB role, and reload
+auto-select uses localStorage (= newest), which **repairs** the JWT. The real residual impact is:
+1. **Session/UI metadata divergence** — `session.user.{role,host,port,username}` (JWT-sourced) can show
+   the superseded connection until the next successful update/refresh; any header-less code path that
+   trusts `session.user.role` is then wrong.
+2. **Header-less / fallback requests** resolve the connection from the stale JWT (`:1112-1113`).
+3. **Transient mid-switch window** where the global reverts to the *old* id via the `:1083` effect —
+   mitigated because the gate blocks graph ops during a switch.
+
+So the finding is real (persisted session + UI diverge from the user's last choice) but it is a
+**metadata/fallback** bug, not general live-query misrouting.
+
+---
+
+## 2. Why the naïve serializer is insufficient (both rubber-duck rounds)
+
+1. **`update()` no-ops while loading** → a microtask-chained call reads the still-`loading` closure,
+   gets `undefined` back **without writing the cookie**, yet resolves and passes `isLatestSwitch` →
+   UI C, cookie B.
+2. **Errors → `null`**, so the ConnectionManager `catch` rollbacks never fire on transport failure.
+3. **Failure rollback is independently broken** — it rolls back only the global (not React), and
+   `confirmRemove` would roll back to a **deleted** connection.
+4. **Zeroing the gate** (`:1632`) reopens graph ops while a **newer** switch D (begun after C's
+   `setActiveConnectionId` but before the reset effect) is still pending.
+
+The minimal fix must therefore **validate** the commit, converge **all** states on failure, and make
+the gate **ticket-owned**.
+
+---
+
+## 3. Minimal design
+
+### 3a. Serialized + validated `commitActiveConnection` — `providers.tsx` (keeps the object signature)
+
+Swap the *implementation* behind the existing context `updateSession({ activeConnectionId })` — **no
+caller/type change** (avoids the signature-mismatch trap; `provider.ts:238` stays):
+
+```ts
+const sessionChainRef = useRef<Promise<unknown>>(Promise.resolve());
+
+// Serialize + validate JWT writes. update() no-ops while loading and turns
+// transport errors into null, so we (a) wait until the provider is authenticated
+// (reuse the existing statusRef :681), (b) validate the returned session actually
+// reflects the target, (c) retry a bounded number of times. We do NOT time-box the
+// update() await: a non-aborting timeout would let a late response overwrite a newer
+// commit's cookie — the exact race we're closing. The chain (and the ticket) stay
+// pending until the real request settles; a hung provider blocking later switches is
+// an accepted residual (no worse than today's single await, §6). Throw on exhaustion
+// so callers' catch/rollback runs.
+const commitActiveConnection = useCallback((data: { activeConnectionId?: string | null }) => {
+  const targetId = data.activeConnectionId ?? null;
+  const run = sessionChainRef.current.catch(() => undefined).then(async () => {
+    for (let attempt = 0; attempt < MAX_COMMIT_ATTEMPTS; attempt += 1) {
+      // Bounded wait for a non-loading provider; a timeout here just fails this
+      // attempt (backoff + retry) — it never abandons an in-flight update().
+      const ready = await waitUntil(() => statusRef.current === "authenticated", READY_TIMEOUT_MS);
+      if (ready) {
+        const result = await updateSessionRef.current({ activeConnectionId: targetId }) as
+          { activeConnectionId?: string | null } | null | undefined;
+        if (result && result.activeConnectionId === targetId) {
+          lastCommittedConnIdRef.current = targetId;    // §3c
+          return result;
+        }
+      }
+      await delay(COMMIT_BACKOFF_MS);
+    }
+    throw new Error(`Failed to commit active connection to session`);
+  });
+  sessionChainRef.current = run.catch(() => undefined);   // a failure never breaks the chain
+  return run;
+}, []);
+```
+
+Expose `commitActiveConnection` as the context `updateSession` (`:696`; swap memo dep `:700`). Stable
+identity (empty deps; reads refs at call time). The three switch sites are unchanged in signature and
+now get ordering + a real throw on failure.
+
+> Extract the pure pieces — `createSerializedRunner`, and a `commitWithValidation(update, statusGetter,
+> target, opts)` core — into `app/components/serializedRunner.ts` so they are unit-testable under
+> `node:test` (route/`.tsx` files aren't; `providers.tsx` wires the refs to them).
+
+### 3b. Ticket-owned gate (fixes issue 4) — `providers.tsx`
+
+Replace the counter with a **set of live tickets**, released **per-ticket by the caller**, never
+globally zeroed:
+
+```ts
+const pendingSwitchTicketsRef = useRef<Set<number>>(new Set());
+// Target-keyed handoff: the reset effect releases this ticket only when React
+// state actually reaches `targetId`, so a batched-away intermediate state can't
+// release the wrong ticket.
+const committedSwitchRef = useRef<{ ticket: number; targetId: string | null } | null>(null);
+const beginConnectionSwitch = () => { const t = (switchTicketRef.current += 1);
+  pendingSwitchTicketsRef.current.add(t); bumpContextGen(); return t; };
+const endConnectionSwitch = (ticket: number) => { pendingSwitchTicketsRef.current.delete(ticket); };
+const isConnectionSwitchInProgress = () => pendingSwitchTicketsRef.current.size > 0;
+// Called by the winning switch (or a state-changing rollback) just before it
+// publishes React state. Retire any prior handed-off ticket first (its own newer
+// live ticket keeps the gate closed), so the ref can't leak a superseded handoff.
+const handoffConnectionSwitch = (ticket: number, targetId: string | null) => {
+  const prev = committedSwitchRef.current;
+  if (prev && prev.ticket !== ticket) endConnectionSwitch(prev.ticket);
+  committedSwitchRef.current = { ticket, targetId };
+};
+```
+
+- Gate predicate at `:722` and `:852` becomes `isConnectionSwitchInProgress()`.
+- **Remove** `pendingSwitchesRef.current = 0` from the reset effect (`:1632`). Instead, at the **end**
+  of the reset effect (after graph state + `bumpContextGen` are done), release the handed-off ticket
+  **only when it matches the connection React actually reached**:
+  `const h = committedSwitchRef.current; if (h && h.targetId === activeConnectionId) { endConnectionSwitch(h.ticket); committedSwitchRef.current = null; }`.
+  A newer D keeps its own ticket, so it can't be clobbered. The reset effect's early-return branches
+  (`:1623-1625`, `prev === null`/unchanged) must **not** skip this release when a matching handoff is
+  pending — a rollback to the same id, or a first-establishment id, still needs its ticket released.
+- Change the `ConnectionContext.endConnectionSwitch` type (`provider.ts:244`) to `(ticket: number)`;
+  expose `handoffConnectionSwitch(ticket, targetId)` and `isConnectionSwitchInProgress()` on the
+  context (ConnectionManager can't read the provider ref directly).
+- **Ticket lifecycle (no leak, no early release):** the switch site wraps its body in `try/finally`
+  with a `handedOff` flag. **Any path that changes React state** — the winning publish **and** a
+  state-changing rollback — calls `handoffConnectionSwitch(ticket, target)` **then**
+  `setActiveConnectionId(target)` and sets `handedOff = true`; the reset effect releases that ticket
+  after graph state is reset. Only when React **already equals** the target (no state change, so no
+  reset effect will fire) does `finally { if (!handedOff) endConnectionSwitch(ticket); }` release
+  directly. Releasing only via the reset effect on a state change is required — `contextGen` discards a
+  stale result *apply* but does **not** undo a server-side effect (`runQuery` `:847-864` can mutate the
+  DB, `fetchCount` `:719-722` can auto-create a graph, `DeleteGraph`/`CreateGraph` mutate before their
+  epoch check), so the gate must stay closed until the reset effect re-pins graph state. A superseded
+  switch never publishes (fails `isLatestSwitch`), and `handoffConnectionSwitch` retires any prior
+  handed-off ticket, so the ref can't leak a superseded ticket. On sign-out/auth reset,
+  `pendingSwitchTicketsRef.current.clear()` **and** `committedSwitchRef.current = null`.
+
+### 3c. Converge all states on failure/supersession (fixes issue 3) — `ConnectionManager.tsx` + `providers.tsx`
+
+- `lastCommittedConnIdRef` (providers) is **seeded** from the authenticated session
+  (`sessionData.activeConnectionId`) as soon as `status === "authenticated"`, and thereafter set only
+  on a **validated** commit success (§3a). Seeding guarantees rollback converges even if the first
+  establishment write and the first user switch both fail (round-2 clarification: an unseeded `null`
+  ref couldn't converge with the existing JWT). Expose a getter (or a small
+  `rollbackActiveConnection()` helper) on the context so the switch sites can read the last-good id;
+  if it is still `null`, fall back to `sessionData.activeConnectionId`.
+- `handleSelect` / `handleAddConnection` — on a thrown commit failure, if `isLatestSwitch(ticket)`,
+  roll back **both** React **and** global + localStorage to the last-good id. Since this rollback
+  **changes React state**, it must go through the same handoff (`handoffConnectionSwitch(ticket,
+  rollbackId)` → `setActiveConnectionId(rollbackId)` → `handedOff = true`) so the ticket is released by
+  that rollback's reset effect — releasing it directly in `finally` would reopen the gate before the
+  reset re-pins graph state (the round-3 unsafe window, which also applies to rollback). Only when
+  React already equals `rollbackId` (no state change) does `finally` release directly.
+- `confirmRemove` — **commit the replacement before deleting** the old connection, and hand the ticket
+  to the reset effect (do **not** hold it across the DELETE — a hung DELETE would otherwise stick the
+  gate). Order: `beginConnectionSwitch` → `commitActiveConnection(newActive)` (validated) →
+  `handoffConnectionSwitch(ticket)` + publish React/global/localStorage → **then** DELETE the old row →
+  update `additionalConnections` **only after DELETE succeeds**. If the commit fails first, nothing was
+  deleted and we roll back to the last-good id (`finally` releases the ticket). If the DELETE fails
+  after a successful commit, the session already sits consistently on the valid replacement; on an
+  **ambiguous** DELETE network failure, **refetch** the connection list rather than assuming the row
+  survived. Because a `Set<number>` can't identify the in-flight switch *target*, **block all removals
+  while a switch is in progress** via the `isConnectionSwitchInProgress()` context predicate (§3b) —
+  simplest and safe. The `isLast` sign-out path is unchanged (it returns before any switch).
+
+### 3d. Route internal writes through the serialized commit — `providers.tsx`
+
+Point the establishment (`:1216`) and migrate-session (`:1253`) writes at `commitActiveConnection` so
+they are ordered against user switches. (Full generation-tagging of their React/global mutations is
+**out of scope** — see §4.)
+
+---
+
+## 4. Explicitly out of scope (documented limitations)
+
+- **Cross-tab / focus-refetch cookie reordering.** Unserialized session GETs (`@auth/core
+  session.js:44-49`, focus/broadcast) can still re-set a stale cookie; each tab has its own serializer.
+  No auto-reconciliation (it can oscillate between tabs). The single-tab guarantee is explicit.
+- **Server-side JWT row validation.** The server sets `token.activeConnectionId` before the Token DB
+  lookup (`:894-911`), so committing to a just-deleted target reports success with stale role. §3c's
+  commit-before-delete avoids the common path; hardening the callback is deferred (Approach B).
+- **Full generation-tagging of internal establishment/migration mutations** (their React/global writes,
+  not just the queued session write) — deferred.
+- **True global (cross-tab) last-wins** — needs server-authoritative active connection with a
+  globally-comparable sequence (Approach B/C from the scoping discussion); not pursued now.
+
+---
+
+## 5. Testing
+
+### 5a. Unit (`node:test`, explicit `.ts` imports) — `app/components/serializedRunner.test.ts`
+- `createSerializedRunner`: order preserved under reversed completion; each caller gets its own
+  result/rejection; a rejection doesn't break the chain; ≤1 call in flight.
+- `commitWithValidation` core (inject `update` + `statusGetter`): `undefined` (no-op) then success →
+  retries and commits + records last-good; `null` (transport) → throws after `MAX_COMMIT_ATTEMPTS`;
+  wrong `activeConnectionId` → retries; waits (bounded) while status ≠ `authenticated`, and a
+  not-ready timeout fails the attempt (retry) without abandoning an in-flight `update`.
+- **Serialization under slow completion:** a slow `update(B)` delays `update(C)`; assert C only starts
+  after B settles and the final committed value is C (this is why the non-aborting timeout was removed
+  — a timed-out B could otherwise land after C).
+- Ticket-set gate helper: releasing C's ticket while D is live keeps `size > 0` (issue-4 regression).
+
+### 5b. E2E — `@admin`, **≥3 connections** (extend `e2e/tests/connectionManager.spec.ts`)
+- 3 connections are required to produce A→B→C (selecting the active one is a no-op `:37-38`; the spec
+  only guarantees one today `:22-25`).
+- `page.route` holds the first `/api/auth/session` update in flight, start the second, release the
+  first; assert convergence by reading **`/api/auth/session` directly** (its `activeConnectionId`) —
+  not a graph op (routes by header, would falsely pass) — and assert the second update POST isn't
+  observed until the first is released.
+- Add regressions: B succeeds → C fails (converge on B); active-connection removal with commit failure
+  (never points at the deleted row); gate stays closed while a newer switch is pending.
+
+### 5c. Gate — same commands CI runs (`.github/workflows/nextjs.yml`)
+`npm test` · `npm run test:coverage` (100% on its allowlist; add `serializedRunner.ts`) ·
+`npm run lint` · `npx tsc --noEmit` · full Playwright in CI.
+
+---
+
+## 6. Risks & mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Serialization + ready-wait + retry adds latency to rapid successive switches. | Bounded (`READY_TIMEOUT_MS`, `MAX_COMMIT_ATTEMPTS`, `COMMIT_BACKOFF_MS`); single switch pays ~0 (chain starts resolved, provider authenticated). |
+| A hung `update()` blocks later switches (chain stays pending). | Accepted residual — **no worse than today's single `await`**, and rare. We deliberately do **not** time-box the `update` await: a non-aborting timeout could let a stale response land after a newer commit (the very race we close). A watchdog may log a stall, but the chain/ticket stay pending until the real request settles. A true abortable fetch is out of scope. |
+| Commit-before-delete changes `confirmRemove` ordering. | Small, contained reorder; `additionalConnections` updated only after DELETE succeeds; ambiguous DELETE failure refetches the list; covered by a new e2e regression; strictly safer (never points at a deleted connection). |
+| Ticket leak / stuck gate. | Winning ticket handed to the reset effect (released after graph reset); all other paths release via `finally`; sign-out/auth reset `clear()`s the set. |
+
+---
+
+## 7. Findings addressed (traceability)
+
+| Source | Concern | This plan |
+| --- | --- | --- |
+| CodeRabbit 🔴 (`ConnectionManager#L51-69`) | superseded `updateSession` commits an older connection | §3a serialized+validated commit |
+| CodeRabbit 🔴 (`providers.tsx#L1615-1620`) | gate cleared while a mutation is in flight | §3b ticket-owned gate; remove `:1632` zero |
+| Round-1/2 #1 | `update()` no-ops while loading; errors→null | §3a ready-wait + validation + throw |
+| Round-1/2 #2 (rollback) | failure leaves cookie/UI/React inconsistent | §3c converge React+global to last-good; commit-before-delete |
+| Round-2 (gate release timing) | releasing before reset effect / newer D | §3b winning ticket handed to the reset effect; released only after graph reset |
+| Round-2 (severity) | overstated impact | §1 corrected + verified |
+| Round-2 (E2E) | 2 conns can't A→B→C; graph-op assert bypasses JWT | §5b ≥3 conns, assert `/api/auth/session` |
+| Round-2 (context API) | `commitActiveConnection(id)` vs object callers | §3a keeps the object signature |
+| Round-3 (non-aborting timeout) | a timed-out `update` can land late and re-set the cookie | §3a timeout removed; chain/ticket stay pending until the real settle |
+| Round-3 (server-side effects) | `contextGen` doesn't undo a server mutation started before the reset | §3b gate stays closed until the reset effect (ticket handoff) |
+| Round-3 (`lastCommittedConnIdRef` init) | unseeded ref can't converge | §3c seed from `sessionData.activeConnectionId`; fallback on rollback |
+| Round-2/3 (cross-tab / server validation / generation) | not solvable single-tab | §4 documented out of scope |
+
+---
+
+## 8. Step-by-step task list
+
+1. `app/components/serializedRunner.ts` (`createSerializedRunner` + `commitWithValidation`) + tests.
+2. `providers.tsx`: `commitActiveConnection` (serialize + ready-wait + validate + retry, **no**
+   non-aborting timeout) + `lastCommittedConnIdRef` (seeded from the session); expose as context
+   `updateSession` (`:696`/`:700`).
+3. `providers.tsx`: ticket-**set** gate + target-keyed `committedSwitchRef` + `handoffConnectionSwitch`
+   + `isConnectionSwitchInProgress`; predicate at `:722`/`:852`; replace the `:1632` zero with a
+   reset-effect release of the matching handed-off ticket (don't skip it in the early-return branches);
+   update `provider.ts:244` type + expose `handoffConnectionSwitch`/`isConnectionSwitchInProgress`.
+4. `ConnectionManager.tsx`: `try/finally` ticket lifecycle (handoff on win, `finally` release
+   otherwise); converge React+global on failure; commit-before-delete in `confirmRemove` (update list
+   only after DELETE; refetch on ambiguous failure); block removals while any switch ticket is live.
+5. `providers.tsx`: route internal writes (`:1216`/`:1253`) through `commitActiveConnection`.
+6. Extend `connectionManager.spec.ts` (≥3 connections; §5b) + unit tests.
+7. Run the §5c gate; open PR to `staging`; drive Copilot + CodeRabbit threads to resolved. **No merge
+   without @barakb's approval.**
+
+---
+
+## 9. Open decisions for you
+
+1. **`confirmRemove` commit-before-delete** (§3c): include (recommended — it's the minimal way to make
+   the removal path converge) or keep DELETE-first with best-effort convergence?
+2. **Coverage allowlist:** add `serializedRunner.ts` at 100% (recommended)?
+3. **Tuning constants** (`MAX_COMMIT_ATTEMPTS`, `READY_TIMEOUT_MS`, `COMMIT_BACKOFF_MS`) — proposed
+   defaults 3 / 3000ms / 150ms; adjust?

--- a/idea-7-serialize-connection-switch-plan.md
+++ b/idea-7-serialize-connection-switch-plan.md
@@ -80,6 +80,94 @@ So the finding is real (persisted session + UI diverge from the user's last choi
 
 ---
 
+## 1a. Worked examples — the race, step by step
+
+Setup: a user has three connections `A`, `B`, `C` (ids `conn-A`, `conn-B`, `conn-C`). They click the
+connection dropdown quickly — A→B, then immediately B→C. Each click runs a switch site that calls
+`updateSession({ activeConnectionId })`, which is **one HTTP POST** to `/api/auth/session` returning a
+fresh JWT cookie. Legend: **cookie** = the JWT the browser holds · **UI** = React `activeConnectionId`
+· **global** = `_activeConnectionId` (the `X-Connection-Id` header source, set synchronously).
+
+### Example 1 — network reordering strands the JWT on the superseded connection (the core bug)
+
+```
+t0  click B:  beginConnectionSwitch()→ticket#1   global=B   POST update(B) ──┐ (in flight)
+t1  click C:  beginConnectionSwitch()→ticket#2   global=C   POST update(C) ─┐│ (in flight)
+t2  server handles update(C)  → Set-Cookie jwt(active=conn-C)               ││
+t3  server handles update(B)  → Set-Cookie jwt(active=conn-B)               ││
+t4  update(C) response arrives → browser cookie=C   handleSelect(C): isLatestSwitch(#2)=true  → UI=C
+t5  update(B) response arrives → browser cookie=B   handleSelect(B): isLatestSwitch(#1)=false → no publish
+```
+
+**End state: UI = C, cookie = B.** `isLatestSwitch` kept the *UI* on C but cannot control which
+`Set-Cookie` the browser applies last; `update(B)`'s response simply landed after `update(C)`'s
+(ordinary jitter). Header-routed graph queries still hit C (global=C), but `session.user.role/host/
+port` now reflect **B**, and any header-less request (`options.ts:1112` fallback) resolves to **B**.
+
+**With the fix (§3a)** `update(C)` is chained after `update(B)` and does not even start until
+`update(B)`'s response — and its `Set-Cookie` — has been received:
+
+```
+t0  click B:  ticket#1   POST update(B) ─── … ─── response, cookie=B
+t1  click C:  ticket#2   (queued — not sent yet)
+t2  update(B) settles → chain advances → POST update(C) ─── response, cookie=C
+```
+
+Only one update is ever in flight, so the final cookie is deterministically **C** — immune to
+reordering.
+
+### Example 2 — why naïve chaining alone is *not* enough (`update()` no-ops while loading)
+
+If we chain but call the raw `useSession().update` closure at microtask time:
+
+```
+update(B) resolves → next-auth setLoading(true)→setLoading(false), a re-render is SCHEDULED
+chained update(C) fires on the SAME microtask flush, BEFORE that re-render commits
+  → the closure it reads still has loading=true
+  → next-auth `if (loading) return;`  → update(C) returns undefined, performs NO HTTP write
+  → C's promise resolves(undefined) → naïve code treats it as success → UI=C, cookie STILL B
+```
+
+The fix therefore **validates** the result: `commitActiveConnection` waits for `status ===
+"authenticated"` and accepts a commit only when the returned session reports
+`activeConnectionId === conn-C`, else it retries. `undefined`/`null` are never treated as success.
+
+### Example 3 — failure rollback must converge all three states
+
+```
+click B → commit(B) succeeds, cookie=B, but superseded by C → B never publishes (UI stays A). lastCommitted=B.
+click C → commit(C) fails (transport error → next-auth returns null → we throw after bounded retries)
+```
+
+Naïve rollback (global only) → UI=A, global/cookie=B → **divergent**. The fix (§3c) rolls back **both**
+React and global/localStorage to the last-committed id (`conn-B`), so all three converge on **B** — the
+connection the session is actually on.
+
+### Example 4 — zeroing the gate clobbers a newer switch
+
+```
+click C → commit(C) ok → setActiveConnectionId(C) scheduled
+click D → beginConnectionSwitch()→ticket#3   (D now pending; graph ops must stay blocked)
+C's reset effect runs → OLD code: pendingSwitchesRef.current = 0  → gate OPEN while D still in flight
+  → a graph op (runQuery/fetchCount) starts mid-D → can query/auto-create the wrong graph on conn-D
+```
+
+The fix (§3b) makes the gate a **set** of tickets released per-ticket via a target-keyed handoff; C's
+reset effect releases only C's ticket, and D's ticket keeps the gate closed.
+
+### Example 5 — removing the active connection must never point the session at a deleted row
+
+```
+OLD confirmRemove: DELETE conn-A → then commit(newActive) fails
+  → the JWT cookie still points at the now-deleted conn-A
+  → next getClient() fallback can 401 / SESSION_INVALID → the user is bounced
+```
+
+The fix (§3c) **commits the replacement before deleting**, and updates `additionalConnections` only
+after the DELETE succeeds — the session is always on a live connection.
+
+---
+
 ## 2. Why the naïve serializer is insufficient (both rubber-duck rounds)
 
 1. **`update()` no-ops while loading** → a microtask-chained call reads the still-`loading` closure,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "node --test \"app/**/*.test.ts\" \"lib/**/*.test.ts\"",
-    "test:coverage": "node --test --experimental-test-coverage --test-coverage-include=\"lib/cypherSuggestions.ts\" --test-coverage-include=\"lib/cypherDiagnostics.ts\" --test-coverage-include=\"lib/aiFix.ts\" --test-coverage-include=\"lib/cypherErrors.ts\" --test-coverage-include=\"lib/clipboard.ts\" --test-coverage-include=\"app/graph/confidence.ts\" --test-coverage-include=\"app/graph/chatHistory.ts\" --test-coverage-lines=100 --test-coverage-functions=100 --test-coverage-branches=100 \"app/**/*.test.ts\" \"lib/**/*.test.ts\"",
+    "test:coverage": "node --test --experimental-test-coverage --test-coverage-include=\"lib/cypherSuggestions.ts\" --test-coverage-include=\"lib/cypherDiagnostics.ts\" --test-coverage-include=\"lib/aiFix.ts\" --test-coverage-include=\"lib/cypherErrors.ts\" --test-coverage-include=\"lib/clipboard.ts\" --test-coverage-include=\"app/graph/confidence.ts\" --test-coverage-include=\"app/graph/chatHistory.ts\" --test-coverage-include=\"app/components/serializedRunner.ts\" --test-coverage-lines=100 --test-coverage-functions=100 --test-coverage-branches=100 \"app/**/*.test.ts\" \"lib/**/*.test.ts\"",
     "test:smoke": "node --test \"lib/**/*.smoke.ts\"",
     "test:e2e": "playwright test"
   },


### PR DESCRIPTION
## What & why

Closes the **🔴 Critical** CodeRabbit thread on #1951 — "the ticket still does not serialize the session mutation" (`app/components/ConnectionManager.tsx#L51-69` + `app/providers.tsx#L1615-1620`). Overlapping connection switches (A→B→C in one tab) must converge the persisted JWT, the React UI, the module-global id, and the switch gate on the **last-selected** connection — never a superseded one.

Design + rationale: `idea-7-serialize-connection-switch-plan.md` (passed **5 rounds** of rubber-duck review; §1a has worked examples).

## Scope (agreed with @barakb): minimal, single-tab

Code verification **narrowed the real severity**: header-routed graph ops already hit the correct connection (`X-Connection-Id` + Token DB role) and reload auto-select uses localStorage — so the residual bug is **session/UI metadata divergence + header-less/fallback routing**, not live query misrouting. Cross-tab / focus-refetch reordering and server-authoritative last-wins are **out of scope** (documented in §4).

## Implementation (landed)

- **`app/components/serializedRunner.ts`** (new) — `createSerializedRunner` (FIFO) + `commitWithValidation` (waits for `status === "authenticated"`, **validates** `result.activeConnectionId === target`, bounded retries, throws on failure; **no** non-aborting timeout). 100% unit-tested and added to the `test:coverage` allowlist.
- **`app/providers.tsx`** — `commitActiveConnection` wraps the raw next-auth `update` as the context `updateSession`; `lastCommittedConnIdRef` seeded from the session. **Ticket-owned gate**: `Set<number>` of live tickets + target-keyed `committedSwitchRef` `{ticket,targetId}` + `handoffConnectionSwitch` (retires the prior handed-off ticket) + `isConnectionSwitchInProgress`. The reset effect releases **only the matching** handed-off ticket after graph state is re-pinned (incl. the early-return / rollback-to-same-id / first-establishment branches) — never a global zero. Internal establishment/migration writes routed through the serialized commit; auth-reset clears the gate.
- **`app/components/ConnectionManager.tsx`** — `try/finally` ticket lifecycle with a `handedOff` flag across all three handlers; on failure, converge **React + global + localStorage** to the last-committed connection (via handoff when it changes React). `confirmRemove` does **commit-before-delete** (never points the session at a deleted row), blocks removals while a switch is in progress, updates the list only after DELETE, and refetches on an ambiguous DELETE failure.
- **`app/components/provider.ts`** — context type + defaults for the new API.

## Validation — all green

- [x] `npm test` (358) · `npm run test:coverage` (100% incl. `serializedRunner.ts`) · `npm run lint` (0 errors) · `npx tsc --noEmit`
- [x] Independent code-review pass on the implementation → **"runtime implementation is sound"** (no runtime bugs; ticket algebra verified against the plan's worked examples)
- [x] **Deterministic e2e regression** (`connectionManager.spec.ts`, `@admin`, ≥3 connections): holds B's `/api/auth/session` update in-flight, triggers C, releases B, and asserts `/api/auth/session` converges on **C** (asserted directly, not via a graph op which routes by header). Verified locally against FalkorDB v4.18.10; the pre-fix code leaves the cookie on B.

## Review

Monitoring + resolving Copilot & CodeRabbit threads. **Not merging without @barakb's approval.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved connection switching with overlap convergence so the last selected connection is retained.
  * Automatically switches to a newly added connection.
* **Bug Fixes**
  * Prevented conflicting connection switching and removal during in-progress operations.
  * Improved active-connection removal by committing the switch before deleting, with rollback on failures.
  * Added safer session-commit validation and retry behavior to avoid stale updates.
* **Tests**
  * Added unit tests for serialized, validated session-commit helpers.
  * Added an end-to-end regression test for overlapping A→B→C switching.
* **Documentation**
  * Added an implementation plan describing the approach, risks, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->