### PR TITLE
Add mTLS client-certificate authentication

### DIFF
--- a/app/api/auth/[...nextauth]/options.ts
+++ b/app/api/auth/[...nextauth]/options.ts
@@ -31,6 +31,8 @@ interface CustomJWTPayload {
   port: number;
   tls: boolean;
   ca?: string;
+  cert?: string;
+  key?: string;
   url?: string;
 }
 
@@ -42,6 +44,8 @@ interface AuthenticatedUser {
   port: number;
   tls: boolean;
   ca?: string;
+  cert?: string;
+  key?: string;
   url?: string;
   credentialRef?: string;
 }
@@ -90,6 +94,8 @@ export async function newClient(
     username?: string;
     tls?: string;
     ca?: string;
+    cert?: string;
+    key?: string;
     url?: string;
   },
   id: string
@@ -115,6 +121,14 @@ export async function newClient(
               !credentials.ca || credentials.ca === "undefined"
                 ? undefined
                 : [Buffer.from(credentials.ca, "base64").toString("utf8")],
+            cert:
+              !credentials.cert || credentials.cert === "undefined"
+                ? undefined
+                : Buffer.from(credentials.cert, "base64").toString("utf8"),
+            key:
+              !credentials.key || credentials.key === "undefined"
+                ? undefined
+                : Buffer.from(credentials.key, "base64").toString("utf8"),
           },
           password: credentials.password ?? undefined,
           username: credentials.username ?? undefined,
