### PR TITLE
fix: address PR #2062 review feedback

### DIFF
--- a/app/components/ForceGraph.tsx
+++ b/app/components/ForceGraph.tsx
@@ -67,6 +67,11 @@ export default function ForceGraph({
     const { background, foreground } = getTheme(theme);
 
     const lastClick = useRef<{ date: number, id: number }>({ date: 0, id: -1 });
+    // One counter per node, bumped whenever a double-click toggles its expansion.
+    // An expand awaits a fetch, so a collapse and a re-expand can both land while
+    // it is in flight; a completion only touches the graph while its token is
+    // still the node's latest.
+    const expandTokens = useRef(new Map<number, number>());
     // When non-null, holds the `data` snapshot at the moment a graphData restore
     // was consumed. The immediately-following setGraphData(undefined) re-run is
     // skipped only when data still matches — if React batches a real data refresh
@@ -252,9 +257,15 @@ export default function ForceGraph({
         lastClick.current = isDoubleClick ? { date: 0, id: -1 } : { date: now, id: node.id };
 
         if (isDoubleClick) {
+            const token = (expandTokens.current.get(node.id) ?? 0) + 1;
+            expandTokens.current.set(node.id, token);
+
             fullNode.expand = !fullNode.expand;
             if (fullNode.expand) {
                 await onFetchNode(fullNode, node);
+                // A newer toggle superseded this one while the fetch was in
+                // flight; it owns the node's neighbours now.
+                if (expandTokens.current.get(node.id) !== token) return;
                 // Guard: if the node was collapsed while fetching, undo the expansion.
                 if (!fullNode.expand) {
                     deleteNeighbors([fullNode]);

--- a/app/components/Tutorial.tsx
+++ b/app/components/Tutorial.tsx
@@ -792,6 +792,9 @@ function TutorialPortal({
 
     const [mounted, setMounted] = useState(false);
     const [targetDisabled, setTargetDisabled] = useState(false);
+    // The step's target never showed up. An action-gated step has no Next of its
+    // own, so without this the user would sit on a step with nothing to click.
+    const [targetUnavailable, setTargetUnavailable] = useState(false);
     // Whether the step Next leads to has its target on screen yet.
     const [nextReady, setNextReady] = useState(true);
     const [arrowStyle, setArrowStyle] = useState<React.CSSProperties>({ display: 'none' });
@@ -845,6 +848,7 @@ function TutorialPortal({
     // Also stop keep-alive UNLESS the incoming step is the expected passthrough consumer.
     useEffect(() => {
         setRetryCount(0);
+        setTargetUnavailable(false);
         advancePendingRef.current = false;
         advanceCancelledRef.current = false;
         // Only preserve keep-alive for passthrough steps that will consume it
@@ -912,8 +916,10 @@ function TutorialPortal({
                     const id = window.setTimeout(() => setRetryCount(c => c + 1), 150);
                     return () => window.clearTimeout(id);
                 }
-                // Gave up after 15 retries — clean up keep-alive and hide arrow
+                // Gave up after 15 retries — clean up keep-alive, hide the arrow
+                // and fall back to a manual Next so the step stays escapable.
                 stopKeepAlive();
+                setTargetUnavailable(true);
                 setArrowStyle({ display: 'none' });
                 return () => { };
             }
@@ -1503,12 +1509,20 @@ function TutorialPortal({
                     </>
                 }
                 {
-                    advanceOn && targetSelector &&
+                    advanceOn && targetSelector && !targetUnavailable &&
                     <div className="flex items-center gap-2 p-3 bg-primary/10 rounded-lg">
                         <svg className="w-5 h-5 text-primary flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122" />
                         </svg>
                         <span className="text-sm text-primary font-medium">Click the highlighted element to continue</span>
+                    </div>
+                }
+                {
+                    targetUnavailable &&
+                    <div className="flex items-center gap-2 p-3 bg-secondary rounded-lg" data-testid="tutorialTargetUnavailable">
+                        <span className="text-sm text-muted-foreground">
+                            We couldn&apos;t find this step&apos;s element on the page. Continue to the next step or skip the tutorial.
+                        </span>
                     </div>
                 }
                 {
@@ -1534,8 +1548,10 @@ function TutorialPortal({
                                 />
                             }
                             {
-                                // If step does not require user action, show enabled Next/Finish
-                                !advanceOn && (
+                                // A step the user advances by acting on the page
+                                // has no Next of its own — unless its target never
+                                // arrived, in which case Next is the only way out.
+                                (!advanceOn || targetUnavailable) && (
                                     <>
                                         {
                                             // A disabled button fires no pointer
@@ -1549,7 +1565,7 @@ function TutorialPortal({
                                         }
                                         <Button
                                             data-testid="tutorialNext"
-                                            disabled={targetDisabled || !nextReady}
+                                            disabled={(targetDisabled && !targetUnavailable) || !nextReady}
                                             variant="Primary"
                                             label={isLastStep ? "Finish" : "Next"}
                                             onClick={isLastStep ? onClose : onNext}

--- a/app/graph/CustomizeStylePanel.tsx
+++ b/app/graph/CustomizeStylePanel.tsx
@@ -2,7 +2,7 @@
 
 import { useContext, useState, useEffect, useCallback, useRef } from "react";
 import { X, Palette } from "lucide-react";
-import { CustomizingItem, LabelStyle, LinkStyle, Label, cn } from "@/lib/utils";
+import { CustomizingItem, LabelStyle, LinkStyle, Label, cn, TAB } from "@/lib/utils";
 import { GraphContext, ForceGraphContext, BrowserSettingsContext } from "@/app/components/provider";
 import { STYLE_COLORS, getLabelWithFewestElements } from "@/app/api/graph/model";
 import { setConnectionItem } from "@/lib/connection-storage";
@@ -118,7 +118,7 @@ export default function CustomizeStylePanel({ customizing, onClose }: Props) {
         // schema view keeps a legend of its own — built from its own elements —
         // and re-derives it from the graph info below, so handing it the graph's
         // labels would only flash the wrong list at it.
-        const ownsLegend = currentTab !== "Schema";
+        const ownsLegend = currentTab !== TAB.Schema;
 
         if (isNode) {
             const size = NODE_SIZE * scale;

--- a/app/graph/DataTable.tsx
+++ b/app/graph/DataTable.tsx
@@ -54,7 +54,12 @@ function SchemaRuleIndicators({ propertyKey, rules }: { propertyKey: string, rul
                 indicators.map(({ id, label, description, Icon }) => (
                     <Tooltip key={id}>
                         <TooltipTrigger asChild>
-                            <span role="img" aria-label={label} data-testid={`DataPanelAttribute${id}${propertyKey}`}>
+                            <span
+                                role="img"
+                                tabIndex={0}
+                                aria-label={label}
+                                data-testid={`DataPanelAttribute${id}${propertyKey}`}
+                            >
                                 <Icon size={iconSize} />
                             </span>
                         </TooltipTrigger>
@@ -230,7 +235,9 @@ export default function DataTable({ object, type, lastObjId, canvasRef, classNam
             return;
         }
 
-        const valueType = value === undefined ? "string" : inferValueType(value);
+        // The type the property was last written with wins: a temporal value reads
+        // back as plain ISO text, which inference alone reports as a string.
+        const valueType = value === undefined ? "string" : (writtenTypes.current[key] ?? inferValueType(value));
 
         setEditable(key);
         // Only the switch holds a value as-is; every other type is edited as
@@ -688,7 +695,7 @@ export default function DataTable({ object, type, lastObjId, canvasRef, classNam
                                         onMouseLeave={() => setHover("")}
                                         key={`${key}-type`}
                                     >
-                                        {editable === key ? getNewTypeInput() : <p className="w-full truncate">{inferValueType(value)}</p>}
+                                        {editable === key ? getNewTypeInput() : <p className="w-full truncate">{writtenTypes.current[key] ?? inferValueType(value)}</p>}
                                     </div>
                                     <div
                                         className={cellClass}

--- a/lib/graphValues.test.ts
+++ b/lib/graphValues.test.ts
@@ -132,6 +132,23 @@ test("parseValue checks the temporal formats", () => {
     assert.match(failure("duration", "P3T12H"), /Expected the format/);
 });
 
+test("parseValue rejects a temporal value that has the right shape but cannot exist", () => {
+    // These used to reach FalkorDB, where `date()`/`localtime()` failed and the
+    // user saw a raw Cypher error instead of the format hint.
+    assert.match(failure("date", "2025-13-15"), /Expected the format/);
+    assert.match(failure("date", "2025-09-45"), /Expected the format/);
+    assert.match(failure("date", "2025-00-15"), /Expected the format/);
+    assert.match(failure("time", "25:00"), /Expected the format/);
+    assert.match(failure("time", "07:61"), /Expected the format/);
+    assert.match(failure("time", "07:00:61"), /Expected the format/);
+    assert.match(failure("datetime", "2025-06-29T25:61"), /Expected the format/);
+
+    // The edges of each range still pass.
+    assert.equal(parsed("date", "2025-12-31"), "2025-12-31");
+    assert.equal(parsed("time", "23:59:59"), "23:59:59");
+    assert.equal(parsed("datetime", "2025-01-01T00:00"), "2025-01-01T00:00");
+});
+
 test("parseValue passes strings through", () => {
     assert.equal(parsed("string", "  keeps its spaces  "), "  keeps its spaces  ");
 });

--- a/lib/graphValues.ts
+++ b/lib/graphValues.ts
@@ -25,13 +25,18 @@ export type ValueType = (typeof VALUE_TYPES)[number];
 /** A geospatial point, in the shape the client hands back. */
 export type GeoPoint = { latitude: number; longitude: number };
 
+/** The values FalkorDB stores as-is. */
+export type ScalarValue = string | number | boolean;
+
+/**
+ * A list FalkorDB can persist. Lists nest as deep as they like, but they hold
+ * scalars only — a point inside a list is not storable, so it stays out of the
+ * type as well.
+ */
+export type ValueArray = (ScalarValue | ValueArray)[];
+
 /** Anything that can sit on the right-hand side of a `SET n.key = …`. */
-export type PropertyValue =
-  | string
-  | number
-  | boolean
-  | GeoPoint
-  | PropertyValue[];
+export type PropertyValue = ScalarValue | GeoPoint | ValueArray;
 
 /**
  * How each type is written. Everything travels as a query parameter; the types
@@ -65,9 +70,13 @@ export const VALUE_PLACEHOLDERS: Partial<Record<ValueType, string>> = {
   duration: "P3DT12H",
 };
 
-const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-const TIME_PATTERN = /^\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/;
-const DATETIME_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/;
+// Digit counts alone would let `2025-13-45` or `25:61` through to FalkorDB,
+// where the failure surfaces as a raw Cypher error instead of the format hint.
+const DATE_BODY = String.raw`\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])`;
+const TIME_BODY = String.raw`([01]\d|2[0-3]):[0-5]\d(:[0-5]\d(\.\d+)?)?`;
+const DATE_PATTERN = new RegExp(`^${DATE_BODY}$`);
+const TIME_PATTERN = new RegExp(`^${TIME_BODY}$`);
+const DATETIME_PATTERN = new RegExp(`^${DATE_BODY}T${TIME_BODY}$`);
 // ISO 8601 duration: at least one component, time components after the `T`.
 const DURATION_PATTERN =
   /^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$/;
@@ -185,7 +194,7 @@ export function parseValue(type: ValueType, raw: PropertyValue): ParseResult {
         return { error: "An array holds strings, numbers, booleans or arrays of them" };
       }
 
-      return { value: parsed as PropertyValue[] };
+      return { value: parsed as ValueArray };
     }
     case "date":
     case "time":

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -456,6 +456,7 @@ describe("parsePanelSizePercent", () => {
   it("accepts a stored percentage", () => {
     assert.equal(parsePanelSizePercent("42"), 42);
     assert.equal(parsePanelSizePercent("33.5"), 33.5);
+    assert.equal(parsePanelSizePercent("100"), 100);
   });
 
   it("rejects anything that is not a usable percentage, so the caller keeps its default", () => {
@@ -474,6 +475,8 @@ describe("parsePanelSizePercent", () => {
     assert.equal(parsePanelSizePercent("0"), undefined);
     assert.equal(parsePanelSizePercent("-10"), undefined);
     assert.equal(parsePanelSizePercent("1e999"), undefined);
+    // Over a full width: would have produced a CSS size of `150%`.
+    assert.equal(parsePanelSizePercent("150"), undefined);
   });
 });
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,7 +12,7 @@ import { signOut } from "next-auth/react";
 import { getCypherErrorHint, SYNTAX_ERROR_HINT, parseSyntaxError, enrichSyntaxMessage, type SyntaxErrorInfo, type HintLink } from "./cypherErrors.ts";
 import { suggestForError, findFuncArgTypo } from "./cypherSuggestions.ts";
 import { quoteCypherIdentifier } from "./cypher.ts";
-import type { GeoPoint } from "./graphValues.ts";
+import type { PropertyValue } from "./graphValues.ts";
 
 export { parseSyntaxError };
 export type { SyntaxErrorInfo };
@@ -38,8 +38,11 @@ export const screenSize = {
 };
 
 
-/** Every type FalkorDB can persist as a property value. */
-export type Value = string | number | boolean | GeoPoint | Value[];
+/**
+ * Every type FalkorDB can persist as a property value. Aliased so the editor
+ * and the parsing/validation layer cannot drift apart.
+ */
+export type Value = PropertyValue;
 
 export type HistoryQuery = {
   queries: Query[];
@@ -211,6 +214,18 @@ export type TextCell = {
 };
 
 export type Tab = "Graph" | "Table" | "Metadata" | "Schema";
+
+/**
+ * The tab ids, as values. Ownership checks (who drives the legend, which
+ * selection is live) key off these instead of spelling the id out inline, so a
+ * rename stays a single edit and can never be confused with a display label.
+ */
+export const TAB = {
+  Graph: "Graph",
+  Table: "Table",
+  Metadata: "Metadata",
+  Schema: "Schema",
+} as const satisfies Record<Tab, Tab>;
 
 /**
  * One observed placement of a relationship type: the source label, the
@@ -847,7 +862,8 @@ export function prepareArg(arg: string) {
  * Reads a panel width back out of storage, which anything can have written to.
  * The size is applied in an animation frame, where a throw is swallowed and the
  * panel would silently keep the wrong width, so a value that is not a usable
- * percentage yields `undefined` and the caller falls back to its default.
+ * percentage — anything outside `(0, 100]` — yields `undefined` and the caller
+ * falls back to its default.
  */
 export function parsePanelSizePercent(stored: string | null | undefined): number | undefined {
   if (!stored) return undefined;
@@ -855,7 +871,7 @@ export function parsePanelSizePercent(stored: string | null | undefined): number
   try {
     const parsed: unknown = JSON.parse(stored);
 
-    return typeof parsed === "number" && Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+    return typeof parsed === "number" && Number.isFinite(parsed) && parsed > 0 && parsed <= 100 ? parsed : undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
- Bound the date/time patterns so an impossible temporal value (2025-13-45, 25:61) is rejected in the editor instead of failing as a raw Cypher error.
- Narrow the property-value types so a list holds scalars only, and alias `Value` to `PropertyValue` so the two cannot drift.
- Clamp `parsePanelSizePercent` to (0, 100]; a corrupted store could size a panel to 150%.
- Preselect and display the type a property was last written with, so re-editing a date no longer downgrades it to a string.
- Give the constraint indicator a tab stop so its description is reachable by keyboard and screen reader.
- Key the legend-ownership check off a shared tab id constant.
- Ignore a stale expand completion so a rapid collapse/re-expand cannot remove neighbours a newer expansion added.
- Fall back to a manual Next when a step's target never arrives, so an action-gated tutorial step cannot strand the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented outdated graph expansion results from overwriting newer user actions.
  - Improved tutorial recovery when required controls are unavailable, allowing users to continue.
  - Preserved explicitly selected data types, including temporal values.
  - Rejected invalid temporal values and panel widths above 100%.

- **Accessibility**
  - Made schema rule indicators keyboard-focusable.

- **Improvements**
  - Added consistent tab navigation identifiers.
  - Improved support for nested property arrays and value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->