### PR TITLE
feat: enhance date validation and improve tutorial step handling

### DIFF
--- a/app/api/validate-body.test.ts
+++ b/app/api/validate-body.test.ts
@@ -64,7 +64,7 @@ describe("updateGraphElementAttribute", () => {
 
       assert.equal(result.success, false, JSON.stringify(body));
       // The schema names the type it was checking, so the reason is a substring.
-      assert.match(result.error?.issues[0].message ?? "", new RegExp(CALENDAR_DATE_ERROR), JSON.stringify(body));
+      assert.ok((result.error?.issues[0].message ?? "").includes(CALENDAR_DATE_ERROR), JSON.stringify(body));
     });
 
     // A leap day the year actually has still goes through.

--- a/app/api/validate-body.test.ts
+++ b/app/api/validate-body.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { updateGraphElementAttribute } from "./validate-body.ts";
+import { CALENDAR_DATE_ERROR } from "../../lib/graphValues.ts";
 
 const parse = (body: unknown) => updateGraphElementAttribute.safeParse(body);
 
@@ -48,6 +49,27 @@ describe("updateGraphElementAttribute", () => {
     assert.equal(result.success, false);
     assert.deepEqual(result.error?.issues[0].path, ["value"]);
     assert.match(result.error?.issues[0].message ?? "", /date/);
+  });
+
+  it("turns away a day the month never had, the shape alone cannot catch it", () => {
+    const impossible: unknown[] = [
+      { type: true, valueType: "date", value: "2025-02-29" },
+      { type: true, valueType: "date", value: "2025-04-31" },
+      { type: true, valueType: "date", value: "1900-02-29" },
+      { type: true, valueType: "datetime", value: "2025-02-30T12:00:00" },
+    ];
+
+    impossible.forEach((body) => {
+      const result = parse(body);
+
+      assert.equal(result.success, false, JSON.stringify(body));
+      // The schema names the type it was checking, so the reason is a substring.
+      assert.match(result.error?.issues[0].message ?? "", new RegExp(CALENDAR_DATE_ERROR), JSON.stringify(body));
+    });
+
+    // A leap day the year actually has still goes through.
+    assert.equal(parse({ type: true, valueType: "date", value: "2024-02-29" }).success, true);
+    assert.equal(parse({ type: true, valueType: "date", value: "2000-02-29" }).success, true);
   });
 
   it("without a type, takes only what a query parameter carries on its own", () => {

--- a/app/api/validate-body.ts
+++ b/app/api/validate-body.ts
@@ -2,7 +2,14 @@ import { z } from "zod";
 // Relative, extension-carrying paths: the schemas are unit-tested under plain
 // node, which has no view of the bundler's `@/` alias.
 import { UDF_CHAT_MAX_LIBRARIES, UDF_CHAT_MAX_FUNCTIONS_PER_LIBRARY, UDF_CHAT_MAX_NAME_LENGTH } from "../utils.ts";
-import { VALUE_TYPES, VALUE_PATTERNS, VALUE_PLACEHOLDERS, type ValueType } from "../../lib/graphValues.ts";
+import {
+  VALUE_TYPES,
+  VALUE_PATTERNS,
+  VALUE_PLACEHOLDERS,
+  CALENDAR_DATE_ERROR,
+  isCalendarDate,
+  type ValueType,
+} from "../../lib/graphValues.ts";
 
 export const createUser = z.object({
   username: z
@@ -122,7 +129,10 @@ const attributeText = z.string().min(1, "Attribute value cannot be empty");
 const geoPoint = z.object({ latitude: z.number(), longitude: z.number() });
 
 const temporal = (type: keyof typeof VALUE_PATTERNS) =>
-  z.string().regex(VALUE_PATTERNS[type], `Expected the format ${VALUE_PLACEHOLDERS[type]}`);
+  z
+    .string()
+    .regex(VALUE_PATTERNS[type], `Expected the format ${VALUE_PLACEHOLDERS[type]}`)
+    .refine((text) => isCalendarDate(type, text), CALENDAR_DATE_ERROR);
 
 /**
  * What each type needs `value` to hold. The route hands `value` to the Cypher

--- a/app/components/ForceGraph.tsx
+++ b/app/components/ForceGraph.tsx
@@ -147,7 +147,11 @@ export default function ForceGraph({
         };
     }, [canvasRef, setGraphData, setViewport, canvasLoaded]);
 
-    const onFetchNode = useCallback(async (node: Node, clickedNode: GraphNode) => {
+    // `isCurrent` reports whether the toggle that started this fetch is still the
+    // one that owns the node's neighbours. It is checked before every commit, not
+    // just on the way out: a superseded expansion that merged its result would
+    // paint neighbours back onto a node the user has since collapsed.
+    const onFetchNode = useCallback(async (node: Node, isCurrent: () => boolean) => {
         const canvas = canvasRef.current;
         if (!canvas || !canvasLoaded) return;
         const startEpoch = getConnectionEpoch();
@@ -160,13 +164,13 @@ export default function ForceGraph({
             }
         }, toast, setIndicator, cid);
 
-        if (getConnectionEpoch() !== startEpoch) return;
+        if (getConnectionEpoch() !== startEpoch || !isCurrent()) return;
         if (result.ok) {
             const json = await result.json();
-            if (getConnectionEpoch() !== startEpoch) return;
+            if (getConnectionEpoch() !== startEpoch || !isCurrent()) return;
 
             const elements = await graph.extend(json.result, true, true);
-            if (getConnectionEpoch() !== startEpoch) return;
+            if (getConnectionEpoch() !== startEpoch || !isCurrent()) return;
 
             if (elements.length === 0) {
                 toast({
@@ -262,10 +266,18 @@ export default function ForceGraph({
 
             fullNode.expand = !fullNode.expand;
             if (fullNode.expand) {
-                await onFetchNode(fullNode, node);
-                // A newer toggle superseded this one while the fetch was in
-                // flight; it owns the node's neighbours now.
-                if (expandTokens.current.get(node.id) !== token) return;
+                await onFetchNode(fullNode, () => expandTokens.current.get(node.id) === token);
+
+                if (expandTokens.current.get(node.id) !== token) {
+                    // A newer toggle superseded this one while the fetch was in
+                    // flight; it owns the node's neighbours now. `graph.extend`
+                    // mutates in place and awaits along the way, so a collapse
+                    // that landed mid-merge may have swept before the neighbours
+                    // arrived — sweep again for it.
+                    if (!fullNode.expand) deleteNeighbors([fullNode]);
+                    return;
+                }
+
                 // Guard: if the node was collapsed while fetching, undo the expansion.
                 if (!fullNode.expand) {
                     deleteNeighbors([fullNode]);

--- a/app/components/Tutorial.tsx
+++ b/app/components/Tutorial.tsx
@@ -559,6 +559,9 @@ const tutorialSteps: TutorialStep[] = [
 const NEXT_TARGET_TIMEOUT = 10000;
 const NEXT_TARGET_POLL = 150;
 
+/** How often a step whose target never arrived keeps looking for it. */
+const TARGET_WATCH_POLL = 300;
+
 /** Helper: close any open overlays/panels that might be stale */
 function closeStaleOverlays(): void {
     // Close layout dropdown if open (check content portal existence, not data-state which conflicts with TooltipTrigger)
@@ -921,7 +924,20 @@ function TutorialPortal({
                 stopKeepAlive();
                 setTargetUnavailable(true);
                 setArrowStyle({ display: 'none' });
-                return () => { };
+
+                // The fallback is an escape hatch, not a verdict: a target that
+                // simply took longer than the retry budget (a slow fetch, a late
+                // render) must not leave an action-gated step permanently
+                // advanceable with no arrow. Keep watching, and hand the step
+                // back to the normal path the moment it shows up.
+                const watch = window.setInterval(() => {
+                    if (!document.querySelector(targetSelector)) return;
+                    window.clearInterval(watch);
+                    setTargetUnavailable(false);
+                    setRetryCount(0);
+                }, TARGET_WATCH_POLL);
+
+                return () => window.clearInterval(watch);
             }
 
             if (element) {
@@ -1519,7 +1535,12 @@ function TutorialPortal({
                 }
                 {
                     targetUnavailable &&
-                    <div className="flex items-center gap-2 p-3 bg-secondary rounded-lg" data-testid="tutorialTargetUnavailable">
+                    <div
+                        role="status"
+                        aria-live="polite"
+                        className="flex items-center gap-2 p-3 bg-secondary rounded-lg"
+                        data-testid="tutorialTargetUnavailable"
+                    >
                         <span className="text-sm text-muted-foreground">
                             We couldn&apos;t find this step&apos;s element on the page. Continue to the next step or skip the tutorial.
                         </span>

--- a/app/components/Tutorial.tsx
+++ b/app/components/Tutorial.tsx
@@ -1534,18 +1534,23 @@ function TutorialPortal({
                     </div>
                 }
                 {
-                    targetUnavailable &&
-                    <div
-                        role="status"
-                        aria-live="polite"
-                        className="flex items-center gap-2 p-3 bg-secondary rounded-lg"
-                        data-testid="tutorialTargetUnavailable"
-                    >
-                        <span className="text-sm text-muted-foreground">
-                            We couldn&apos;t find this step&apos;s element on the page. Continue to the next step or skip the tutorial.
-                        </span>
-                    </div>
+                    // The live region is mounted for every step, not only while the
+                    // message shows: a region inserted together with its text is
+                    // announced unreliably, and one that is only ever replaced by an
+                    // identical copy is not re-announced at all. Keeping it means the
+                    // content genuinely goes empty -> text on each occurrence.
+                    // `empty:hidden` keeps the placeholder out of the panel's layout.
                 }
+                <div role="status" aria-live="polite" className="empty:hidden">
+                    {
+                        targetUnavailable &&
+                        <div className="flex items-center gap-2 p-3 bg-secondary rounded-lg" data-testid="tutorialTargetUnavailable">
+                            <span className="text-sm text-muted-foreground">
+                                We couldn&apos;t find this step&apos;s element on the page. Continue to the next step or skip the tutorial.
+                            </span>
+                        </div>
+                    }
+                </div>
                 {
                     step > 0 &&
                     <div className="flex justify-between items-center gap-4 pt-4">

--- a/app/components/Tutorial.tsx
+++ b/app/components/Tutorial.tsx
@@ -1506,6 +1506,25 @@ function TutorialPortal({
                 </div>
                 <div className="text-muted-foreground">
                     {parseDescription(description, toast)}
+                    {
+                        // The live region is mounted for every step, not only while the
+                        // message shows: a region inserted together with its text is
+                        // announced unreliably, and one that is only ever replaced by an
+                        // identical copy is not re-announced at all. Keeping it means the
+                        // content genuinely goes empty -> text on each occurrence.
+                        // It sits inside the description rather than beside it because an
+                        // empty child of the panel's `space-y-4` would still add a gap.
+                    }
+                    <div role="status" aria-live="polite">
+                        {
+                            targetUnavailable &&
+                            <div className="mt-4 flex items-center gap-2 p-3 bg-secondary rounded-lg" data-testid="tutorialTargetUnavailable">
+                                <span className="text-sm text-muted-foreground">
+                                    We couldn&apos;t find this step&apos;s element on the page. Continue to the next step or skip the tutorial.
+                                </span>
+                            </div>
+                        }
+                    </div>
                 </div>
                 {
                     step === 1 &&
@@ -1533,24 +1552,6 @@ function TutorialPortal({
                         <span className="text-sm text-primary font-medium">Click the highlighted element to continue</span>
                     </div>
                 }
-                {
-                    // The live region is mounted for every step, not only while the
-                    // message shows: a region inserted together with its text is
-                    // announced unreliably, and one that is only ever replaced by an
-                    // identical copy is not re-announced at all. Keeping it means the
-                    // content genuinely goes empty -> text on each occurrence.
-                    // `empty:hidden` keeps the placeholder out of the panel's layout.
-                }
-                <div role="status" aria-live="polite" className="empty:hidden">
-                    {
-                        targetUnavailable &&
-                        <div className="flex items-center gap-2 p-3 bg-secondary rounded-lg" data-testid="tutorialTargetUnavailable">
-                            <span className="text-sm text-muted-foreground">
-                                We couldn&apos;t find this step&apos;s element on the page. Continue to the next step or skip the tutorial.
-                            </span>
-                        </div>
-                    }
-                </div>
                 {
                     step > 0 &&
                     <div className="flex justify-between items-center gap-4 pt-4">

--- a/app/graph/DataPanel.tsx
+++ b/app/graph/DataPanel.tsx
@@ -6,7 +6,7 @@ import { Pencil, TableProperties, X } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import Button from "../components/ui/Button";
 import { IndicatorContext, GraphContext, ConnectionContext } from "../components/provider";
-import DataTable from "./DataTable";
+import DataTable, { elementKey } from "./DataTable";
 import AddLabel from "./addLabel";
 import RemoveLabel from "./RemoveLabel";
 
@@ -27,7 +27,7 @@ export default function DataPanel({ object, onClose, setLabels, canvasRef, schem
     // A schema element is derived, so it is read-only whatever the connection is.
     const readOnly = isReadOnly || !!schema;
 
-    const lastObjId = useRef<number | undefined>(undefined);
+    const lastObjKey = useRef<string | undefined>(undefined);
     const labelsListRef = useRef<HTMLUListElement>(null);
 
     const { toast } = useToast();
@@ -51,13 +51,13 @@ export default function DataPanel({ object, onClose, setLabels, canvasRef, schem
     }, [handleClose]);
 
     useEffect(() => {
-        if (lastObjId.current !== object.id) {
+        if (lastObjKey.current !== elementKey(object)) {
             setLabelsHover(false);
         }
         // The unlabeled schema node stands for a label of its own, so its empty
         // name is kept and rendered as "No Label" rather than dropped.
         setLabel(type ? (object as Node).labels.filter((c) => schema || c !== "") : [object.relationship]);
-        lastObjId.current = object.id;
+        lastObjKey.current = elementKey(object);
     }, [object, type, schema]);
 
     const handleAddLabel = async (newLabel: string) => {
@@ -245,7 +245,7 @@ export default function DataPanel({ object, onClose, setLabels, canvasRef, schem
             </div>
             <DataTable
                 className="h-1 grow w-full"
-                lastObjId={lastObjId}
+                lastObjKey={lastObjKey}
                 object={object}
                 type={type}
                 canvasRef={canvasRef}

--- a/app/graph/DataTable.tsx
+++ b/app/graph/DataTable.tsx
@@ -20,6 +20,15 @@ import Combobox from "../components/ui/combobox";
 const iconSize = 15;
 
 /**
+ * Identifies a selected element across renders. FalkorDB hands out node ids and
+ * relationship ids from separate namespaces, so the same number names both a
+ * node and a relationship — the kind has to be part of the key, or picking one
+ * right after the other reads as "same element" and carries its edit state over.
+ */
+export const elementKey = (element: Node | Link): string =>
+    `${"source" in element ? "l" : "n"}:${element.id}`;
+
+/**
  * The constraints the graph enforces on a schema property, as icons. The index
  * types get a column of their own since they read as text, not as a flag.
  */
@@ -76,14 +85,19 @@ function SchemaRuleIndicators({ propertyKey, rules }: { propertyKey: string, rul
 interface Props {
     object: Node | Link
     type: boolean
-    lastObjId: MutableRefObject<number | undefined>
+    /**
+     * Identifies the element the panel last showed. Nodes and relationships get
+     * their ids from separate FalkorDB namespaces, so the id alone collides —
+     * the key carries which of the two it belongs to.
+     */
+    lastObjKey: MutableRefObject<string | undefined>
     canvasRef: GraphRef
     className?: string
     /** Schema elements have no values, only the type(s) each key holds. */
     schema?: boolean
 }
 
-export default function DataTable({ object, type, lastObjId, canvasRef, className, schema }: Props) {
+export default function DataTable({ object, type, lastObjKey, canvasRef, className, schema }: Props) {
 
     const { graph, setGraphInfo } = useContext(GraphContext);
     const { settings: { userExperienceSettings: { captionKeysSettings: { captionsKeys } } } } = useContext(BrowserSettingsContext);
@@ -207,7 +221,7 @@ export default function DataTable({ object, type, lastObjId, canvasRef, classNam
     }, [isAddValue]);
 
     useEffect(() => {
-        if (lastObjId.current !== object.id) {
+        if (lastObjKey.current !== elementKey(object)) {
             setEditable("");
             setNewVal("");
             setNewKey("");
@@ -216,7 +230,7 @@ export default function DataTable({ object, type, lastObjId, canvasRef, classNam
         }
         setAttributes(Object.keys(object.data));
         setExpandedAttributes({});
-    }, [lastObjId, object, setAttributes, type]);
+    }, [lastObjKey, object, setAttributes, type]);
 
     // A map is the only thing a property can never hold, and it is the only
     // shape the editor has nothing to offer for.

--- a/lib/graphValues.test.ts
+++ b/lib/graphValues.test.ts
@@ -149,6 +149,25 @@ test("parseValue rejects a temporal value that has the right shape but cannot ex
     assert.equal(parsed("datetime", "2025-01-01T00:00"), "2025-01-01T00:00");
 });
 
+test("parseValue rejects a day the month never had", () => {
+    // The component ranges alone let these through: the day is within 1-31, but
+    // not within the month it sits in.
+    assert.match(failure("date", "2025-02-31"), /does not exist/);
+    assert.match(failure("date", "2025-04-31"), /does not exist/);
+    assert.match(failure("date", "2025-06-31"), /does not exist/);
+    assert.match(failure("datetime", "2025-02-30T12:00"), /does not exist/);
+
+    // February follows the leap year, including the century rules.
+    assert.match(failure("date", "2025-02-29"), /does not exist/);
+    assert.match(failure("date", "1900-02-29"), /does not exist/);
+    assert.equal(parsed("date", "2024-02-29"), "2024-02-29");
+    assert.equal(parsed("date", "2000-02-29"), "2000-02-29");
+    assert.equal(parsed("date", "2025-02-28"), "2025-02-28");
+
+    // A time carries no date, so it is left alone.
+    assert.equal(parsed("time", "23:59:59"), "23:59:59");
+});
+
 test("parseValue passes strings through", () => {
     assert.equal(parsed("string", "  keeps its spaces  "), "  keeps its spaces  ");
 });

--- a/lib/graphValues.ts
+++ b/lib/graphValues.ts
@@ -93,6 +93,31 @@ export const VALUE_PATTERNS = {
   duration: DURATION_PATTERN,
 } as const;
 
+export type TemporalType = keyof typeof VALUE_PATTERNS;
+
+/** What a shape-valid date that names a day the month never had is told. */
+export const CALENDAR_DATE_ERROR = "That day does not exist in that month";
+
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+const isLeapYear = (year: number): boolean =>
+  (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+
+/**
+ * The regex bounds the day to 1–31, which still lets `2025-02-31` — and
+ * `2025-02-29`, a leap day in a year that has none — through to FalkorDB. This
+ * bounds it to the month it actually sits in. Only meaningful once the shape
+ * has already matched.
+ */
+export const isCalendarDate = (type: TemporalType, text: string): boolean => {
+  if (type !== "date" && type !== "datetime") return true;
+
+  const [year, month, day] = text.slice(0, 10).split("-").map(Number);
+  const lastDay = month === 2 && isLeapYear(year) ? 29 : DAYS_IN_MONTH[month - 1];
+
+  return day <= lastDay;
+};
+
 export const isGeoPoint = (value: unknown): value is GeoPoint =>
   typeof value === "object" &&
   value !== null &&
@@ -205,6 +230,8 @@ export function parseValue(type: ValueType, raw: PropertyValue): ParseResult {
       if (!VALUE_PATTERNS[type].test(text)) {
         return { error: `Expected the format ${VALUE_PLACEHOLDERS[type]}` };
       }
+
+      if (!isCalendarDate(type, text)) return { error: CALENDAR_DATE_ERROR };
 
       return { value: text };
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid calendar dates, including impossible month lengths and non-leap-year February 29, are now rejected.
  - Graph expansions no longer apply outdated results after connection changes or overlapping actions.
  - Editing state no longer carries over between different graph element types with matching IDs.
  - Tutorial steps continue checking for unavailable targets until they appear.

- **Accessibility**
  - Improved status announcements for tutorial steps waiting on unavailable targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->