### PR TITLE
fix(chat): keep CYPHER keyword on parameter headers in displayed queries

### DIFF
--- a/app/graph/Chat.tsx
+++ b/app/graph/Chat.tsx
@@ -19,6 +19,7 @@ import { getConnectionItem, setConnectionItem, getConnectionPrefix } from "@/lib
 import { tabScopedKey } from "@/lib/useGraphTabs";
 import { getConfidenceStyle, normalizeConfidence } from "./confidence";
 import { parseStoredMessages, serializeChatHistory } from "./chatHistory";
+import { stripCypherFenceTag } from "./cypherDisplay";
 
 const mdInstance = new MarkdownIt({
     html: false,
@@ -379,7 +380,7 @@ export default function Chat({ onClose }: Props) {
             // Show cypher query if available
             if (data.cypherQuery) {
                 const cypherContent = typeof data.cypherQuery === "string"
-                    ? data.cypherQuery.replace(/^cypher\s+/i, "")
+                    ? stripCypherFenceTag(data.cypherQuery)
                     : data.cypherQuery;
                 setQueryCollapse(prev => ({ ...prev, [newMessages.length]: false }));
                 handleSetMessages({

--- a/app/graph/cypherDisplay.test.ts
+++ b/app/graph/cypherDisplay.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { stripCypherFenceTag } from "./cypherDisplay.ts";
+
+describe("stripCypherFenceTag", () => {
+    it("strips a bare fence-language tag before a clause", () => {
+        assert.equal(stripCypherFenceTag("cypher MATCH (n) RETURN n"), "MATCH (n) RETURN n");
+        assert.equal(stripCypherFenceTag("Cypher\nMATCH (n) RETURN n"), "MATCH (n) RETURN n");
+    });
+
+    it("keeps a FalkorDB parameter header intact", () => {
+        const query =
+            "CYPHER sourceCode='TLV' targetDesc='Narita' MATCH (src:airport), (dst:airport) WHERE src.code = $sourceCode RETURN src";
+        assert.equal(stripCypherFenceTag(query), query);
+    });
+
+    it("keeps a lowercase parameter header intact", () => {
+        const query = "cypher a=1 b='x' MATCH (n {v: $a}) RETURN n";
+        assert.equal(stripCypherFenceTag(query), query);
+    });
+
+    it("keeps a parameter header whose first param name is keyword-like", () => {
+        const query = "CYPHER match='x' a=1 MATCH (n {v: $a}) RETURN n";
+        assert.equal(stripCypherFenceTag(query), query);
+    });
+
+    it("strips a fence tag even when the query itself starts with a CYPHER header", () => {
+        const query = "CYPHER sourceCode='TLV' MATCH (src:airport {code: $sourceCode}) RETURN src";
+        assert.equal(stripCypherFenceTag(`cypher ${query}`), query);
+    });
+
+    it("strips the fence tag before any clause, not only MATCH", () => {
+        assert.equal(
+            stripCypherFenceTag("cypher FOREACH (x IN [1,2] | CREATE (:N {v: x}))"),
+            "FOREACH (x IN [1,2] | CREATE (:N {v: x}))"
+        );
+        assert.equal(
+            stripCypherFenceTag("cypher LOAD CSV FROM 'file://a.csv' AS row RETURN row"),
+            "LOAD CSV FROM 'file://a.csv' AS row RETURN row"
+        );
+        assert.equal(stripCypherFenceTag("cypher EXPLAIN MATCH (n) RETURN n"), "EXPLAIN MATCH (n) RETURN n");
+    });
+
+    it("keeps a parameter header whose value is not quoted", () => {
+        const query = "CYPHER limit=10 ids=[1,2] MATCH (n) RETURN n LIMIT $limit";
+        assert.equal(stripCypherFenceTag(query), query);
+    });
+
+    it("leaves queries without a prefix unchanged", () => {
+        assert.equal(stripCypherFenceTag("MATCH (n) RETURN n"), "MATCH (n) RETURN n");
+    });
+});

--- a/app/graph/cypherDisplay.ts
+++ b/app/graph/cypherDisplay.ts
@@ -1,0 +1,19 @@
+// Prepares a generated Cypher query for display in the Chat panel.
+//
+// LLMs sometimes leave a bare "cypher" fence-language tag in front of the
+// query (residue of a ```cypher code block). Strip that, but never touch a
+// FalkorDB parameter header such as `CYPHER name='x' MATCH ...` — the CYPHER
+// keyword is mandatory there and removing it makes the query unparseable
+// ("Invalid input 'o': expected SET or START").
+
+const PARAMETER_HEADER = /^[A-Za-z_][A-Za-z0-9_]*\s*=/;
+
+export function stripCypherFenceTag(query: string): string {
+    const match = /^cypher\s+/i.exec(query);
+    if (!match) return query;
+
+    const rest = query.slice(match[0].length);
+    // A parameter header (`name=value ...`) needs the CYPHER prefix to stay;
+    // anything else (MATCH, FOREACH, LOAD CSV, EXPLAIN, ...) is fence residue.
+    return PARAMETER_HEADER.test(rest) ? query : rest;
+}

--- a/e2e/tests/chat.spec.ts
+++ b/e2e/tests/chat.spec.ts
@@ -563,6 +563,7 @@ test.describe("Chat Feature Tests", () => {
     // parameter header and left an unparseable query in the chat bubble / Run button.
     const graphName = getRandomString("chat");
     await apiCall.addGraph(graphName);
+    let page: Awaited<ReturnType<typeof browser.getPage>> | undefined;
 
     try {
       await apiCall.runQuery(
@@ -573,7 +574,7 @@ test.describe("Chat Feature Tests", () => {
       const chat = await browser.createNewPage(ChatComponent, urls.graphUrl);
       await browser.setPageToFullScreen();
 
-      const page = await browser.getPage();
+      page = await browser.getPage();
       await page.evaluate(() => {
         localStorage.setItem("model", "gpt-4o-mini");
         localStorage.setItem("chatModelSource", "local");
@@ -618,9 +619,8 @@ test.describe("Chat Feature Tests", () => {
         .toMatch(/^CYPHER sourceCode='TLV'/);
       await expect.poll(() => chat.getTableTabEnabled(), { timeout: 10000 }).toBe(true);
       expect(await chat.getNotificationErrorToast()).toBe(false);
-
-      await page.unroute("**/api/chat");
     } finally {
+      await page?.unroute("**/api/chat");
       await apiCall.removeGraph(graphName);
     }
   });

--- a/e2e/tests/chat.spec.ts
+++ b/e2e/tests/chat.spec.ts
@@ -557,6 +557,74 @@ test.describe("Chat Feature Tests", () => {
     await apiCall.removeGraph(graphName);
   });
 
+  test(`@readwrite Verify chat keeps the CYPHER parameter header in the displayed query and it runs`, async () => {
+    // Regression test for #2076: the chat stripped a leading "cypher" token from the
+    // generated query, which also removed the mandatory CYPHER keyword of a FalkorDB
+    // parameter header and left an unparseable query in the chat bubble / Run button.
+    const graphName = getRandomString("chat");
+    await apiCall.addGraph(graphName);
+
+    try {
+      await apiCall.runQuery(
+        graphName,
+        "CREATE (tlv:airport {code: 'TLV'})-[:route]->(ist:airport {code: 'IST'})-[:route]->(nrt:airport {code: 'NRT', desc: 'Tokyo Narita International'})"
+      );
+
+      const chat = await browser.createNewPage(ChatComponent, urls.graphUrl);
+      await browser.setPageToFullScreen();
+
+      const page = await browser.getPage();
+      await page.evaluate(() => {
+        localStorage.setItem("model", "gpt-4o-mini");
+        localStorage.setItem("chatModelSource", "local");
+      });
+      await page.reload({ waitUntil: "networkidle" });
+
+      await chat.selectGraphByName(graphName);
+      await chat.openChat();
+      await chat.waitForChatPanel();
+
+      // This is what text-to-cypher returns after normalizing the LLM output.
+      const cypherQuery =
+        "CYPHER sourceCode='TLV' targetDesc='Narita' MATCH (src:airport), (dst:airport) WHERE src.code = $sourceCode AND toLower(dst.desc) CONTAINS toLower($targetDesc) CALL algo.SPpaths({sourceNode: src, targetNode: dst, relTypes: ['route'], relDirection: 'outgoing', pathCount: 1}) YIELD path, pathWeight RETURN [n IN nodes(path) | n.code] AS codes, pathWeight";
+
+      await page.route("**/api/chat", (route) => {
+        route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            cypherQuery,
+            cypherResult: null,
+            answer: "The shortest path from TLV to Narita is TLV → IST → NRT.",
+            confidence: 92,
+            tokenUsage: null,
+          }),
+        });
+      });
+
+      await chat.fillChatInput("find a path from tlv to narita airport");
+      await chat.clickChatSendButton();
+
+      expect(await chat.waitForAssistantResponse("CypherQuery")).toBe(true);
+
+      // The displayed query must keep the mandatory CYPHER prefix.
+      const displayedQuery = await chat.getLastAssistantMessageContent("CypherQuery");
+      expect(displayedQuery?.trim().startsWith("CYPHER sourceCode='TLV'")).toBe(true);
+
+      // Running it from the chat must execute successfully against FalkorDB.
+      await chat.clickChatRunQueryButton();
+
+      await expect.poll(() => chat.getEditorInput(), { timeout: 10000 })
+        .toMatch(/^CYPHER sourceCode='TLV'/);
+      await expect.poll(() => chat.getTableTabEnabled(), { timeout: 10000 }).toBe(true);
+      expect(await chat.getNotificationErrorToast()).toBe(false);
+
+      await page.unroute("**/api/chat");
+    } finally {
+      await apiCall.removeGraph(graphName);
+    }
+  });
+
   test(`@readwrite Verify messages are graph-specific and respect maxSavedMessages limit`, async () => {
     test.setTimeout(90000);
     const graph1Name = getRandomString("chat");


### PR DESCRIPTION
Fixes #2076

## Root cause

Not a `text-to-cypher` regression. The library (0.2.4 on staging) correctly normalizes LLM output to `CYPHER sourceCode='TLV' targetDesc='Narita' MATCH …` and executes it fine — the chat *answer* works.

The bug is in the Browser client: `app/graph/Chat.tsx` ran

```ts
data.cypherQuery.replace(/^cypher\s+/i, "")
```

on the returned query before displaying it. This was added (09bfe49a) to strip a leftover ```` ```cypher ```` fence-language tag, but it is too greedy and also removes the **mandatory** `CYPHER` keyword of a FalkorDB parameter header. The query shown in the chat bubble / ▶ Run / Copy therefore becomes `sourceCode='TLV' … MATCH …`, which fails with `Invalid input 'o': expected SET or START`. Confirmed present in the deployed staging bundle (`app/graph/page-*.js`).

## Fix

- New `app/graph/cypherDisplay.ts` → `stripCypherFenceTag()`: strips a leading `cypher` only when it is directly followed by a query clause keyword (fence residue); leaves `CYPHER name='x' MATCH …` untouched.
- `Chat.tsx` uses the helper.
- Unit tests (`cypherDisplay.test.ts`) incl. the exact query from the issue screenshot.

## Verification

- `node --test`: 4/4 pass; `tsc` + `eslint` clean.
- Native binding test: fed the screenshot's bare-param query through `@falkordb/text-to-cypher` 0.2.4 → normalized + executed (`status: success`). Same input on 0.2.3 (Browser 2.3.1) reproduces the issue error, so 2.3.1 additionally needs the already-shipped dependency bump.
- **Real UI (Playwright, local FalkorDB + airports dataset, mock LLM returning the screenshot's malformed query):**
  - before fix: chat shows `sourceCode='TLV' …`, ▶ Run sends the invalid query.
  - after fix: chat shows `CYPHER sourceCode='TLV' …`, ▶ Run executes and returns the path (`codes: [TLV, IST, NRT]`, `pathWeight: 2`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of generated Cypher queries by removing stray code-block language markers when appropriate.
  * Preserved valid Cypher parameter headers and queries without removable markers.
  * Ensured queries with valid `CYPHER` parameter headers remain intact when displayed and executed from chat.
  * Improved reliability when running generated queries with parameters, preventing malformed queries and related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->