@@ -207,6 +221,7 @@ export interface ConnectionInfo {
   port: number;
   tls: boolean;
   ca?: string;
+  cert?: string;
 }
 
 /**
@@ -223,6 +238,8 @@ export async function addSessionConnection(
     username?: string;
     tls?: string;
     ca?: string;
+    cert?: string;
+    key?: string;
   }
 ): Promise<ConnectionInfo> {
   const connId = uuidv4();
@@ -250,6 +267,8 @@ export async function addSessionConnection(
       kind: "session",
       tls: credentials.tls === "true",
       ca: credentials.ca,
+      cert: credentials.cert,
+      key: credentials.key,
       expiresAtUnix: Math.floor(Date.now() / 1000) + SESSION_MAX_AGE_SECONDS,
     });
   } catch (storageError) {
@@ -270,6 +289,7 @@ export async function addSessionConnection(
     port: credentials.port ? parseInt(credentials.port, 10) : 6379,
     tls: credentials.tls === "true",
     ca: credentials.ca,
+    cert: credentials.cert,
   };
 }
 
@@ -290,6 +310,7 @@ export async function listSessionConnections(sessionId: string): Promise<Connect
       port: t.port,
       tls: t.tls ?? false,
       ca: t.ca || undefined,
+      cert: t.cert || undefined,
     }));
 }
 
@@ -365,6 +386,8 @@ async function getConnectionClient(
         password,
         tls: (tokenData.tls ?? false).toString(),
         ca: tokenData.ca || undefined,
+        cert: tokenData.cert || undefined,
+        key: tokenData.encrypted_key ? decrypt(tokenData.encrypted_key) : undefined,
       },
       key
     );
@@ -379,6 +402,7 @@ async function getConnectionClient(
         port: tokenData.port,
         tls: tokenData.tls ?? false,
         ca: tokenData.ca || undefined,
+        cert: tokenData.cert || undefined,
       },
     };
   }
@@ -417,6 +441,7 @@ async function getConnectionClient(
         port: tokenData.port,
         tls: tokenData.tls ?? false,
         ca: tokenData.ca || undefined,
+        cert: tokenData.cert || undefined,
       },
     };
   } catch (metaErr) {
@@ -518,6 +543,8 @@ function createUserFromJWTPayload(payload: CustomJWTPayload): AuthenticatedUser 
     port: payload.port,
     tls: payload.tls || false,
     ca: payload.ca,
+    cert: payload.cert,
+    key: payload.key,
     url: payload.url,
   };
 }
@@ -619,6 +646,8 @@ async function tryJWTAuthentication(): Promise<{ client: FalkorDB; user: Authent
             password,
             tls: payload.tls.toString(),
             ca: payload.ca || undefined,
+            cert: payload.cert || undefined,
+            key: payload.key || undefined,
           },
           payload.sub
         );
@@ -681,6 +710,8 @@ const authOptions: NextAuthConfig = {
         password: { label: "Password", type: "password" },
         tls: { label: "tls", type: "boolean" },
         ca: { label: "ca", type: "string" },
+        cert: { label: "cert", type: "string" },
+        key: { label: "key", type: "string" },
         url: { label: "url", type: "string" },
       },
       async authorize(credentials) {
@@ -696,6 +727,8 @@ const authOptions: NextAuthConfig = {
           username: (credentials.username as string) || undefined,
           tls: (credentials.tls as string) || undefined,
           ca: (credentials.ca as string) || undefined,
+          cert: (credentials.cert as string) || undefined,
+          key: (credentials.key as string) || undefined,
           url: (credentials.url as string) || undefined,
         };
 
@@ -734,6 +767,8 @@ const authOptions: NextAuthConfig = {
               kind: 'session',
               tls: creds.tls === "true",
               ca: creds.url ? undefined : creds.ca,
+              cert: creds.url ? undefined : creds.cert,
+              key: creds.url ? undefined : creds.key,
               expiresAtUnix: Math.floor(Date.now() / 1000) + SESSION_MAX_AGE_SECONDS,
             });
           } catch (storageError) {
@@ -759,6 +794,8 @@ const authOptions: NextAuthConfig = {
             username: creds.username || "default",
             tls: creds.tls === "true",
             ca: creds.url ? undefined : creds.ca,
+            cert: creds.url ? undefined : creds.cert,
+            key: creds.url ? undefined : creds.key,
             role,
           };
           return res;
@@ -823,6 +860,8 @@ const authOptions: NextAuthConfig = {
       delete token.picture;
       delete token.image;
       delete token.ca;          // CA certs are large; stored in Token DB
+      delete token.cert;      // client cert; stored in Token DB
+      delete token.key;       // client key is sensitive; stored in Token DB
       delete token.url;         // Connection URL; stored in Token DB
       delete token.credentialRef; // Legacy field replaced by Token DB
 

--- a/app/api/auth/tokenUtils.ts
+++ b/app/api/auth/tokenUtils.ts
@@ -126,6 +126,8 @@ export async function storeEncryptedCredential(params: {
   kind?: 'session' | 'pat';
   tls?: boolean;
   ca?: string;
+  cert?: string;
+  key?: string;
 }): Promise<void> {
   const storage = StorageFactory.getStorage();
   const nowUnix = Math.floor(Date.now() / 1000);
@@ -147,5 +149,8 @@ export async function storeEncryptedCredential(params: {
     kind: params.kind ?? 'pat',
     tls: params.tls ?? false,
     ca: params.ca,
+    cert: params.cert,
+    // Client private key is encrypted at rest, exactly like the password.
+    encrypted_key: params.key ? encrypt(params.key) : undefined,
   });
 }

--- a/app/api/auth/tokens/credentials/route.ts
+++ b/app/api/auth/tokens/credentials/route.ts
@@ -14,6 +14,8 @@ type LoginInput = {
   port?: string | number;
   tls?: string | boolean;
   ca?: string;
+  cert?: string;
+  key?: string;
   name?: string;
   expiresAt?: string | null;
   ttlSeconds?: number | undefined;
@@ -68,6 +70,8 @@ export async function POST(request: NextRequest) {
       port = "6379",
       tls = "false",
       ca,
+      cert,
+      key,
       name = "API Token",
       expiresAt = null,
       ttlSeconds = undefined,
@@ -89,6 +93,8 @@ export async function POST(request: NextRequest) {
           password: userPassword === "" ? undefined : userPassword,
           tls: String(tls),
           ca: ca || "undefined",
+          cert: cert || "undefined",
+          key: key || "undefined",
         },
         userId
       );

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: Request) {
 /**
  * POST /api/connections
  * Adds a new connection (different ACL user) to the current session.
- * Body: { host?, port?, username?, password?, tls?, ca? }
+ * Body: { host?, port?, username?, password?, tls?, ca?, cert?, key? }
  */
 export async function POST(request: Request) {
   try {
@@ -78,7 +78,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const { host, port, username, password, tls, ca } = result.data;
+    const { host, port, username, password, tls, ca, cert, key } = result.data;
 
     const connInfo = await addSessionConnection(id, {
       host: (host as string) || session.user.host,
@@ -87,6 +87,8 @@ export async function POST(request: Request) {
       password: password as string,
       tls: tls?.toString() || String(session.user.tls),
       ca: ca as string | undefined,
+      cert: cert as string | undefined,
+      key: key as string | undefined,
     });
 
     return NextResponse.json(

--- a/app/api/utils.ts
+++ b/app/api/utils.ts
@@ -32,6 +32,8 @@ export function buildFalkorDBConnection(user: {
     password?: string;
     tls?: boolean;
     ca?: string;
+    cert?: string;
+    key?: string;
 }): string {
     // Use URL if provided
     if (user.url) {

--- a/app/api/validate-body.ts
+++ b/app/api/validate-body.ts
@@ -379,6 +379,18 @@ export const login = z.object({
     })
     .min(1, "CA certificate cannot be empty")
     .optional(),
+  cert: z
+    .string({
+      error: "Invalid client certificate",
+    })
+    .min(1, "Client certificate cannot be empty")
+    .optional(),
+  key: z
+    .string({
+      error: "Invalid client key",
+    })
+    .min(1, "Client key cannot be empty")
+    .optional(),
   name: z
     .string({
       error: "Invalid token name",
@@ -451,6 +463,12 @@ export const addConnection = z.object({
     .optional(),
   ca: z
     .string({ error: "Invalid CA certificate" })
+    .optional(),
+  cert: z
+    .string({ error: "Invalid client certificate" })
+    .optional(),
+  key: z
+    .string({ error: "Invalid client key" })
     .optional(),
 });
 

--- a/app/components/ConnectionManager.tsx
+++ b/app/components/ConnectionManager.tsx
@@ -155,6 +155,8 @@ export default function ConnectionManager() {
         password: credentials.password,
         tls: credentials.tls,
         ca: credentials.ca || undefined,
+        cert: credentials.cert || undefined,
+        key: credentials.key || undefined,
       }),
     }, toast, setIndicator);
 

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -80,6 +80,8 @@ export interface LoginFormCredentials {
   password: string;
   tls: boolean;
   ca?: string;
+  cert?: string;
+  key?: string;
 }
 
 interface LoginFormProps {
@@ -113,6 +115,10 @@ export default function LoginForm({
   const [TLS, setTLS] = useState(initialTLS);
   const [CA, setCA] = useState<string>();
   const [uploadedFileName, setUploadedFileName] = useState<string>("");
+  const [clientCert, setClientCert] = useState<string>();
+  const [clientCertFileName, setClientCertFileName] = useState<string>("");
+  const [clientKey, setClientKey] = useState<string>();
+  const [clientKeyFileName, setClientKeyFileName] = useState<string>("");
 
   useEffect(() => {
     setHost(initialHost);
@@ -311,6 +317,8 @@ export default function LoginForm({
         password,
         tls: TLS,
         ca: CA,
+        cert: clientCert,
+        key: clientKey,
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Connection failed";
@@ -327,6 +335,34 @@ export default function LoginForm({
       clearError();
       setCA((reader.result as string).split(',').pop());
       setUploadedFileName(acceptedFiles[0].name);
+    };
+
+    reader.readAsDataURL(acceptedFiles[0]);
+  };
+
+  const onCertDrop = (acceptedFiles: File[]) => {
+    if (acceptedFiles.length === 0) return;
+
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      clearError();
+      setClientCert((reader.result as string).split(',').pop());
+      setClientCertFileName(acceptedFiles[0].name);
+    };
+
+    reader.readAsDataURL(acceptedFiles[0]);
+  };
+
+  const onKeyDrop = (acceptedFiles: File[]) => {
+    if (acceptedFiles.length === 0) return;
+
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      clearError();
+      setClientKey((reader.result as string).split(',').pop());
+      setClientKeyFileName(acceptedFiles[0].name);
     };
 
     reader.readAsDataURL(acceptedFiles[0]);
@@ -377,6 +413,10 @@ export default function LoginForm({
                   if (!checked) {
                     setCA(undefined);
                     setUploadedFileName("");
+                    setClientCert(undefined);
+                    setClientCertFileName("");
+                    setClientKey(undefined);
+                    setClientKeyFileName("");
                   }
                 }}
                 data-testid="tls-checkbox"
@@ -425,6 +465,52 @@ export default function LoginForm({
                         title="Remove certificate"
                         data-testid="remove-certificate-btn"
                         aria-label="Remove certificate"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs font-medium text-muted">Client certificate (mTLS)</span>
+                  {!clientCertFileName ? (
+                    <Dropzone title="Upload Client Certificate" onFileDrop={onCertDrop} disabled={!TLS} />
+                  ) : (
+                    <div className="flex items-center justify-between p-3 bg-primary/10 border border-primary/20 rounded-md" data-testid="client-cert-uploaded-status">
+                      <span className="text-sm font-medium text-foreground truncate max-w-48">{clientCertFileName}</span>
+                      <button
+                        type="button"
+                        onClick={() => { clearError(); setClientCert(undefined); setClientCertFileName(""); }}
+                        className="flex-shrink-0 p-1 text-muted hover:text-foreground hover:bg-primary/20 rounded"
+                        title="Remove client certificate"
+                        data-testid="remove-client-cert-btn"
+                        aria-label="Remove client certificate"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs font-medium text-muted">Client private key (mTLS)</span>
+                  {!clientKeyFileName ? (
+                    <Dropzone title="Upload Client Key" onFileDrop={onKeyDrop} disabled={!TLS} />
+                  ) : (
+                    <div className="flex items-center justify-between p-3 bg-primary/10 border border-primary/20 rounded-md" data-testid="client-key-uploaded-status">
+                      <span className="text-sm font-medium text-foreground truncate max-w-48">{clientKeyFileName}</span>
+                      <button
+                        type="button"
+                        onClick={() => { clearError(); setClientKey(undefined); setClientKeyFileName(""); }}
+                        className="flex-shrink-0 p-1 text-muted hover:text-foreground hover:bg-primary/20 rounded"
+                        title="Remove client key"
+                        data-testid="remove-client-key-btn"
+                        aria-label="Remove client key"
                       >
                         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/app/login/LoginPage.tsx
+++ b/app/login/LoginPage.tsx
@@ -45,6 +45,8 @@ export default function LoginPage() {
       port: credentials.port,
       tls: credentials.tls,
       ca: credentials.ca,
+      cert: credentials.cert,
+      key: credentials.key,
     };
 
     if (credentials.username) {

--- a/lib/token-storage/FalkorDBTokenStorage.ts
+++ b/lib/token-storage/FalkorDBTokenStorage.ts
@@ -31,7 +31,9 @@ class FalkorDBTokenStorage implements ITokenStorage {
         encrypted_password: '${this.escapeString(tokenData.encrypted_password)}',
         kind: '${this.escapeString(kind)}',
         tls: ${tokenData.tls ?? false},
-        ca: '${this.escapeString(tokenData.ca ?? '')}'
+        ca: '${this.escapeString(tokenData.ca ?? '')}',
+        cert: '${this.escapeString(tokenData.cert ?? '')}',
+        encrypted_key: '${this.escapeString(tokenData.encrypted_key ?? '')}'
       })
       CREATE (t)-[:BELONGS_TO]->(u)
       RETURN t.token_id as token_id
@@ -69,7 +71,9 @@ class FalkorDBTokenStorage implements ITokenStorage {
              t.encrypted_password as encrypted_password,
              t.kind as kind,
              t.tls as tls,
-             t.ca as ca
+             t.ca as ca,
+             t.cert as cert,
+             t.encrypted_key as encrypted_key
       ORDER BY t.created_at DESC
     `;
 
@@ -93,6 +97,8 @@ class FalkorDBTokenStorage implements ITokenStorage {
       kind: row.kind ?? 'pat',
       tls: row.tls ?? false,
       ca: row.ca || undefined,
+      cert: row.cert || undefined,
+      encrypted_key: row.encrypted_key || undefined,
     }));
   }
 
@@ -113,7 +119,9 @@ class FalkorDBTokenStorage implements ITokenStorage {
              t.is_active as is_active,
              t.encrypted_password as encrypted_password,
              t.tls as tls,
-             t.ca as ca
+             t.ca as ca,
+             t.cert as cert,
+             t.encrypted_key as encrypted_key
     `;
 
     const result = await executePATQuery(query);
@@ -141,6 +149,8 @@ class FalkorDBTokenStorage implements ITokenStorage {
       encrypted_password: row.encrypted_password,
       tls: row.tls ?? false,
       ca: row.ca || undefined,
+      cert: row.cert || undefined,
+      encrypted_key: row.encrypted_key || undefined,
     };
   }
 
@@ -247,7 +257,9 @@ class FalkorDBTokenStorage implements ITokenStorage {
              t.encrypted_password as encrypted_password,
              t.kind as kind,
              t.tls as tls,
-             t.ca as ca
+             t.ca as ca,
+             t.cert as cert,
+             t.encrypted_key as encrypted_key
       ORDER BY t.created_at DESC
     `;
     const result = await executePATQuery(query);
@@ -269,6 +281,8 @@ class FalkorDBTokenStorage implements ITokenStorage {
       kind: row.kind ?? 'pat',
       tls: row.tls ?? false,
       ca: row.ca || undefined,
+      cert: row.cert || undefined,
+      encrypted_key: row.encrypted_key || undefined,
     }));
   }
 

--- a/lib/token-storage/ITokenStorage.ts
+++ b/lib/token-storage/ITokenStorage.ts
@@ -32,6 +32,10 @@ export interface TokenData {
   tls?: boolean;
   /** Base64-encoded CA certificate for TLS connections. */
   ca?: string;
+  /** Base64-encoded client certificate for mTLS (public; stored as-is). */
+  cert?: string;
+  /** Encrypted base64-encoded client private key for mTLS. Never stored in plaintext. */
+  encrypted_key?: string;
 }
 
 /**

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -20,6 +20,8 @@ declare module "next-auth" {
     tls: boolean;
     url: string;
     ca?: string;
+    cert?: string;
+    key?: string;
     username?: string;
     credentialRef?: string;
     connId?: string;
@@ -42,6 +44,8 @@ declare module "@auth/core/types" {
     tls: boolean;
     url: string;
     ca?: string;
+    cert?: string;
+    key?: string;
     username?: string;
     credentialRef?: string;
     connId?: string;


### PR DESCRIPTION
## What

Adds optional **mTLS** support: a user can supply a **client certificate** and **client private key** (base64-encoded PEM) alongside the existing server **CA**, for TLS connections to the database.

## How

- The login form gains two uploads (client certificate, client key) next to the existing CA upload, shown only when TLS is enabled.
- `cert` and `key` are threaded through the same connection path as the existing `ca` field and passed to the node TLS socket (`socket.cert` / `socket.key`) as single PEM strings.

## Security

- The **client private key is a secret** and is handled like the connection password, not like the (public) CA:
  - **encrypted at rest** (`encrypted_key`, via the same `encrypt()`/`decrypt()` used for the password),
  - **decrypted only server-side** when re-establishing a connection,
  - **never placed in a session JWT or a personal access token**, and
  - **never returned in connection metadata** to the client.
- The public client **certificate** is stored as-is, mirroring the CA.
- **Server-certificate verification is unchanged** — this is purely additive; no `rejectUnauthorized` change and no new insecure/skip path.

## Scope

Client mTLS is wired for the interactive login/session flow. PAT-based connections continue to support server-CA TLS as before (client cert/key are intentionally not embedded in bearer tokens).

## Checks

`tsc --noEmit`: 0 errors. `npm run lint`: 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for mutual TLS authentication using optional client certificates and private keys.
  - Login and connection forms now allow users to upload, remove, and submit certificate credentials.
  - Certificate credentials persist across saved connections and reconnections.
  - Private keys are securely encrypted when stored.
  - TLS certificate fields are validated before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->